### PR TITLE
perf: add query caching for Link Subscriptions, Mahad stats, donations page

### DIFF
--- a/app/admin/dugsi/actions.ts
+++ b/app/admin/dugsi/actions.ts
@@ -507,7 +507,7 @@ export async function updateFamilyShift(
       shift: validated.shift,
     })
 
-    revalidatePath('/admin/dugsi', 'layout')
+    revalidatePath('/admin/dugsi')
 
     return {
       success: true,

--- a/app/admin/link-subscriptions/actions.ts
+++ b/app/admin/link-subscriptions/actions.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { revalidatePath } from 'next/cache'
+import { revalidatePath, revalidateTag, unstable_cache } from 'next/cache'
 
 import { createActionLogger, logError, logInfo } from '@/lib/logger'
 import {
@@ -26,14 +26,25 @@ export interface OrphanedSubscriptionsResult {
   error?: string
 }
 
-/**
- * Get all orphaned subscriptions (subscriptions in Stripe not linked to any student).
- * Combines results from both Mahad and Dugsi programs.
- * Returns an error message if Stripe is not configured.
- */
+const getCachedOrphanedSubscriptions = unstable_cache(
+  async () => getAllOrphanedSubscriptions(),
+  ['orphaned-subscriptions'],
+  { revalidate: 300, tags: ['link-subscriptions'] }
+)
+
 export async function getOrphanedSubscriptions(): Promise<OrphanedSubscriptionsResult> {
   try {
-    const data = await getAllOrphanedSubscriptions()
+    const raw = await getCachedOrphanedSubscriptions()
+    const data = raw.map((sub) => ({
+      ...sub,
+      created: new Date(sub.created),
+      currentPeriodStart: sub.currentPeriodStart
+        ? new Date(sub.currentPeriodStart)
+        : null,
+      currentPeriodEnd: sub.currentPeriodEnd
+        ? new Date(sub.currentPeriodEnd)
+        : null,
+    }))
     return { data }
   } catch (error) {
     await logError(logger, error, 'Failed to fetch orphaned subscriptions')
@@ -82,6 +93,7 @@ export async function linkSubscriptionToStudent(
       studentId,
       program,
     })
+    revalidateTag('link-subscriptions')
     revalidatePath('/admin/link-subscriptions')
   }
 
@@ -109,6 +121,7 @@ export async function ignoreSubscription(
       program,
       reason,
     })
+    revalidateTag('link-subscriptions')
     revalidatePath('/admin/link-subscriptions')
   }
 
@@ -129,6 +142,7 @@ export async function unignoreSubscription(
       subscriptionId,
       program,
     })
+    revalidateTag('link-subscriptions')
     revalidatePath('/admin/link-subscriptions')
   }
 

--- a/app/admin/link-subscriptions/components/stats-cards.tsx
+++ b/app/admin/link-subscriptions/components/stats-cards.tsx
@@ -2,13 +2,14 @@ import { AlertTriangle } from 'lucide-react'
 
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 
-import { getOrphanedSubscriptions } from '../actions'
+import type { OrphanedSubscriptionsResult } from '../actions'
 import { StatsCardsClient } from './stats-cards-client'
 
