### PR TITLE
feat(dugsi): add card payment method option

### DIFF
--- a/lib/services/dugsi/checkout-service.ts
+++ b/lib/services/dugsi/checkout-service.ts
@@ -306,7 +306,7 @@ export async function createDugsiCheckoutSession(
   // Create the checkout session
   const session = await stripe.checkout.sessions.create({
     mode: 'subscription',
-    payment_method_types: ['us_bank_account'], // ACH only
+    payment_method_types: ['card', 'us_bank_account'],
     customer: customerId,
     customer_email: customerId ? undefined : guardianEmail,
     line_items: [


### PR DESCRIPTION
## Summary
- Add card payment option for Dugsi checkout alongside existing ACH bank transfers
- Families can now choose to pay with credit/debit card

## Test plan
- [ ] Generate a Dugsi payment link from admin
- [ ] Verify checkout shows both card and bank account options
- [ ] Complete a test payment with card

🤖 Generated with [Claude Code](https://claude.com/claude-code)