### PR TITLE
feat(mahad): Add new Dugsi-style cohorts admin (Phase 1)

### DIFF
--- a/app/admin/mahad/cohorts-new/_hooks/index.ts
+++ b/app/admin/mahad/cohorts-new/_hooks/index.ts
@@ -1,0 +1,6 @@
+export { useStudentFilters } from './use-student-filters'
+export {
+  useStudentGroups,
+  useStudentStats,
+  useDuplicates,
+} from './use-student-groups'

--- a/app/admin/mahad/cohorts-new/_hooks/use-student-filters.ts
+++ b/app/admin/mahad/cohorts-new/_hooks/use-student-filters.ts
@@ -1,0 +1,13 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import { MahadStudent, StudentFilters } from '../_types'
+import { applyAllFilters } from '../_utils'
+
+export function useStudentFilters(
+  students: MahadStudent[],
+  filters: StudentFilters
+): MahadStudent[] {
+  return useMemo(() => applyAllFilters(students, filters), [students, filters])
+}

--- a/app/admin/mahad/cohorts-new/_hooks/use-student-groups.ts
+++ b/app/admin/mahad/cohorts-new/_hooks/use-student-groups.ts
@@ -1,0 +1,34 @@
+'use client'
+
+import { useMemo } from 'react'
+
+import {
+  DashboardStats,
+  DuplicateGroup,
+  MahadBatch,
+  MahadStudent,
+} from '../_types'
+import {
+  BatchGroup,
+  calculateStats,
+  detectDuplicates,
+  groupStudentsByBatch,
+} from '../_utils'
+
+export function useStudentGroups(
+  students: MahadStudent[],
+  batches: MahadBatch[]
+): BatchGroup[] {
+  return useMemo(
+    () => groupStudentsByBatch(students, batches),
+    [students, batches]
+  )
+}
+
+export function useStudentStats(students: MahadStudent[]): DashboardStats {
+  return useMemo(() => calculateStats(students), [students])
+}
+
+export function useDuplicates(students: MahadStudent[]): DuplicateGroup[] {
+  return useMemo(() => detectDuplicates(students), [students])
+}

--- a/app/admin/mahad/cohorts-new/_types/index.ts
+++ b/app/admin/mahad/cohorts-new/_types/index.ts
@@ -1,0 +1,122 @@
+/**
+ * Centralized type definitions for Mahad Cohorts Admin module
+ * Single source of truth for all types used across components
+ */
+
+import {
+  GradeLevel,
+  GraduationStatus,
+  PaymentFrequency,
+  StudentBillingType,
+} from '@prisma/client'
+
+import { StudentStatus } from '@/lib/types/student'
+
+export type {
+  StudentFormData,
+  UpdateStudentPayload,
+} from '../../cohorts/_types/student-form'
+export { FORM_DEFAULTS, isNoneValue } from '../../cohorts/_types/student-form'
+
+/**
+ * MahadStudent - DTO for Mahad student data displayed in admin UI
+ * Mirrors StudentWithBatchData from lib/db/queries/student.ts
+ */
+export interface MahadStudent {
+  id: string
+  name: string
+  email: string | null
+  phone: string | null
+  dateOfBirth: Date | null
+  gradeLevel: GradeLevel | null
+  schoolName: string | null
+  graduationStatus: GraduationStatus | null
+  paymentFrequency: PaymentFrequency | null
+  billingType: StudentBillingType | null
+  paymentNotes: string | null
+  status: StudentStatus
+  batchId: string | null
+  createdAt: Date
+  updatedAt: Date
+  batch: {
+    id: string
+    name: string
+    startDate: Date | null
+    endDate: Date | null
+  } | null
+  subscription: {
+    id: string
+    status: string
+    stripeSubscriptionId: string | null
+    amount: number
+  } | null
+  siblingCount?: number
+}
+
+/**
+ * Batch with student count
+ */
+export interface MahadBatch {
+  id: string
+  name: string
+  startDate: Date | null
+  endDate: Date | null
+  createdAt: Date
+  updatedAt: Date
+  studentCount: number
+}
+
+/**
+ * Tab values for main navigation
+ */
+export type TabValue = 'students' | 'batches' | 'duplicates'
+
+/**
+ * Student filter types
+ */
+export interface StudentFilters {
+  search: string
+  batchId: string | null
+  status: StudentStatus | null
+}
+
+/**
+ * Stats for dashboard cards
+ */
+export interface DashboardStats {
+  total: number
+  active: number
+  registered: number
+  onLeave: number
+  unpaid: number
+}
+
+/**
+ * Dialog types for single-dialog pattern
+ */
+export type DialogType =
+  | 'createBatch'
+  | 'assignStudents'
+  | 'deleteStudent'
+  | 'paymentLink'
+  | 'studentDetail'
+  | null
+
+/**
+ * Action result for server actions
+ */
+export interface ActionResult<T = void> {
+  success: boolean
+  data?: T
+  error?: string
+  message?: string
+}
+
+/**
+ * Duplicate group for duplicate detection
+ */
+export interface DuplicateGroup {
+  key: string
+  students: MahadStudent[]
+  matchType: 'email' | 'phone' | 'name'
+}