-export async function StatsCards() {
-  const result = await getOrphanedSubscriptions()
+interface StatsCardsProps {
+  result: OrphanedSubscriptionsResult
+}
 
-  // Show error alert if Stripe is not configured
+export function StatsCards({ result }: StatsCardsProps) {
   if (result.error) {
     return (
       <Alert variant="destructive">
@@ -35,7 +36,7 @@ export async function StatsCards() {
   ).length
 
   const totalRevenue =
-    orphanedSubs.reduce((sum, sub) => sum + sub.amount, 0) / 100 // Convert cents to dollars
+    orphanedSubs.reduce((sum, sub) => sum + sub.amount, 0) / 100
 
   return (
     <StatsCardsClient

--- a/app/admin/link-subscriptions/components/subscriptions-list-shell.tsx
+++ b/app/admin/link-subscriptions/components/subscriptions-list-shell.tsx
@@ -5,16 +5,19 @@ import { Badge } from '@/components/ui/badge'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
 import {
-  getOrphanedSubscriptions,
   getPotentialMatches,
   type OrphanedSubscription,
+  type OrphanedSubscriptionsResult,
 } from '../actions'
 import { SubscriptionsListClient } from './subscriptions-list-client'
 
-export async function SubscriptionsListShell() {
-  const result = await getOrphanedSubscriptions()
+interface SubscriptionsListShellProps {
+  result: OrphanedSubscriptionsResult
+}
 
-  // Show error alert if Stripe is not configured
+export async function SubscriptionsListShell({
+  result,
+}: SubscriptionsListShellProps) {
   if (result.error) {
     return (
       <Alert variant="destructive">
@@ -104,7 +107,8 @@ export async function SubscriptionsListShell() {
         </AlertTitle>
         <AlertDescription className="text-blue-800 dark:text-blue-200">
           Review each subscription below and select the corresponding student
-          from the dropdown. Click "Link Subscription" to connect them.
+          from the dropdown. Click &quot;Link Subscription&quot; to connect
+          them.
         </AlertDescription>
       </Alert>
 

--- a/app/admin/link-subscriptions/page.tsx
+++ b/app/admin/link-subscriptions/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react'
 
+import { getOrphanedSubscriptions } from './actions'
 import {
   StatsCardsSkeleton,
   SubscriptionsListSkeleton,
@@ -12,6 +13,17 @@ export const dynamic = 'force-dynamic'
 export const metadata = {
   title: 'Link Subscriptions | Admin',
   description: 'Link orphaned Stripe subscriptions to students',
+}
+
+async function LinkSubscriptionsContent() {
+  const result = await getOrphanedSubscriptions()
+
+  return (
+    <>
+      <StatsCards result={result} />
+      <SubscriptionsListShell result={result} />
+    </>
+  )
 }
 
 export default function LinkSubscriptionsPage() {
@@ -28,12 +40,15 @@ export default function LinkSubscriptionsPage() {
         </div>
       </div>
 
-      <Suspense fallback={<StatsCardsSkeleton />}>
-        <StatsCards />
-      </Suspense>
-
-      <Suspense fallback={<SubscriptionsListSkeleton />}>
-        <SubscriptionsListShell />
+      <Suspense
+        fallback={
+          <>
+            <StatsCardsSkeleton />
+            <SubscriptionsListSkeleton />
+          </>
+        }
+      >
+        <LinkSubscriptionsContent />
       </Suspense>
     </div>
   )

--- a/app/admin/mahad/_actions/__tests__/actions.test.ts
+++ b/app/admin/mahad/_actions/__tests__/actions.test.ts
@@ -14,6 +14,7 @@ const {
   mockPrismaTransaction,
   mockPrismaFindUnique,
   mockRevalidatePath,
+  mockRevalidateTag,
   mockLoggerError,
   mockLoggerWarn,
   mockStripeSessionCreate,
@@ -31,6 +32,7 @@ const {
   mockPrismaTransaction: vi.fn(),
   mockPrismaFindUnique: vi.fn(),
   mockRevalidatePath: vi.fn(),
+  mockRevalidateTag: vi.fn(),
   mockLoggerError: vi.fn(),
   mockLoggerWarn: vi.fn(),
   mockStripeSessionCreate: vi.fn(),
@@ -38,6 +40,7 @@ const {
 
 vi.mock('next/cache', () => ({
   revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+  revalidateTag: (...args: unknown[]) => mockRevalidateTag(...args),
 }))
 
 vi.mock('@/lib/db', () => ({

--- a/app/admin/mahad/_actions/index.ts
+++ b/app/admin/mahad/_actions/index.ts
@@ -9,7 +9,7 @@
  * Uses Prisma-generated types and error codes for better type safety.
  */
 
-import { revalidatePath } from 'next/cache'
+import { revalidatePath, revalidateTag } from 'next/cache'
 
 import {
   Prisma,
@@ -176,6 +176,7 @@ export async function createBatchAction(
       endDate: validated.endDate ?? null,
     })
 
+    revalidateTag('mahad-stats')
     revalidatePath('/admin/mahad')
 
     return {
@@ -213,6 +214,7 @@ export async function deleteBatchAction(id: string): Promise<ActionResult> {
     }
 
     await deleteBatch(id)
+    revalidateTag('mahad-stats')
     revalidatePath('/admin/mahad')
 
     return {
@@ -253,6 +255,7 @@ export async function updateBatchAction(
       endDate: validated.endDate,
     })
 
+    revalidateTag('mahad-stats')
     revalidatePath('/admin/mahad')
 
     return {
@@ -296,6 +299,7 @@ export async function assignStudentsAction(
       validated.studentIds
     )
 
+    revalidateTag('mahad-stats')
     revalidatePath('/admin/mahad')
 
     return {
@@ -363,6 +367,7 @@ export async function transferStudentsAction(
       validated.studentIds
     )
 
+    revalidateTag('mahad-stats')
     revalidatePath('/admin/mahad')
 
     return {
@@ -436,6 +441,7 @@ export async function resolveDuplicatesAction(
 
     await resolveDuplicateStudents(keepId, deleteIds, mergeData)
 
+    revalidateTag('mahad-stats')
     revalidatePath('/admin/mahad')
 
     return {
@@ -491,6 +497,7 @@ export async function deleteStudentAction(id: string): Promise<ActionResult> {
 
     await prisma.programProfile.delete({ where: { id } })
 
+    revalidateTag('mahad-stats')
     revalidatePath('/admin/mahad')
 
     return {
@@ -539,6 +546,7 @@ export async function bulkDeleteStudentsAction(
       }
     }
 
+    revalidateTag('mahad-stats')
     revalidatePath('/admin/mahad')
 
     return {
@@ -700,6 +708,7 @@ export async function updateStudentAction(
       }
     })
 
+    revalidateTag('mahad-stats')
     revalidatePath('/admin/mahad')
 
     return {
@@ -965,6 +974,7 @@ export async function generatePaymentLinkWithDefaultsAction(
       return result
     }
 
+    revalidateTag('mahad-stats')
     revalidatePath('/admin/mahad')
 
     // Generate payment link (outside transaction since it's an external API call)

--- a/app/admin/mahad/payments/components/stats-cards.tsx
+++ b/app/admin/mahad/payments/components/stats-cards.tsx
@@ -1,3 +1,5 @@
+import { unstable_cache } from 'next/cache'
+
 import {
   Users,
   CreditCard,
@@ -10,10 +12,12 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { MAHAD_PROGRAM } from '@/lib/constants/mahad'
 import { prisma } from '@/lib/db'
 
-/**
- * Get payment stats from ProgramProfile/Enrollment model
- * TODO: Add revenue stats when StudentPayment migration is complete
- */
+const getCachedStats = unstable_cache(
+  async () => getStats(),
+  ['mahad-payment-stats'],
+  { revalidate: 60, tags: ['mahad-stats'] }
+)
+
 async function getStats() {
   // Count Mahad program profiles (excluding Test batch)
   const [
@@ -98,7 +102,7 @@ export async function StatsCards() {
     registeredStudents,
     totalRevenue,
     enrolledStudents,
-  } = await getStats()
+  } = await getCachedStats()
 
   const enrollmentRate =
     totalStudents > 0 ? (enrolledStudents / totalStudents) * 100 : 0

--- a/app/admin/people/lookup/actions.ts
+++ b/app/admin/people/lookup/actions.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { revalidatePath } from 'next/cache'
+import { revalidatePath, revalidateTag } from 'next/cache'
 
 import { Program } from '@prisma/client'
 import { z } from 'zod'
@@ -139,6 +139,7 @@ export async function deletePersonAction(
     revalidatePath('/admin/people')
     revalidatePath('/admin/teachers')
     revalidatePath('/admin/dugsi')
+    revalidateTag('mahad-stats')
     revalidatePath('/admin/mahad')
 
     return { success: true, data: undefined }

--- a/app/donations/page.tsx
+++ b/app/donations/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react'
 
+import { unstable_cache } from 'next/cache'
 import Image from 'next/image'
 
 import { fromZonedTime, toZonedTime } from 'date-fns-tz'
@@ -13,8 +14,6 @@ import { formatCurrency, formatDate } from '@/lib/utils/formatters'
 
 import { AnimatedStat } from './_components/animated-stat'
 import { PeriodFilter, type DonationPeriod } from './_components/period-filter'
-
-export const dynamic = 'force-dynamic'
 
 export const metadata: Metadata = {
   title: 'Donation Campaign | Irshad Center',
@@ -76,18 +75,10 @@ function isValidPeriod(value: string | undefined): value is DonationPeriod {
   )
 }
 
-interface PageProps {
-  searchParams: Promise<Record<string, string | string[] | undefined>>
-}
+const hiddenDonors = ['mustafamuse']
 
-export default async function DonationsPage({ searchParams }: PageProps) {
-  const params = await searchParams
-  const rawPeriod =
-    typeof params.period === 'string' ? params.period : undefined
-  const period: DonationPeriod = isValidPeriod(rawPeriod) ? rawPeriod : 'all'
+async function fetchDonationsData(period: DonationPeriod) {
   const dateRange = period === 'all' ? undefined : getDonationDateRange(period)
-
-  const hiddenDonors = ['mustafamuse']
 
   const activeStatuses: ('succeeded' | 'pending')[] = ['succeeded', 'pending']
 
@@ -129,8 +120,31 @@ export default async function DonationsPage({ searchParams }: PageProps) {
       )
   )
 
-  const donatorCount = donationCount
-  const totalAmountCents = amountStats._sum.amount ?? 0
+  return {
+    donations,
+    donatorCount: donationCount,
+    totalAmountCents: amountStats._sum.amount ?? 0,
+  }
+}
+
+const getCachedDonationsData = unstable_cache(
+  fetchDonationsData,
+  ['donations-page'],
+  { revalidate: 30, tags: ['donations'] }
+)
+
+interface PageProps {
+  searchParams: Promise<Record<string, string | string[] | undefined>>
+}
+
+export default async function DonationsPage({ searchParams }: PageProps) {
+  const params = await searchParams
+  const rawPeriod =
+    typeof params.period === 'string' ? params.period : undefined
+  const period: DonationPeriod = isValidPeriod(rawPeriod) ? rawPeriod : 'all'
+
+  const { donations, donatorCount, totalAmountCents } =
+    await getCachedDonationsData(period)
 
   return (
     <main className="min-h-screen bg-white">

--- a/app/mahad/register/_actions/__tests__/index.test.ts
+++ b/app/mahad/register/_actions/__tests__/index.test.ts
@@ -4,18 +4,21 @@ const {
   mockCreateMahadStudent,
   mockContactPointFindFirst,
   mockRevalidatePath,
+  mockRevalidateTag,
   mockLoggerInfo,
   mockLogError,
 } = vi.hoisted(() => ({
   mockCreateMahadStudent: vi.fn(),
   mockContactPointFindFirst: vi.fn(),
   mockRevalidatePath: vi.fn(),
+  mockRevalidateTag: vi.fn(),
   mockLoggerInfo: vi.fn(),
   mockLogError: vi.fn(),
 }))
 
 vi.mock('next/cache', () => ({
   revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+  revalidateTag: (...args: unknown[]) => mockRevalidateTag(...args),
 }))
 
 vi.mock('@/lib/db', () => ({

--- a/app/mahad/register/_actions/index.ts
+++ b/app/mahad/register/_actions/index.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { revalidatePath } from 'next/cache'
+import { revalidatePath, revalidateTag } from 'next/cache'
 
 import { Prisma } from '@prisma/client'
 
@@ -53,6 +53,7 @@ export async function registerStudent(
       paymentFrequency: data.paymentFrequency,
     })
 
+    revalidateTag('mahad-stats')
     revalidatePath('/admin/mahad')
 
     logger.info(

--- a/lib/services/webhooks/__tests__/donation-handler.test.ts
+++ b/lib/services/webhooks/__tests__/donation-handler.test.ts
@@ -61,6 +61,10 @@ vi.mock('@/lib/logger', () => ({
   logError: (...args: unknown[]) => mockLogError(...args),
 }))
 
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+}))
+
 vi.mock('@/lib/utils/type-guards', () => ({
   extractCustomerId: (customer: unknown) => {
     if (typeof customer === 'string') return customer

--- a/lib/services/webhooks/donation-handler.ts
+++ b/lib/services/webhooks/donation-handler.ts
@@ -3,6 +3,8 @@
 //   sub_setup_{subscriptionId}    -- placeholder created at recurring checkout, cleaned up on first invoice
 //   sub_cancelled_{subscriptionId} -- cancellation marker to exclude subscription from MRR
 
+import { revalidateTag } from 'next/cache'
+
 import { DonationStatus, Prisma } from '@prisma/client'
 import type Stripe from 'stripe'
 
@@ -94,6 +96,7 @@ export async function handleOneTimeDonation(
     },
   })
 
+  revalidateTag('donations')
   logger.info(
     { paymentIntentId, amount: session.amount_total },
     'One-time donation recorded'
@@ -188,6 +191,7 @@ export async function handleRecurringDonationCheckout(
     })
   })
 
+  revalidateTag('donations')
   logger.info(
     { subscriptionId, amount: session.amount_total },
     'Recurring donation checkout recorded'
@@ -220,6 +224,7 @@ export async function handleDonationPaymentIntentSucceeded(
     },
   })
 
+  revalidateTag('donations')
   logger.info(
     { paymentIntentId: paymentIntent.id },
     'Donation payment confirmed'
@@ -313,6 +318,7 @@ export async function handleDonationInvoicePaid(
       })
   }
 
+  revalidateTag('donations')
   logger.info(
     { invoiceId: invoice.id, subscriptionId, amount: invoice.amount_paid },
     'Recurring donation invoice paid'
@@ -389,6 +395,7 @@ export async function handleDonationSubscriptionDeleted(
     },
   })
 
+  revalidateTag('donations')
   logger.info(
     { subscriptionId: subscription.id, customerId },
     'Donation subscription cancelled'


### PR DESCRIPTION
## Summary

- **Cache orphaned subscriptions** with `unstable_cache` (5-min TTL, `link-subscriptions` tag) — most expensive query in the app (paginates through all Stripe subscriptions)
- **Fix double-fetch** on Link Subscriptions page — both `StatsCards` and `SubscriptionsListShell` were independently calling `getOrphanedSubscriptions()`. Now fetched once in a shared `LinkSubscriptionsContent` wrapper and passed as props
- **Cache Mahad payment stats** with `unstable_cache` (60s TTL, `mahad-stats` tag) — 5 parallel Prisma count/aggregate queries
- **Cache public donations page** with `unstable_cache` (30s TTL, `donations` tag) — removed `force-dynamic`, parameterized cache by period filter
- **Fix `revalidatePath` bug** in `updateFamilyShift` — removed invalid `'layout'` second argument
- **Tag-based invalidation** added to all relevant mutations and webhook handlers via `revalidateTag()`

## Cache invalidation map

| Cache tag | TTL | Invalidated by |
|---|---|---|
| `link-subscriptions` | 300s | `linkSubscriptionToStudent`, `ignoreSubscription`, `unignoreSubscription` |
| `mahad-stats` | 60s | All Mahad admin actions, registration, person deletion |
| `donations` | 30s | All donation webhook handlers (one-time, recurring, invoice, cancellation) |

## Test plan

- [x] TypeScript type-check passes (`tsc --noEmit`)
- [x] Production build passes (`next build`)
- [x] All affected test suites pass (updated mocks for `revalidateTag`)
- [ ] Verify Link Subscriptions page loads with single Stripe API call
- [ ] Verify Mahad stats refresh within 60s after student mutation
- [ ] Verify donations page reflects new donations within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)