### PR TITLE
fix(dugsi): fix unassigned students list not scrolling

### DIFF
--- a/app/admin/dugsi/classes/_components/unassigned-students-section.tsx
+++ b/app/admin/dugsi/classes/_components/unassigned-students-section.tsx
@@ -173,7 +173,7 @@ export function UnassignedStudentsSection({
                 : `Select All (${sorted.length})`}
             </span>
           </div>
-          <ScrollArea className="max-h-80">
+          <ScrollArea className="h-80">
             {sorted.map((student) => (
               <label
                 key={student.profileId}


### PR DESCRIPTION
## Summary
- Changed `ScrollArea` from `max-h-80` to `h-80` so the Radix viewport has a fixed boundary and actually scrolls
- Previously, students below the fold were invisible with no way to scroll down

## Test plan
- [ ] Navigate to dugsi classes page with unassigned students
- [ ] Verify the list scrolls when there are more students than fit in view
- [ ] Verify select all / individual selection still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)