--- a/app/admin/mahad/cohorts-new/_utils/filters.ts
+++ b/app/admin/mahad/cohorts-new/_utils/filters.ts
@@ -1,0 +1,68 @@
+/**
+ * Filter utilities for Mahad students
+ * Pure functions for filtering logic
+ */
+
+import { StudentStatus } from '@/lib/types/student'
+
+import { MahadStudent, StudentFilters } from '../_types'
+
+export function filterBySearch(
+  students: MahadStudent[],
+  query: string
+): MahadStudent[] {
+  if (!query.trim()) return students
+
+  const lowerQuery = query.toLowerCase().trim()
+  return students.filter((student) => {
+    const searchableFields = [
+      student.name,
+      student.email,
+      student.phone,
+      student.batch?.name,
+    ]
+    return searchableFields.some((field) =>
+      field?.toLowerCase().includes(lowerQuery)
+    )
+  })
+}
+
+export function filterByBatch(
+  students: MahadStudent[],
+  batchId: string | null
+): MahadStudent[] {
+  if (!batchId) return students
+  if (batchId === 'unassigned') {
+    return students.filter((s) => !s.batchId)
+  }
+  return students.filter((s) => s.batchId === batchId)
+}
+
+export function filterByStatus(
+  students: MahadStudent[],
+  status: StudentStatus | null
+): MahadStudent[] {
+  if (!status) return students
+  return students.filter((s) => s.status === status)
+}
+
+export function applyAllFilters(
+  students: MahadStudent[],
+  filters: StudentFilters
+): MahadStudent[] {
+  let result = students
+
+  if (filters.search) {
+    result = filterBySearch(result, filters.search)
+  }
+
+  if (filters.batchId !== null) {
+    result = filterByBatch(result, filters.batchId)
+  }
+
+  if (filters.status !== null) {
+    result = filterByStatus(result, filters.status)
+  }
+
+  return result
+}

--- a/app/admin/mahad/cohorts-new/_utils/grouping.ts
+++ b/app/admin/mahad/cohorts-new/_utils/grouping.ts
@@ -1,0 +1,114 @@
+/**
+ * Grouping utilities for Mahad students
+ * Pure functions for batch grouping and duplicate detection
+ */
+
+import { StudentStatus } from '@/lib/types/student'
+
+import {
+  DashboardStats,
+  DuplicateGroup,
+  MahadBatch,
+  MahadStudent,
+} from '../_types'
+
+export interface BatchGroup {
+  batch: MahadBatch | null
+  students: MahadStudent[]
+}
+
+export function groupStudentsByBatch(
+  students: MahadStudent[],
+  batches: MahadBatch[]
+): BatchGroup[] {
+  const batchMap = new Map<string | null, MahadStudent[]>()
+
+  for (const student of students) {
+    const key = student.batchId ?? null
+    const existing = batchMap.get(key) || []
+    existing.push(student)
+    batchMap.set(key, existing)
+  }
+
+  const groups: BatchGroup[] = []
+
+  for (const batch of batches) {
+    const batchStudents = batchMap.get(batch.id) || []
+    groups.push({ batch, students: batchStudents })
+    batchMap.delete(batch.id)
+  }
+
+  const unassigned = batchMap.get(null) || []
+  if (unassigned.length > 0) {
+    groups.push({ batch: null, students: unassigned })
+  }
+
+  return groups
+}
+
+export function calculateStats(students: MahadStudent[]): DashboardStats {
+  const stats: DashboardStats = {
+    total: students.length,
+    active: 0,
+    registered: 0,
+    onLeave: 0,
+    unpaid: 0,
+  }
+
+  for (const student of students) {
+    switch (student.status) {
+      case StudentStatus.ENROLLED:
+        stats.active++
+        break
+      case StudentStatus.REGISTERED:
+        stats.registered++
+        break
+      case StudentStatus.ON_LEAVE:
+        stats.onLeave++
+        break
+    }
+
+    if (!student.subscription || student.subscription.status !== 'ACTIVE') {
+      stats.unpaid++
+    }
+  }
+
+  return stats
+}
+
+export function detectDuplicates(students: MahadStudent[]): DuplicateGroup[] {
+  const duplicates: DuplicateGroup[] = []
+  const seen = new Map<string, MahadStudent[]>()
+
+  for (const student of students) {
+    if (student.email) {
+      const emailKey = `email:${student.email.toLowerCase()}`
+      const existing = seen.get(emailKey) || []
+      existing.push(student)
+      seen.set(emailKey, existing)
+    }
+
+    if (student.phone) {
+      const normalized = student.phone.replace(/\D/g, '')
+      if (normalized.length >= 10) {
+        const phoneKey = `phone:${normalized.slice(-10)}`
+        const existing = seen.get(phoneKey) || []
+        existing.push(student)
+        seen.set(phoneKey, existing)
+      }
+    }
+  }
+
+  Array.from(seen.entries()).forEach(([key, group]) => {
+    if (group.length > 1) {
+      const matchType = key.startsWith('email:') ? 'email' : 'phone'
+      duplicates.push({
+        key,
+        students: group,
+        matchType: matchType as 'email' | 'phone',
+      })
+    }
+  })
+
+  return duplicates
+}

--- a/app/admin/mahad/cohorts-new/_utils/index.ts
+++ b/app/admin/mahad/cohorts-new/_utils/index.ts
@@ -1,0 +1,12 @@
+export {
+  applyAllFilters,
+  filterBySearch,
+  filterByBatch,
+  filterByStatus,
+} from './filters'
+export {
+  groupStudentsByBatch,
+  calculateStats,
+  detectDuplicates,
+  type BatchGroup,
+} from './grouping'

