### PR TITLE
feat(dugsi): add toggleable card payment method

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,9 +24,6 @@ NEXT_PUBLIC_STRIPE_MAHAD_PUBLISHABLE_KEY_TEST=pk_test_xxx
 NEXT_PUBLIC_STRIPE_MAHAD_PUBLISHABLE_KEY_LIVE=pk_live_xxx
 NEXT_PUBLIC_STRIPE_MAHAD_PRICING_TABLE_ID=prctbl_xxx
 
-# Feature flags
-MAHAD_CARD_PAYMENTS_ENABLED=true  # Set to 'true' to allow card payments, otherwise ACH only
-
 # ═══════════════════════════════════════════════════════════════
 # DUGSI (Separate Stripe Account)
 # Pattern: STRIPE_DUGSI_{TYPE}_{ENV}
@@ -43,9 +40,6 @@ STRIPE_DUGSI_PRODUCT_ID=prod_xxx                # Dugsi subscription product ID 
 NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_TEST=pk_test_xxx  # Optional
 NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_LIVE=pk_live_xxx
 NEXT_PUBLIC_STRIPE_DUGSI_PAYMENT_LINK=https://buy.stripe.com/xxx
-
-# Feature flags
-DUGSI_CARD_PAYMENTS_ENABLED=true  # Set to 'true' to allow card payments, otherwise ACH only
 
 # ═══════════════════════════════════════════════════════════════
 # YOUTH (Future - defaults to MAHAD account)
@@ -75,3 +69,18 @@ WHATSAPP_WEBHOOK_VERIFY_TOKEN=           # Random string for webhook verificatio
 # APP CONFIG
 # ═══════════════════════════════════════════════════════════════
 NEXT_PUBLIC_APP_URL=http://localhost:3000
+
+# ═══════════════════════════════════════════════════════════════
+# FEATURE FLAGS
+# ═══════════════════════════════════════════════════════════════
+# Toggle features without redeploying. Changes take effect immediately.
+# See lib/config/feature-flags.ts for all available flags.
+#
+# VERCEL SETUP:
+#   1. Go to Project Settings > Environment Variables
+#   2. Add the flag with value 'true' to enable
+#   3. Remove or set to any other value to disable
+#   4. Changes apply immediately (no redeploy needed for serverless)
+#
+# MAHAD_CARD_PAYMENTS_ENABLED=true   # Allow card payments for Mahad (default: ACH only)
+# DUGSI_CARD_PAYMENTS_ENABLED=true   # Allow card payments for Dugsi (default: ACH only)

--- a/app/admin/mahad/_actions/index.ts
+++ b/app/admin/mahad/_actions/index.ts
@@ -19,7 +19,7 @@ import {
 } from '@prisma/client'
 import { z } from 'zod'
 
