### PR TITLE
fix: send WhatsApp payment link to primary payer's phone

### DIFF
--- a/app/admin/dugsi/_utils/__tests__/family.test.ts
+++ b/app/admin/dugsi/_utils/__tests__/family.test.ts
@@ -352,17 +352,14 @@ describe('getPrimaryPayerPhone', () => {
       expect(result.fallbackReason).toBe('primary_payer_phone_missing')
     })
 
-    it('should fallback to family.parentPhone when both parent phones are missing', () => {
-      const family = createFamily(
-        {
-          primaryPayerParentNumber: 1,
-          parentPhone: null,
-          parent2Phone: null,
-        },
-        { parentPhone: '5553333333' }
-      )
+    it('should return null when both parent phones are missing', () => {
+      const family = createFamily({
+        primaryPayerParentNumber: 1,
+        parentPhone: null,
+        parent2Phone: null,
+      })
       const result = getPrimaryPayerPhone(family)
-      expect(result.phone).toBe('5553333333')
+      expect(result.phone).toBeNull()
       expect(result.usedFallback).toBe(true)
       expect(result.fallbackReason).toBe('primary_payer_phone_missing')
     })
@@ -387,17 +384,14 @@ describe('getPrimaryPayerPhone', () => {
       expect(result.fallbackReason).toBe('primary_payer_phone_missing')
     })
 
-    it('should fallback to family.parentPhone when both parent phones are missing', () => {
-      const family = createFamily(
-        {
-          primaryPayerParentNumber: 2,
-          parentPhone: null,
-          parent2Phone: null,
-        },
-        { parentPhone: '5553333333' }
-      )
+    it('should return null when both parent phones are missing', () => {
+      const family = createFamily({
+        primaryPayerParentNumber: 2,
+        parentPhone: null,
+        parent2Phone: null,
+      })
       const result = getPrimaryPayerPhone(family)
-      expect(result.phone).toBe('5553333333')
+      expect(result.phone).toBeNull()
       expect(result.usedFallback).toBe(true)
       expect(result.fallbackReason).toBe('primary_payer_phone_missing')
     })
@@ -423,24 +417,21 @@ describe('getPrimaryPayerPhone', () => {
       expect(result.fallbackReason).toBe('primary_payer_not_set')
     })
 
-    it('should fallback to family.parentPhone when both parent phones are missing', () => {
-      const family = createFamily(
-        {
-          primaryPayerParentNumber: null,
-          parentPhone: null,
-          parent2Phone: null,
-        },
-        { parentPhone: '5553333333' }
-      )
+    it('should return null when both parent phones are missing', () => {
+      const family = createFamily({
+        primaryPayerParentNumber: null,
+        parentPhone: null,
+        parent2Phone: null,
+      })
       const result = getPrimaryPayerPhone(family)
-      expect(result.phone).toBe('5553333333')
+      expect(result.phone).toBeNull()
       expect(result.usedFallback).toBe(true)
       expect(result.fallbackReason).toBe('primary_payer_not_set')
     })
   })
 
   describe('edge cases', () => {
-    it('should handle empty members array', () => {
+    it('should handle empty members array by returning family.parentPhone', () => {
       const family: Family = {
         familyKey: 'family-1',
         members: [],

--- a/app/admin/dugsi/_utils/family.ts
+++ b/app/admin/dugsi/_utils/family.ts
@@ -193,7 +193,7 @@ export function getPrimaryPayerPhone(family: Family): PrimaryPayerPhoneResult {
       return { phone: parent2Phone, usedFallback: false }
     }
     return {
-      phone: parentPhone || family.parentPhone,
+      phone: parentPhone,
       usedFallback: true,
       fallbackReason: 'primary_payer_phone_missing',
     }
@@ -201,7 +201,7 @@ export function getPrimaryPayerPhone(family: Family): PrimaryPayerPhoneResult {
 
   if (primaryPayerParentNumber === null) {
     return {
-      phone: parentPhone || parent2Phone || family.parentPhone,
+      phone: parentPhone || parent2Phone,
       usedFallback: true,
       fallbackReason: 'primary_payer_not_set',
     }
@@ -212,7 +212,7 @@ export function getPrimaryPayerPhone(family: Family): PrimaryPayerPhoneResult {
   }
 
   return {
-    phone: parent2Phone || family.parentPhone,
+    phone: parent2Phone,
     usedFallback: true,
     fallbackReason: 'primary_payer_phone_missing',
   }

--- a/app/admin/dugsi/components/dialogs/payment-link-dialog.tsx
+++ b/app/admin/dugsi/components/dialogs/payment-link-dialog.tsx
@@ -181,6 +181,16 @@ export function PaymentLinkDialog({
             </Alert>
           )}
 
+          {phoneResult.fallbackReason === 'primary_payer_phone_missing' && (
+            <Alert>
+              <AlertTriangle className="h-4 w-4" />
+              <AlertDescription className="text-sm">
+                Primary payer&apos;s phone missing. Using alternate
+                parent&apos;s phone.
+              </AlertDescription>
+            </Alert>
+          )}
+
           {!result && (
             <>
               <div className="rounded-lg border bg-muted/50 p-4">


### PR DESCRIPTION
## Summary
- WhatsApp payment links now go to the primary payer's phone instead of always Parent 1
- Uses `primaryPayerParentNumber` set during registration to determine correct recipient

## Type of Change
- [x] Bug fix

## Testing
- [x] Tested locally
- [x] No console errors

**What I tested:**
- Verified logic uses `primaryPayerParentNumber` to select correct phone
- Build passes

## Database Safety
- [x] No database changes

## Code Quality
- [x] Self-reviewed
- [x] No linter errors
- [x] TypeScript types added
- [x] Used Server Components where possible

---

Generated with [Claude Code](https://claude.com/claude-code)