--- a/app/admin/mahad/cohorts-new/components/batches/batch-grid.tsx
+++ b/app/admin/mahad/cohorts-new/components/batches/batch-grid.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { format } from 'date-fns'
+import { Calendar, Users, Layers } from 'lucide-react'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+import { MahadBatch, MahadStudent } from '../../_types'
+import { useMahadUIStore } from '../../store'
+
+interface BatchGridProps {
+  batches: MahadBatch[]
+  students: MahadStudent[]
+}
+
+function BatchCard({
+  batch,
+  studentCount,
+}: {
+  batch: MahadBatch
+  studentCount: number
+}) {
+  const setBatchFilter = useMahadUIStore((s) => s.setBatchFilter)
+  const setActiveTab = useMahadUIStore((s) => s.setActiveTab)
+
+  const handleClick = () => {
+    setBatchFilter(batch.id)
+    setActiveTab('students')
+  }
+
+  return (
+    <Card
+      className="cursor-pointer transition-colors hover:bg-muted/50"
+      onClick={handleClick}
+    >
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg">{batch.name}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Users className="h-4 w-4" />
+          <span>{studentCount} students</span>
+        </div>
+        {batch.startDate && (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Calendar className="h-4 w-4" />
+            <span>Started {format(batch.startDate, 'MMM yyyy')}</span>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function UnassignedCard({ count }: { count: number }) {
+  const setBatchFilter = useMahadUIStore((s) => s.setBatchFilter)
+  const setActiveTab = useMahadUIStore((s) => s.setActiveTab)
+
+  const handleClick = () => {
+    setBatchFilter('unassigned')
+    setActiveTab('students')
+  }
+
+  if (count === 0) return null
+
+  return (
+    <Card
+      className="cursor-pointer border-dashed transition-colors hover:bg-muted/50"
+      onClick={handleClick}
+    >
+      <CardHeader className="pb-2">
+        <CardTitle className="text-lg text-muted-foreground">
+          Unassigned
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Users className="h-4 w-4" />
+          <span>{count} students need batch assignment</span>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function BatchGrid({ batches, students }: BatchGridProps) {
+  const unassignedCount = students.filter((s) => !s.batchId).length
+
+  if (batches.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-lg border border-dashed p-12 text-center">
+        <Layers className="h-12 w-12 text-muted-foreground" />
+        <h3 className="mt-4 text-lg font-semibold">No batches yet</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Create your first batch to start organizing students.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {batches.map((batch) => (
+        <BatchCard
+          key={batch.id}
+          batch={batch}
+          studentCount={batch.studentCount}
+        />
+      ))}
+      <UnassignedCard count={unassignedCount} />
+    </div>
+  )
+}

--- a/app/admin/mahad/cohorts-new/components/batches/index.ts
+++ b/app/admin/mahad/cohorts-new/components/batches/index.ts
@@ -1,0 +1,1 @@
+export { BatchGrid } from './batch-grid'

--- a/app/admin/mahad/cohorts-new/components/dashboard/dashboard-filters.tsx
+++ b/app/admin/mahad/cohorts-new/components/dashboard/dashboard-filters.tsx
@@ -1,0 +1,94 @@
+'use client'
+
+import { Search, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { StudentStatus } from '@/lib/types/student'
+
+import { MahadBatch } from '../../_types'
+import { useMahadFilters, useMahadUIStore } from '../../store'
+
+interface DashboardFiltersProps {
+  batches: MahadBatch[]
+}
+
+const STATUS_OPTIONS = [
+  { value: StudentStatus.ENROLLED, label: 'Enrolled' },
+  { value: StudentStatus.REGISTERED, label: 'Registered' },
+  { value: StudentStatus.ON_LEAVE, label: 'On Leave' },
+  { value: StudentStatus.WITHDRAWN, label: 'Withdrawn' },
+]
+
+export function DashboardFilters({ batches }: DashboardFiltersProps) {
+  const filters = useMahadFilters()
+  const { setSearchQuery, setBatchFilter, setStatusFilter, resetFilters } =
+    useMahadUIStore()
+
+  const hasFilters = filters.search || filters.batchId || filters.status
+
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+      <div className="relative flex-1">
+        <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          placeholder="Search students..."
+          value={filters.search}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          className="pl-9"
+        />
+      </div>
+
+      <Select
+        value={filters.batchId ?? 'all'}
+        onValueChange={(v) => setBatchFilter(v === 'all' ? null : v)}
+      >
+        <SelectTrigger className="w-full sm:w-[180px]">
+          <SelectValue placeholder="All Batches" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All Batches</SelectItem>
+          <SelectItem value="unassigned">Unassigned</SelectItem>
+          {batches.map((batch) => (
+            <SelectItem key={batch.id} value={batch.id}>
+              {batch.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <Select
+        value={filters.status ?? 'all'}
+        onValueChange={(v) =>
+          setStatusFilter(v === 'all' ? null : (v as StudentStatus))
+        }
+      >
+        <SelectTrigger className="w-full sm:w-[150px]">
+          <SelectValue placeholder="All Statuses" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">All Statuses</SelectItem>
+          {STATUS_OPTIONS.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value}>
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {hasFilters && (
+        <Button variant="ghost" size="sm" onClick={resetFilters}>
+          <X className="mr-2 h-4 w-4" />
+          Clear
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/app/admin/mahad/cohorts-new/components/dashboard/dashboard-header.tsx
+++ b/app/admin/mahad/cohorts-new/components/dashboard/dashboard-header.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { Plus } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+import { useMahadUIStore } from '../../store'
+
+export function DashboardHeader() {
+  const openDialogWithData = useMahadUIStore((s) => s.openDialogWithData)
+
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight sm:text-3xl">
+          Mahad Cohorts
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground sm:text-base">
+          Manage students, batches, and enrollment
+        </p>
+      </div>
+
+      <Button
+        onClick={() => openDialogWithData('createBatch')}
+        className="w-full sm:w-auto"
+      >
+        <Plus className="mr-2 h-4 w-4" />
+        New Batch
+      </Button>
+    </div>
+  )
+}

--- a/app/admin/mahad/cohorts-new/components/dashboard/dashboard-stats.tsx
+++ b/app/admin/mahad/cohorts-new/components/dashboard/dashboard-stats.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { AlertCircle, Clock, UserCheck, Users } from 'lucide-react'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+import { DashboardStats as Stats } from '../../_types'
+
+interface DashboardStatsProps {
+  stats: Stats
+}
+
+export function DashboardStats({ stats }: DashboardStatsProps) {
+  return (
+    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Total Students</CardTitle>
+          <Users className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{stats.total}</div>
+          <p className="text-xs text-muted-foreground">Across all batches</p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Active</CardTitle>
+          <UserCheck className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{stats.active}</div>
+          <p className="text-xs text-muted-foreground">Enrolled students</p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Registered</CardTitle>
+          <Clock className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{stats.registered}</div>
+          <p className="text-xs text-muted-foreground">Awaiting enrollment</p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Unpaid</CardTitle>
+          <AlertCircle
+            className={`h-4 w-4 ${stats.unpaid > 0 ? 'text-amber-500' : 'text-muted-foreground'}`}
+          />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{stats.unpaid}</div>
+          <p className="text-xs text-muted-foreground">
+            No active subscription
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/admin/mahad/cohorts-new/components/dashboard/index.ts
+++ b/app/admin/mahad/cohorts-new/components/dashboard/index.ts
@@ -1,0 +1,4 @@
+export { DashboardHeader } from './dashboard-header'
+export { DashboardStats } from './dashboard-stats'
+export { DashboardFilters } from './dashboard-filters'
+export { TabContent } from './tab-content'

--- a/app/admin/mahad/cohorts-new/components/dashboard/tab-content.tsx
+++ b/app/admin/mahad/cohorts-new/components/dashboard/tab-content.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import {
+  DuplicateGroup,
+  MahadBatch,
+  MahadStudent,
+  TabValue,
+} from '../../_types'
+import { BatchGrid } from '../batches/batch-grid'
+import { DuplicatesView } from '../duplicates/duplicates-view'
+import { StudentsTable } from '../students/students-table'
+
+interface TabContentProps {
+  tab: TabValue
+  students: MahadStudent[]
+  batches: MahadBatch[]
+  duplicates: DuplicateGroup[]
+}
+
+export function TabContent({
+  tab,
+  students,
+  batches,
+  duplicates,
+}: TabContentProps) {
+  switch (tab) {
+    case 'students':
+      return <StudentsTable students={students} />
+    case 'batches':
+      return <BatchGrid batches={batches} students={students} />
+    case 'duplicates':
+      return <DuplicatesView duplicates={duplicates} />
+    default:
+      return null
+  }
+}

--- a/app/admin/mahad/cohorts-new/components/duplicates/duplicates-view.tsx
+++ b/app/admin/mahad/cohorts-new/components/duplicates/duplicates-view.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { AlertTriangle, Mail, Phone, CheckCircle } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+import { DuplicateGroup } from '../../_types'
+
+interface DuplicatesViewProps {
+  duplicates: DuplicateGroup[]
+}
+
+function DuplicateCard({ group }: { group: DuplicateGroup }) {
+  const Icon = group.matchType === 'email' ? Mail : Phone
+  const label = group.matchType === 'email' ? 'Email match' : 'Phone match'
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-sm font-medium">
+            <Badge variant="outline" className="gap-1">
+              <Icon className="h-3 w-3" />
+              {label}
+            </Badge>
+          </CardTitle>
+          <Badge variant="secondary">{group.students.length} students</Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <ul className="space-y-2">
+          {group.students.map((student) => (
+            <li
+              key={student.id}
+              className="flex items-center justify-between rounded-md bg-muted/50 p-2 text-sm"
+            >
+              <span className="font-medium">{student.name}</span>
+              <span className="text-muted-foreground">
+                {student.batch?.name || 'Unassigned'}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function DuplicatesView({ duplicates }: DuplicatesViewProps) {
+  if (duplicates.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-lg border border-dashed p-12 text-center">
+        <CheckCircle className="h-12 w-12 text-green-500" />
+        <h3 className="mt-4 text-lg font-semibold">No duplicates detected</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          All students appear to be unique based on email and phone.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 p-4 dark:border-amber-900 dark:bg-amber-950">
+        <AlertTriangle className="h-5 w-5 text-amber-500" />
+        <div>
+          <p className="font-medium text-amber-700 dark:text-amber-400">
+            {duplicates.length} potential duplicate groups found
+          </p>
+          <p className="text-sm text-amber-600 dark:text-amber-500">
+            Review these students and merge or remove duplicates as needed.
+          </p>
+        </div>
+      </div>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {duplicates.map((group) => (
+          <DuplicateCard key={group.key} group={group} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/admin/mahad/cohorts-new/components/duplicates/index.ts
+++ b/app/admin/mahad/cohorts-new/components/duplicates/index.ts
@@ -1,0 +1,1 @@
+export { DuplicatesView } from './duplicates-view'

--- a/app/admin/mahad/cohorts-new/components/index.ts
+++ b/app/admin/mahad/cohorts-new/components/index.ts
@@ -1,0 +1,5 @@
+export { MahadDashboard } from './mahad-dashboard'
+export * from './dashboard'
+export * from './students'
+export * from './batches'
+export * from './duplicates'

--- a/app/admin/mahad/cohorts-new/components/mahad-dashboard.tsx
+++ b/app/admin/mahad/cohorts-new/components/mahad-dashboard.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { Layers, Users, AlertTriangle } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { BatchWithCount } from '@/lib/db/queries/batch'
+import { StudentWithBatchData } from '@/lib/db/queries/student'
+
+import { useStudentFilters } from '../_hooks/use-student-filters'
+import { useStudentStats, useDuplicates } from '../_hooks/use-student-groups'
+import { MahadBatch, MahadStudent, TabValue } from '../_types'
+import { useActiveTab, useMahadFilters, useMahadUIStore } from '../store'
+import { DashboardFilters } from './dashboard/dashboard-filters'
+import { DashboardHeader } from './dashboard/dashboard-header'
+import { DashboardStats } from './dashboard/dashboard-stats'
+import { TabContent } from './dashboard/tab-content'
+
+interface MahadDashboardProps {
+  students: StudentWithBatchData[]
+  batches: BatchWithCount[]
+}
+
+function mapStudent(s: StudentWithBatchData): MahadStudent {
+  return {
+    id: s.id,
+    name: s.name,
+    email: s.email ?? null,
+    phone: s.phone ?? null,
+    dateOfBirth: s.dateOfBirth ?? null,
+    gradeLevel: s.gradeLevel ?? null,
+    schoolName: s.schoolName ?? null,
+    graduationStatus: s.graduationStatus ?? null,
+    paymentFrequency: s.paymentFrequency ?? null,
+    billingType: s.billingType ?? null,
+    paymentNotes: s.paymentNotes ?? null,
+    status: s.status,
+    batchId: s.batchId ?? null,
+    createdAt: s.createdAt,
+    updatedAt: s.updatedAt,
+    batch: s.batch
+      ? {
+          id: s.batch.id,
+          name: s.batch.name,
+          startDate: s.batch.startDate,
+          endDate: s.batch.endDate,
+        }
+      : null,
+    subscription: s.subscription
+      ? {
+          id: s.subscription.id,
+          status: s.subscription.status,
+          stripeSubscriptionId: s.subscription.stripeSubscriptionId,
+          amount: s.subscription.amount,
+        }
+      : null,
+    siblingCount: s.siblingCount,
+  }
+}
+
+function mapBatch(b: BatchWithCount): MahadBatch {
+  return {
+    id: b.id,
+    name: b.name,
+    startDate: b.startDate,
+    endDate: b.endDate,
+    createdAt: b.createdAt,
+    updatedAt: b.updatedAt,
+    studentCount: b.studentCount,
+  }
+}
+
+export function MahadDashboard({ students, batches }: MahadDashboardProps) {
+  const activeTab = useActiveTab()
+  const filters = useMahadFilters()
+  const setActiveTab = useMahadUIStore((s) => s.setActiveTab)
+
+  const mahadStudents = students.map(mapStudent)
+  const mahadBatches = batches.map(mapBatch)
+
+  const filteredStudents = useStudentFilters(mahadStudents, filters)
+  const stats = useStudentStats(mahadStudents)
+  const duplicates = useDuplicates(mahadStudents)
+
+  return (
+    <div className="space-y-6">
+      <DashboardHeader />
+
+      <DashboardStats stats={stats} />
+
+      <DashboardFilters batches={mahadBatches} />
+
+      <Tabs
+        value={activeTab}
+        onValueChange={(v) => setActiveTab(v as TabValue)}
+        aria-label="Cohort management tabs"
+      >
+        <TabsList className="flex h-auto flex-wrap justify-start sm:grid sm:grid-cols-3">
+          <TabsTrigger
+            value="students"
+            className="flex-1 gap-1 px-2 py-2 text-xs sm:gap-2 sm:px-3 sm:text-sm"
+          >
+            <Users className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+            <span className="hidden sm:inline">Students</span>
+            <Badge
+              variant="secondary"
+              className="ml-1 px-1 text-[10px] sm:px-1.5 sm:text-xs"
+            >
+              {filteredStudents.length}
+            </Badge>
+          </TabsTrigger>
+          <TabsTrigger
+            value="batches"
+            className="flex-1 gap-1 px-2 py-2 text-xs sm:gap-2 sm:px-3 sm:text-sm"
+          >
+            <Layers className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+            <span className="hidden sm:inline">Batches</span>
+            <Badge
+              variant="secondary"
+              className="ml-1 px-1 text-[10px] sm:px-1.5 sm:text-xs"
+            >
+              {mahadBatches.length}
+            </Badge>
+          </TabsTrigger>
+          <TabsTrigger
+            value="duplicates"
+            className="flex-1 gap-1 px-2 py-2 text-xs sm:gap-2 sm:px-3 sm:text-sm"
+          >
+            <AlertTriangle className="h-3.5 w-3.5 sm:h-4 sm:w-4" />
+            <span className="hidden sm:inline">Duplicates</span>
+            {duplicates.length > 0 && (
+              <Badge
+                variant="destructive"
+                className="ml-1 px-1 text-[10px] sm:px-1.5 sm:text-xs"
+              >
+                {duplicates.length}
+              </Badge>
+            )}
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="students" className="mt-6">
+          <TabContent
+            tab="students"
+            students={filteredStudents}
+            batches={mahadBatches}
+            duplicates={duplicates}
+          />
+        </TabsContent>
+
+        <TabsContent value="batches" className="mt-6">
+          <TabContent
+            tab="batches"
+            students={mahadStudents}
+            batches={mahadBatches}
+            duplicates={duplicates}
+          />
+        </TabsContent>
+
+        <TabsContent value="duplicates" className="mt-6">
+          <TabContent
+            tab="duplicates"
+            students={mahadStudents}
+            batches={mahadBatches}
+            duplicates={duplicates}
+          />
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/app/admin/mahad/cohorts-new/components/students/index.ts
+++ b/app/admin/mahad/cohorts-new/components/students/index.ts
@@ -1,0 +1,2 @@
+export { StudentsTable } from './students-table'
+export { StudentDetailSheet } from './student-detail-sheet'

--- a/app/admin/mahad/cohorts-new/components/students/student-detail-sheet.tsx
+++ b/app/admin/mahad/cohorts-new/components/students/student-detail-sheet.tsx
@@ -1,0 +1,134 @@
+'use client'
+
+import { format } from 'date-fns'
+import { Mail, Phone, Calendar, GraduationCap, Building2 } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Separator } from '@/components/ui/separator'
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { StudentStatus } from '@/lib/types/student'
+
+import { MahadStudent } from '../../_types'
+
+interface StudentDetailSheetProps {
+  student: MahadStudent | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+function InfoRow({
+  icon: Icon,
+  label,
+  value,
+}: {
+  icon: React.ElementType
+  label: string
+  value: string | null
+}) {
+  if (!value) return null
+  return (
+    <div className="flex items-start gap-3">
+      <Icon className="mt-0.5 h-4 w-4 text-muted-foreground" />
+      <div>
+        <p className="text-xs text-muted-foreground">{label}</p>
+        <p className="text-sm">{value}</p>
+      </div>
+    </div>
+  )
+}
+
+export function StudentDetailSheet({
+  student,
+  open,
+  onOpenChange,
+}: StudentDetailSheetProps) {
+  if (!student) return null
+
+  const statusLabels: Record<StudentStatus, string> = {
+    [StudentStatus.ENROLLED]: 'Enrolled',
+    [StudentStatus.REGISTERED]: 'Registered',
+    [StudentStatus.ON_LEAVE]: 'On Leave',
+    [StudentStatus.WITHDRAWN]: 'Withdrawn',
+  }
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="w-full sm:max-w-md">
+        <SheetHeader>
+          <SheetTitle>{student.name}</SheetTitle>
+          <SheetDescription>
+            <Badge variant="secondary">{statusLabels[student.status]}</Badge>
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="mt-6 space-y-6">
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold">Contact Information</h3>
+            <div className="space-y-3">
+              <InfoRow icon={Mail} label="Email" value={student.email} />
+              <InfoRow icon={Phone} label="Phone" value={student.phone} />
+            </div>
+          </div>
+
+          <Separator />
+
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold">Academic Information</h3>
+            <div className="space-y-3">
+              <InfoRow
+                icon={Calendar}
+                label="Date of Birth"
+                value={
+                  student.dateOfBirth
+                    ? format(student.dateOfBirth, 'PPP')
+                    : null
+                }
+              />
+              <InfoRow
+                icon={GraduationCap}
+                label="Grade Level"
+                value={student.gradeLevel}
+              />
+              <InfoRow
+                icon={Building2}
+                label="School"
+                value={student.schoolName}
+              />
+            </div>
+          </div>
+
+          <Separator />
+
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold">Enrollment</h3>
+            <div className="space-y-3">
+              <div className="flex items-start gap-3">
+                <div>
+                  <p className="text-xs text-muted-foreground">Batch</p>
+                  <p className="text-sm">
+                    {student.batch?.name || 'Unassigned'}
+                  </p>
+                </div>
+              </div>
+              {student.subscription && (
+                <div>
+                  <p className="text-xs text-muted-foreground">Subscription</p>
+                  <p className="text-sm">
+                    {student.subscription.status} - $
+                    {student.subscription.amount / 100}/mo
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/app/admin/mahad/cohorts-new/components/students/students-table.tsx
+++ b/app/admin/mahad/cohorts-new/components/students/students-table.tsx
@@ -1,0 +1,176 @@
+'use client'
+
+import { useState } from 'react'
+
+import { MoreHorizontal, User } from 'lucide-react'
+
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Checkbox } from '@/components/ui/checkbox'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { StudentStatus } from '@/lib/types/student'
+
+import { StudentDetailSheet } from './student-detail-sheet'
+import { MahadStudent } from '../../_types'
+import { useSelectedStudents, useMahadUIStore } from '../../store'
+
+interface StudentsTableProps {
+  students: MahadStudent[]
+}
+
+function getStatusBadge(status: StudentStatus) {
+  const variants: Record<
+    StudentStatus,
+    {
+      variant: 'default' | 'secondary' | 'destructive' | 'outline'
+      label: string
+    }
+  > = {
+    [StudentStatus.ENROLLED]: { variant: 'default', label: 'Enrolled' },
+    [StudentStatus.REGISTERED]: { variant: 'secondary', label: 'Registered' },
+    [StudentStatus.ON_LEAVE]: { variant: 'outline', label: 'On Leave' },
+    [StudentStatus.WITHDRAWN]: { variant: 'destructive', label: 'Withdrawn' },
+  }
+  const config = variants[status] || { variant: 'outline', label: status }
+  return <Badge variant={config.variant}>{config.label}</Badge>
+}
+
+export function StudentsTable({ students }: StudentsTableProps) {
+  const [selectedStudent, setSelectedStudent] = useState<MahadStudent | null>(
+    null
+  )
+  const selectedIds = useSelectedStudents()
+  const { toggleStudent, setSelected, clearSelected, openDialogWithData } =
+    useMahadUIStore()
+
+  const allSelected =
+    students.length > 0 && students.every((s) => selectedIds.has(s.id))
+  const someSelected = students.some((s) => selectedIds.has(s.id))
+
+  const handleSelectAll = () => {
+    if (allSelected) {
+      clearSelected()
+    } else {
+      setSelected(students.map((s) => s.id))
+    }
+  }
+
+  if (students.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center rounded-lg border border-dashed p-12 text-center">
+        <User className="h-12 w-12 text-muted-foreground" />
+        <h3 className="mt-4 text-lg font-semibold">No students found</h3>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Try adjusting your filters or add new students.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <>
+      <div className="rounded-md border">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[50px]">
+                <Checkbox
+                  checked={allSelected}
+                  ref={(el) => {
+                    if (el)
+                      (el as HTMLInputElement).indeterminate =
+                        someSelected && !allSelected
+                  }}
+                  onCheckedChange={handleSelectAll}
+                  aria-label="Select all students"
+                />
+              </TableHead>
+              <TableHead>Name</TableHead>
+              <TableHead className="hidden md:table-cell">Email</TableHead>
+              <TableHead className="hidden sm:table-cell">Batch</TableHead>
+              <TableHead>Status</TableHead>
+              <TableHead className="w-[50px]"></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {students.map((student) => (
+              <TableRow
+                key={student.id}
+                className="cursor-pointer"
+                onClick={() => setSelectedStudent(student)}
+              >
+                <TableCell onClick={(e) => e.stopPropagation()}>
+                  <Checkbox
+                    checked={selectedIds.has(student.id)}
+                    onCheckedChange={() => toggleStudent(student.id)}
+                    aria-label={`Select ${student.name}`}
+                  />
+                </TableCell>
+                <TableCell className="font-medium">{student.name}</TableCell>
+                <TableCell className="hidden md:table-cell">
+                  {student.email || '-'}
+                </TableCell>
+                <TableCell className="hidden sm:table-cell">
+                  {student.batch?.name || (
+                    <span className="text-muted-foreground">Unassigned</span>
+                  )}
+                </TableCell>
+                <TableCell>{getStatusBadge(student.status)}</TableCell>
+                <TableCell onClick={(e) => e.stopPropagation()}>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button variant="ghost" size="icon">
+                        <MoreHorizontal className="h-4 w-4" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        onClick={() => setSelectedStudent(student)}
+                      >
+                        View Details
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        onClick={() =>
+                          openDialogWithData('paymentLink', student)
+                        }
+                      >
+                        Generate Payment Link
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        className="text-destructive"
+                        onClick={() =>
+                          openDialogWithData('deleteStudent', student)
+                        }
+                      >
+                        Delete Student
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+
+      <StudentDetailSheet
+        student={selectedStudent}
+        open={!!selectedStudent}
+        onOpenChange={(open) => !open && setSelectedStudent(null)}
+      />
+    </>
+  )
+}

--- a/app/admin/mahad/cohorts-new/page.tsx
+++ b/app/admin/mahad/cohorts-new/page.tsx
@@ -1,0 +1,63 @@
+import { Suspense } from 'react'
+
+import { Metadata } from 'next'
+
+import { AppErrorBoundary } from '@/components/error-boundary'
+import { getBatches } from '@/lib/db/queries/batch'
+import { getStudentsWithBatch } from '@/lib/db/queries/student'
+
+import { MahadDashboard } from './components/mahad-dashboard'
+
+export const dynamic = 'force-dynamic'
+
+export const metadata: Metadata = {
+  title: 'Mahad Cohorts',
+  description: 'Manage Mahad student cohorts and batches',
+}
+
+function Loading() {
+  return (
+    <div className="container mx-auto space-y-6 p-4 sm:space-y-8 sm:p-6">
+      <div className="animate-pulse">
+        <div className="mb-6 h-8 w-64 rounded bg-muted" />
+        <div className="mb-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="h-24 rounded-lg bg-muted" />
+          ))}
+        </div>
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row">
+          <div className="h-10 flex-1 rounded-md bg-muted" />
+          <div className="h-10 w-24 rounded-md bg-muted" />
+        </div>
+        <div className="mb-6 flex gap-2">
+          <div className="h-9 w-24 rounded-md bg-muted" />
+          <div className="h-9 w-24 rounded-md bg-muted" />
+          <div className="h-9 w-24 rounded-md bg-muted" />
+        </div>
+        <div className="h-96 rounded-lg bg-muted" />
+      </div>
+    </div>
+  )
+}
+
+export default async function MahadCohortsPage() {
+  const [batches, students] = await Promise.all([
+    getBatches(),
+    getStudentsWithBatch(),
+  ])
+
+  return (
+    <main className="container mx-auto space-y-4 p-4 sm:space-y-6 sm:p-6 lg:space-y-8 lg:p-8">
+      <AppErrorBoundary
+        context="Mahad cohorts dashboard"
+        variant="card"
+        fallbackUrl="/admin/mahad/cohorts-new"
+        fallbackLabel="Reload Dashboard"
+      >
+        <Suspense fallback={<Loading />}>
+          <MahadDashboard students={students} batches={batches} />
+        </Suspense>
+      </AppErrorBoundary>
+    </main>
+  )
+}

--- a/app/admin/mahad/cohorts-new/store/index.ts
+++ b/app/admin/mahad/cohorts-new/store/index.ts
@@ -1,0 +1,8 @@
+export {
+  useMahadUIStore,
+  useActiveTab,
+  useMahadFilters,
+  useSelectedStudents,
+  useDialogState,
+  useDialogData,
+} from './ui-store'

--- a/app/admin/mahad/cohorts-new/store/ui-store.ts
+++ b/app/admin/mahad/cohorts-new/store/ui-store.ts
@@ -1,0 +1,139 @@
+/**
+ * Simplified UI Store for Mahad Cohorts Management
+ *
+ * Manages transient UI state:
+ * - Active tab
+ * - Student filters (search, batch, status)
+ * - Student selection for bulk operations
+ * - Dialog visibility
+ *
+ * Follows the Dugsi admin pattern for consistency.
+ */
+
+import { enableMapSet } from 'immer'
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import { immer } from 'zustand/middleware/immer'
+
+import { StudentStatus } from '@/lib/types/student'
+
+import { DialogType, StudentFilters, TabValue } from '../_types'
+
+enableMapSet()
+
+interface MahadUIStore {
+  activeTab: TabValue
+  filters: StudentFilters
+  selectedStudentIds: Set<string>
+  openDialog: DialogType
+  dialogData: unknown
+
+  setActiveTab: (tab: TabValue) => void
+  setFilters: (filters: Partial<StudentFilters>) => void
+  setSearchQuery: (query: string) => void
+  setBatchFilter: (batchId: string | null) => void
+  setStatusFilter: (status: StudentStatus | null) => void
+  resetFilters: () => void
+  toggleStudent: (id: string) => void
+  setSelected: (ids: string[]) => void
+  clearSelected: () => void
+  openDialogWithData: (dialog: DialogType, data?: unknown) => void
+  closeDialog: () => void
+  reset: () => void
+}
+
+const defaultFilters: StudentFilters = {
+  search: '',
+  batchId: null,
+  status: null,
+}
+
+export const useMahadUIStore = create<MahadUIStore>()(
+  devtools(
+    immer((set) => ({
+      activeTab: 'students',
+      filters: defaultFilters,
+      selectedStudentIds: new Set(),
+      openDialog: null,
+      dialogData: null,
+
+      setActiveTab: (tab) =>
+        set((state) => {
+          state.activeTab = tab
+        }),
+
+      setFilters: (filters) =>
+        set((state) => {
+          state.filters = { ...state.filters, ...filters }
+        }),
+
+      setSearchQuery: (query) =>
+        set((state) => {
+          state.filters.search = query
+        }),
+
+      setBatchFilter: (batchId) =>
+        set((state) => {
+          state.filters.batchId = batchId
+        }),
+
+      setStatusFilter: (status) =>
+        set((state) => {
+          state.filters.status = status
+        }),
+
+      resetFilters: () =>
+        set((state) => {
+          state.filters = { ...defaultFilters }
+        }),
+
+      toggleStudent: (id) =>
+        set((state) => {
+          if (state.selectedStudentIds.has(id)) {
+            state.selectedStudentIds.delete(id)
+          } else {
+            state.selectedStudentIds.add(id)
+          }
+        }),
+
+      setSelected: (ids) =>
+        set((state) => {
+          state.selectedStudentIds = new Set(ids)
+        }),
+
+      clearSelected: () =>
+        set((state) => {
+          state.selectedStudentIds = new Set()
+        }),
+
+      openDialogWithData: (dialog, data) =>
+        set((state) => {
+          state.openDialog = dialog
+          state.dialogData = data ?? null
+        }),
+
+      closeDialog: () =>
+        set((state) => {
+          state.openDialog = null
+          state.dialogData = null
+        }),
+
+      reset: () =>
+        set((state) => {
+          state.activeTab = 'students'
+          state.filters = { ...defaultFilters }
+          state.selectedStudentIds = new Set()
+          state.openDialog = null
+          state.dialogData = null
+        }),
+    })),
+    { name: 'mahad-cohorts-ui-store' }
+  )
+)
+
+export const useActiveTab = () => useMahadUIStore((s) => s.activeTab)
+export const useMahadFilters = () => useMahadUIStore((s) => s.filters)
+export const useSelectedStudents = () =>
+  useMahadUIStore((s) => s.selectedStudentIds)
+export const useDialogState = () => useMahadUIStore((s) => s.openDialog)
+export const useDialogData = () => useMahadUIStore((s) => s.dialogData)


### PR DESCRIPTION
Implements foundation for the Mahad cohorts rewrite following the Dugsi admin pattern:

- Single page.tsx with server data fetching (no parallel routes)
- Tab-based navigation: Students, Batches, Duplicates
- Simplified Zustand store for UI state only
- Clean hooks/utils separation with memoized filtering
- Consistent component structure:
  - MahadDashboard as main orchestrator
  - Dashboard header, stats, filters components
  - StudentsTable with detail sheet
  - BatchGrid with clickable cards
  - DuplicatesView for email/phone matching

New page available at /admin/mahad/cohorts-new for testing. Old parallel routes preserved at /admin/mahad/cohorts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Pull Request

## Description

<!-- What does this PR do? -->

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🎨 UI/UX improvement
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] 🗃️ Database change

## Testing

- [ ] Tested locally
- [ ] Works on mobile/tablet/desktop
- [ ] No console errors

**What I tested:**

## Database Safety (if applicable)

- [ ] No database changes OR
- [ ] Changes are additive only (no data loss)
- [ ] Follows `/docs/CRITICAL_RULES.md`

## Code Quality

- [ ] Self-reviewed
- [ ] No linter errors
- [ ] TypeScript types added
- [ ] Used Server Components where possible

## Screenshots (if applicable)

## Notes

---

**Remember:** Production data is sacred 🔒