-import { isMahadCardPaymentsEnabled } from '@/lib/constants/mahad'
+import { featureFlags } from '@/lib/config/feature-flags'
 import { prisma } from '@/lib/db'
 import {
   createBatch,
@@ -846,7 +846,7 @@ export async function generatePaymentLinkAction(
       // Feature flag: Toggle card payments to manage transaction fees
       // ACH only: Lower fees for the organization
       // Card + ACH: More convenience for families
-      payment_method_types: isMahadCardPaymentsEnabled()
+      payment_method_types: featureFlags.mahadCardPayments()
         ? ['card', 'us_bank_account']
         : ['us_bank_account'],
       customer_email: email,
@@ -1216,7 +1216,7 @@ export async function generatePaymentLinkWithOverrideAction(
       // Feature flag: Toggle card payments to manage transaction fees
       // ACH only: Lower fees for the organization
       // Card + ACH: More convenience for families
-      payment_method_types: isMahadCardPaymentsEnabled()
+      payment_method_types: featureFlags.mahadCardPayments()
         ? ['card', 'us_bank_account']
         : ['us_bank_account'],
       customer_email: email,

--- a/app/api/mahad/create-checkout-session/route.ts
+++ b/app/api/mahad/create-checkout-session/route.ts
@@ -11,7 +11,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { z } from 'zod'
 
-import { isMahadCardPaymentsEnabled } from '@/lib/constants/mahad'
+import { featureFlags } from '@/lib/config/feature-flags'
 import { prisma } from '@/lib/db'
 import { getMahadKeys } from '@/lib/keys/stripe'
 import { createServiceLogger, logError, logWarning } from '@/lib/logger'
@@ -173,7 +173,7 @@ export async function POST(request: NextRequest) {
       // Feature flag: Toggle card payments to manage transaction fees
       // ACH only: Lower fees for the organization
       // Card + ACH: More convenience for families
-      payment_method_types: isMahadCardPaymentsEnabled()
+      payment_method_types: featureFlags.mahadCardPayments()
         ? ['card', 'us_bank_account']
         : ['us_bank_account'],
       customer: customerId,

--- a/lib/config/feature-flags.ts
+++ b/lib/config/feature-flags.ts
@@ -1,0 +1,44 @@
+/**
+ * Centralized Feature Flags
+ *
+ * All feature flags in one place for easy auditing and management.
+ * Toggle these via environment variables in Vercel without redeploying.
+ *
+ * Usage:
+ *   import { featureFlags } from '@/lib/config/feature-flags'
+ *   if (featureFlags.dugsiCardPayments()) { ... }
+ *
+ * Vercel Configuration:
+ *   - Go to Project Settings > Environment Variables
+ *   - Add the flag with value 'true' to enable
+ *   - Remove or set to any other value to disable
+ *   - Changes take effect immediately (no redeploy needed)
+ */
+
+export const featureFlags = {
+  /**
+   * Enable card payments for Dugsi program
+   * When enabled: Families can pay with card or ACH
+   * When disabled: ACH only (lower transaction fees)
+   */
+  dugsiCardPayments: (): boolean =>
+    process.env.DUGSI_CARD_PAYMENTS_ENABLED === 'true',
+
+  /**
+   * Enable card payments for Mahad program
+   * When enabled: Students can pay with card or ACH
+   * When disabled: ACH only (lower transaction fees)
+   */
+  mahadCardPayments: (): boolean =>
+    process.env.MAHAD_CARD_PAYMENTS_ENABLED === 'true',
+} as const
+
+/**
+ * Get all feature flag states for debugging/logging
+ */
+export function getFeatureFlagStates(): Record<string, boolean> {
+  return {
+    dugsiCardPayments: featureFlags.dugsiCardPayments(),
+    mahadCardPayments: featureFlags.mahadCardPayments(),
+  }
+}

--- a/lib/constants/dugsi.ts
+++ b/lib/constants/dugsi.ts
@@ -19,11 +19,6 @@ export const STRIPE_CHECKOUT_SESSION_PREFIX = 'cs_'
 export const DUGSI_PROGRAM = 'DUGSI_PROGRAM' as const
 export const DUGSI_WEBHOOK_SOURCE = 'dugsi' as const
 
-// Feature Flags
-export function isDugsiCardPaymentsEnabled(): boolean {
-  return process.env.DUGSI_CARD_PAYMENTS_ENABLED === 'true'
-}
-
 // Dashboard URLs
 export const STRIPE_DASHBOARD_BASE_URL = 'https://dashboard.stripe.com'
 

--- a/lib/constants/mahad.ts
+++ b/lib/constants/mahad.ts
@@ -12,11 +12,6 @@
 export const MAHAD_PROGRAM = 'MAHAD_PROGRAM' as const
 export const MAHAD_WEBHOOK_SOURCE = 'mahad' as const
 
-// Feature Flags
-export function isMahadCardPaymentsEnabled(): boolean {
-  return process.env.MAHAD_CARD_PAYMENTS_ENABLED === 'true'
-}
-
 // Maximum expected rate in cents ($220 bi-monthly for non-graduate full-time)
 export const MAX_EXPECTED_MAHAD_RATE = 22000
 

--- a/lib/services/dugsi/checkout-service.ts
+++ b/lib/services/dugsi/checkout-service.ts
@@ -8,7 +8,7 @@
  * never client-provided values.
  */
 
-import { isDugsiCardPaymentsEnabled } from '@/lib/constants/dugsi'
+import { featureFlags } from '@/lib/config/feature-flags'
 import { prisma } from '@/lib/db'
 import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
 import { getDugsiKeys } from '@/lib/keys/stripe'
@@ -310,7 +310,7 @@ export async function createDugsiCheckoutSession(
     // Feature flag: Toggle card payments to manage transaction fees
     // ACH only: Lower fees for the organization
     // Card + ACH: More convenience for families
-    payment_method_types: isDugsiCardPaymentsEnabled()
+    payment_method_types: featureFlags.dugsiCardPayments()
       ? ['card', 'us_bank_account']
       : ['us_bank_account'],
     customer: customerId,


### PR DESCRIPTION
## Summary
- Add `DUGSI_CARD_PAYMENTS_ENABLED` env var to toggle card payments on/off
- Set to `true` in Vercel to enable card+ACH, otherwise defaults to ACH only
- Changes take effect immediately without redeploying

## Usage
In Vercel Environment Variables:
- **Enable cards**: `DUGSI_CARD_PAYMENTS_ENABLED=true`
- **Disable cards**: Remove the variable or set to any other value

## Test plan
- [ ] Set env var to `true`, generate payment link, verify card option appears
- [ ] Remove env var, generate payment link, verify only bank account option

🤖 Generated with [Claude Code](https://claude.com/claude-code)