### PR TITLE
security: expand env validation from 5 to 49 vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,8 +72,8 @@ WHATSAPP_WEBHOOK_VERIFY_TOKEN=           # Random string for webhook verificatio
 # ═══════════════════════════════════════════════════════════════
 # ADMIN AUTH
 # ═══════════════════════════════════════════════════════════════
-ADMIN_PIN=                        # Signs admin session tokens (min 6 chars)
-ADMIN_PASSWORD=                   # Admin login password (min 8 chars)
+ADMIN_PIN=                        # Signs admin session tokens (required)
+ADMIN_PASSWORD=                   # Admin login password (required)
 
 # ═══════════════════════════════════════════════════════════════
 # APP CONFIG

--- a/.env.example
+++ b/.env.example
@@ -67,6 +67,13 @@ WHATSAPP_PHONE_NUMBER_ID=                # From Meta Business Dashboard
 WHATSAPP_ACCESS_TOKEN=                   # System User token with whatsapp_business_messaging permission
 WHATSAPP_APP_SECRET=                     # App Secret for webhook signature verification
 WHATSAPP_WEBHOOK_VERIFY_TOKEN=           # Random string for webhook verification challenge
+# WHATSAPP_DEFAULT_LANGUAGE=en           # Template language code (default: en)
+
+# ═══════════════════════════════════════════════════════════════
+# ADMIN AUTH
+# ═══════════════════════════════════════════════════════════════
+ADMIN_PIN=                        # Signs admin session tokens (min 6 chars)
+ADMIN_PASSWORD=                   # Admin login password (min 8 chars)
 
 # ═══════════════════════════════════════════════════════════════
 # APP CONFIG
@@ -112,3 +119,9 @@ SENTRY_PROJECT=irshad-center
 # Required for next-axiom logging (https://axiom.co/docs/send-data/nextjs)
 NEXT_PUBLIC_AXIOM_DATASET=irshad-center
 NEXT_PUBLIC_AXIOM_TOKEN=xaat-xxx
+
+# ═══════════════════════════════════════════════════════════════
+# TEACHER CHECK-IN / GEOFENCE
+# ═══════════════════════════════════════════════════════════════
+IRSHAD_CENTER_LAT=               # Irshad Center latitude (required for teacher check-in)
+IRSHAD_CENTER_LNG=               # Irshad Center longitude (required for teacher check-in)

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Irshad Center Environment Variables
-# Copy this file to .env and fill in the values
+# Copy this file to .env.local and fill in the values
 
 # ═══════════════════════════════════════════════════════════════
 # DATABASE

--- a/.env.example
+++ b/.env.example
@@ -72,8 +72,8 @@ WHATSAPP_WEBHOOK_VERIFY_TOKEN=           # Random string for webhook verificatio
 # ═══════════════════════════════════════════════════════════════
 # ADMIN AUTH
 # ═══════════════════════════════════════════════════════════════
-ADMIN_PIN=                        # Signs admin session tokens (required)
-ADMIN_PASSWORD=                   # Admin login password (required)
+ADMIN_PIN=                        # Signs admin session tokens (required) — use: openssl rand -base64 32
+ADMIN_PASSWORD=                   # Admin login password (required) — use: openssl rand -base64 32
 
 # ═══════════════════════════════════════════════════════════════
 # APP CONFIG

--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,14 @@ ADMIN_PIN=                        # Signs admin session tokens (required) — us
 ADMIN_PASSWORD=                   # Admin login password (required) — use: openssl rand -base64 32
 
 # ═══════════════════════════════════════════════════════════════
+# EMAIL
+# ═══════════════════════════════════════════════════════════════
+RESEND_API_KEY=re_xxx             # Resend API key (required) — https://resend.com/api-keys
+ADMIN_EMAIL=admin@irshadcenter.com  # Recipient for admin notifications (required)
+# EMAIL_FROM=Irshad Center <noreply@irshadcenter.com>  # Sender name/address (default shown)
+# REPLY_TO_EMAIL=                # Optional reply-to address for outbound emails
+
+# ═══════════════════════════════════════════════════════════════
 # APP CONFIG
 # ═══════════════════════════════════════════════════════════════
 NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -3,6 +3,7 @@ import { type Instrumentation } from 'next'
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
+    await import('@/lib/env')
     await import('./sentry.server.config')
 
     if (process.env.NODE_ENV === 'production') {

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -9,14 +9,28 @@ export async function register() {
     // Run in dev too (not just production) so geofence misconfiguration surfaces
     // at startup rather than silently at first teacher check-in attempt.
     // Guarded by var presence so devs without teacher check-in vars don't crash.
+    // env.ts superRefine rejects partial sets, so by the time this runs they
+    // are either both valid or both absent.
     if (
       process.env.NODE_ENV !== 'test' &&
       (process.env.IRSHAD_CENTER_LAT || process.env.IRSHAD_CENTER_LNG)
     ) {
-      const { validateCenterLocationConfig } = await import(
-        '@/lib/constants/teacher-checkin'
-      )
-      validateCenterLocationConfig()
+      try {
+        const { validateCenterLocationConfig } = await import(
+          '@/lib/constants/teacher-checkin'
+        )
+        validateCenterLocationConfig()
+      } catch (err) {
+        Sentry.captureException(err, {
+          tags: { source: 'startup', check: 'geofence-config' },
+        })
+        console.error(
+          '[instrumentation] Geofence configuration is invalid. ' +
+            'Check IRSHAD_CENTER_LAT and IRSHAD_CENTER_LNG in your environment.',
+          err
+        )
+        throw err
+      }
     }
   }
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -6,7 +6,10 @@ export async function register() {
     await import('@/lib/env')
     await import('./sentry.server.config')
 
-    if (process.env.NODE_ENV !== 'test') {
+    if (
+      process.env.NODE_ENV !== 'test' &&
+      (process.env.IRSHAD_CENTER_LAT || process.env.IRSHAD_CENTER_LNG)
+    ) {
       const { validateCenterLocationConfig } = await import(
         '@/lib/constants/teacher-checkin'
       )

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -11,10 +11,7 @@ export async function register() {
     // Guarded by var presence so devs without teacher check-in vars don't crash.
     // lib/env (imported above) already enforces via superRefine that LAT and LNG
     // must both be set or both absent — this adds a semantic check (non-zero values).
-    if (
-      process.env.NODE_ENV !== 'test' &&
-      env.IRSHAD_CENTER_LAT !== undefined
-    ) {
+    if (env.NODE_ENV !== 'test' && env.IRSHAD_CENTER_LAT !== undefined) {
       try {
         const { validateCenterLocationConfig } = await import(
           '@/lib/constants/teacher-checkin'

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -3,8 +3,8 @@ import { type Instrumentation } from 'next'
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    const { env } = await import('@/lib/env')
     await import('./sentry.server.config')
+    const { env } = await import('@/lib/env')
 
     // Run in dev too (not just production) so geofence misconfiguration surfaces
     // at startup rather than silently at first teacher check-in attempt.

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -6,6 +6,9 @@ export async function register() {
     await import('@/lib/env')
     await import('./sentry.server.config')
 
+    // Run in dev too (not just production) so geofence misconfiguration surfaces
+    // at startup rather than silently at first teacher check-in attempt.
+    // Guarded by var presence so devs without teacher check-in vars don't crash.
     if (
       process.env.NODE_ENV !== 'test' &&
       (process.env.IRSHAD_CENTER_LAT || process.env.IRSHAD_CENTER_LNG)

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -6,7 +6,7 @@ export async function register() {
     await import('@/lib/env')
     await import('./sentry.server.config')
 
-    if (process.env.NODE_ENV === 'production') {
+    if (process.env.NODE_ENV !== 'test') {
       const { validateCenterLocationConfig } = await import(
         '@/lib/constants/teacher-checkin'
       )

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -9,8 +9,8 @@ export async function register() {
     // Run in dev too (not just production) so geofence misconfiguration surfaces
     // at startup rather than silently at first teacher check-in attempt.
     // Guarded by var presence so devs without teacher check-in vars don't crash.
-    // env.ts superRefine rejects partial sets, so by the time this runs they
-    // are either both valid or both absent.
+    // lib/env (imported above) already enforces via superRefine that LAT and LNG
+    // must both be set or both absent — this adds a semantic check (non-zero values).
     if (
       process.env.NODE_ENV !== 'test' &&
       (process.env.IRSHAD_CENTER_LAT || process.env.IRSHAD_CENTER_LNG)

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -3,7 +3,7 @@ import { type Instrumentation } from 'next'
 
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
-    await import('@/lib/env')
+    const { env } = await import('@/lib/env')
     await import('./sentry.server.config')
 
     // Run in dev too (not just production) so geofence misconfiguration surfaces
@@ -13,7 +13,7 @@ export async function register() {
     // must both be set or both absent — this adds a semantic check (non-zero values).
     if (
       process.env.NODE_ENV !== 'test' &&
-      (process.env.IRSHAD_CENTER_LAT || process.env.IRSHAD_CENTER_LNG)
+      env.IRSHAD_CENTER_LAT !== undefined
     ) {
       try {
         const { validateCenterLocationConfig } = await import(

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -13,10 +13,8 @@ const envSchema = z.object({
   DIRECT_URL: z.string().optional(),
 
   // ── Admin Auth ───────────────────────────────────────────────────────────────
-  ADMIN_PIN: z.string().min(6, 'ADMIN_PIN must be at least 6 characters'),
-  ADMIN_PASSWORD: z
-    .string()
-    .min(8, 'ADMIN_PASSWORD must be at least 8 characters'),
+  ADMIN_PIN: z.string().min(1, 'ADMIN_PIN is required'),
+  ADMIN_PASSWORD: z.string().min(1, 'ADMIN_PASSWORD is required'),
 
   // ── App Config ───────────────────────────────────────────────────────────────
   NEXT_PUBLIC_APP_URL: z

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -32,6 +32,8 @@ const envSchema = z
     // must read them via process.env directly — server-only prevents this module
     // from being imported in client components. The schema's role for these is
     // startup format-checking.
+    // Required in production — superRefine below rejects localhost values.
+    // Default is for local development only.
     NEXT_PUBLIC_APP_URL: z.preprocess(
       (v) => (v === '' ? undefined : v),
       z
@@ -204,6 +206,22 @@ const envSchema = z
         message: 'NEXT_PUBLIC_APP_URL must be set to a real URL in production',
         path: ['NEXT_PUBLIC_APP_URL'],
       })
+    }
+
+    if (data.NODE_ENV === 'production') {
+      const requiredInProduction = [
+        'STRIPE_MAHAD_SECRET_KEY_LIVE',
+        'STRIPE_DUGSI_SECRET_KEY_LIVE',
+      ] as const
+      for (const key of requiredInProduction) {
+        if (!data[key]) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `${key} is required in production`,
+            path: [key],
+          })
+        }
+      }
     }
 
     const hasLat = data.IRSHAD_CENTER_LAT !== undefined

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -39,11 +39,14 @@ const envSchema = z
 
     // ── Email ────────────────────────────────────────────────────────────────────
     RESEND_API_KEY: z.string().min(1, 'RESEND_API_KEY is required'),
-    EMAIL_FROM: z
-      .string()
-      .min(1)
-      .optional()
-      .default('Irshad Center <noreply@irshadcenter.com>'),
+    EMAIL_FROM: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z
+        .string()
+        .min(1)
+        .optional()
+        .default('Irshad Center <noreply@irshadcenter.com>')
+    ),
     ADMIN_EMAIL: z.string().email('ADMIN_EMAIL must be a valid email'),
     REPLY_TO_EMAIL: z.preprocess(
       (v) => (v === '' ? undefined : v),

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -211,7 +211,9 @@ const envSchema = z
     if (data.NODE_ENV === 'production') {
       const requiredInProduction = [
         'STRIPE_MAHAD_SECRET_KEY_LIVE',
+        'STRIPE_MAHAD_WEBHOOK_SECRET_LIVE',
         'STRIPE_DUGSI_SECRET_KEY_LIVE',
+        'STRIPE_DUGSI_WEBHOOK_SECRET_LIVE',
       ] as const
       for (const key of requiredInProduction) {
         if (!data[key]) {

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,37 +1,156 @@
 import { z } from 'zod'
 
-/**
- * Validates required environment variables at app startup
- */
 const envSchema = z.object({
-  // Resend Email Service
-  RESEND_API_KEY: z.string().min(1, 'RESEND_API_KEY is required'),
-  EMAIL_FROM: z
-    .string()
-    .min(1, 'EMAIL_FROM is required')
-    .optional()
-    .default('Irshad Center <noreply@irshadcenter.com>'),
-  ADMIN_EMAIL: z
-    .string()
-    .email('ADMIN_EMAIL must be a valid email')
-    .min(1, 'ADMIN_EMAIL is required'),
-  REPLY_TO_EMAIL: z.string().email().optional(),
-
-  // Node Environment
+  // ── Node / Vercel ────────────────────────────────────────────────────────────
   NODE_ENV: z
     .enum(['development', 'production', 'test'])
     .optional()
     .default('development'),
+  VERCEL_ENV: z.string().optional(),
+
+  // ── Database ─────────────────────────────────────────────────────────────────
+  DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
+  DIRECT_URL: z.string().optional(),
+
+  // ── Admin Auth ───────────────────────────────────────────────────────────────
+  ADMIN_PIN: z.string().min(1, 'ADMIN_PIN is required'),
+  ADMIN_PASSWORD: z.string().min(1, 'ADMIN_PASSWORD is required'),
+
+  // ── App Config ───────────────────────────────────────────────────────────────
+  NEXT_PUBLIC_APP_URL: z
+    .string()
+    .url('NEXT_PUBLIC_APP_URL must be a valid URL'),
+
+  // ── Email ────────────────────────────────────────────────────────────────────
+  RESEND_API_KEY: z.string().min(1, 'RESEND_API_KEY is required'),
+  EMAIL_FROM: z
+    .string()
+    .optional()
+    .default('Irshad Center <noreply@irshadcenter.com>'),
+  ADMIN_EMAIL: z.string().email('ADMIN_EMAIL must be a valid email'),
+  REPLY_TO_EMAIL: z.string().email().optional(),
+
+  // ── Stripe — Mahad ───────────────────────────────────────────────────────────
+  STRIPE_MAHAD_SECRET_KEY_TEST: z
+    .string()
+    .startsWith('sk_test_', 'Must start with sk_test_')
+    .optional(),
+  STRIPE_MAHAD_SECRET_KEY_LIVE: z
+    .string()
+    .startsWith('sk_live_', 'Must start with sk_live_')
+    .optional(),
+  STRIPE_MAHAD_WEBHOOK_SECRET_TEST: z
+    .string()
+    .startsWith('whsec_', 'Must start with whsec_')
+    .optional(),
+  STRIPE_MAHAD_WEBHOOK_SECRET_LIVE: z
+    .string()
+    .startsWith('whsec_', 'Must start with whsec_')
+    .optional(),
+  STRIPE_MAHAD_PRODUCT_ID: z
+    .string()
+    .startsWith('prod_', 'Must start with prod_')
+    .optional(),
+  NEXT_PUBLIC_STRIPE_MAHAD_PUBLISHABLE_KEY_TEST: z
+    .string()
+    .startsWith('pk_test_', 'Must start with pk_test_')
+    .optional(),
+  NEXT_PUBLIC_STRIPE_MAHAD_PUBLISHABLE_KEY_LIVE: z
+    .string()
+    .startsWith('pk_live_', 'Must start with pk_live_')
+    .optional(),
+  NEXT_PUBLIC_STRIPE_MAHAD_PRICING_TABLE_ID: z.string().optional(),
+
+  // ── Stripe — Dugsi ───────────────────────────────────────────────────────────
+  STRIPE_DUGSI_SECRET_KEY_TEST: z
+    .string()
+    .startsWith('sk_test_', 'Must start with sk_test_')
+    .optional(),
+  STRIPE_DUGSI_SECRET_KEY_LIVE: z
+    .string()
+    .startsWith('sk_live_', 'Must start with sk_live_')
+    .optional(),
+  STRIPE_DUGSI_WEBHOOK_SECRET_TEST: z
+    .string()
+    .startsWith('whsec_', 'Must start with whsec_')
+    .optional(),
+  STRIPE_DUGSI_WEBHOOK_SECRET_LIVE: z
+    .string()
+    .startsWith('whsec_', 'Must start with whsec_')
+    .optional(),
+  STRIPE_DUGSI_PRODUCT_ID: z
+    .string()
+    .startsWith('prod_', 'Must start with prod_')
+    .optional(),
+  NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_TEST: z
+    .string()
+    .startsWith('pk_test_', 'Must start with pk_test_')
+    .optional(),
+  NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_LIVE: z
+    .string()
+    .startsWith('pk_live_', 'Must start with pk_live_')
+    .optional(),
+  NEXT_PUBLIC_STRIPE_DUGSI_PAYMENT_LINK: z.string().url().optional(),
+
+  // ── Stripe — Zakat / Donation ────────────────────────────────────────────────
+  STRIPE_ZAKAT_FITR_PRODUCT_ID: z
+    .string()
+    .startsWith('prod_', 'Must start with prod_')
+    .optional(),
+  STRIPE_DONATION_SECRET_KEY_TEST: z
+    .string()
+    .startsWith('sk_test_', 'Must start with sk_test_')
+    .optional(),
+  STRIPE_DONATION_SECRET_KEY_LIVE: z
+    .string()
+    .startsWith('sk_live_', 'Must start with sk_live_')
+    .optional(),
+  STRIPE_DONATION_WEBHOOK_SECRET_TEST: z
+    .string()
+    .startsWith('whsec_', 'Must start with whsec_')
+    .optional(),
+  STRIPE_DONATION_WEBHOOK_SECRET_LIVE: z
+    .string()
+    .startsWith('whsec_', 'Must start with whsec_')
+    .optional(),
+
+  // ── WhatsApp ─────────────────────────────────────────────────────────────────
+  WHATSAPP_PHONE_NUMBER_ID: z.string().optional(),
+  WHATSAPP_ACCESS_TOKEN: z.string().optional(),
+  WHATSAPP_APP_SECRET: z.string().optional(),
+  WHATSAPP_WEBHOOK_VERIFY_TOKEN: z.string().optional(),
+  WHATSAPP_DEFAULT_LANGUAGE: z.string().optional().default('en'),
+
+  // ── Feature Flags ────────────────────────────────────────────────────────────
+  DUGSI_CARD_PAYMENTS_ENABLED: z.string().optional(),
+  MAHAD_CARD_PAYMENTS_ENABLED: z.string().optional(),
+  NEXT_PUBLIC_SHOW_GRADE_SCHOOL: z.string().optional(),
+
+  // ── Sentry ───────────────────────────────────────────────────────────────────
+  SENTRY_DSN: z.string().optional(),
+  NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
+  SENTRY_ORG: z.string().optional(),
+  SENTRY_PROJECT: z.string().optional(),
+  SENTRY_RELEASE: z.string().optional(),
+  SENTRY_DEBUG: z.string().optional(),
+  NEXT_PUBLIC_SENTRY_DEBUG: z.string().optional(),
+  NEXT_PUBLIC_SENTRY_RELEASE: z.string().optional(),
+
+  // ── Axiom ────────────────────────────────────────────────────────────────────
+  NEXT_PUBLIC_AXIOM_DATASET: z.string().optional(),
+  NEXT_PUBLIC_AXIOM_TOKEN: z.string().optional(),
+
+  // ── Logging ──────────────────────────────────────────────────────────────────
+  PINO_LOG_LEVEL: z
+    .enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
+    .optional(),
+
+  // ── Geofence ─────────────────────────────────────────────────────────────────
+  IRSHAD_CENTER_LAT: z.string().optional(),
+  IRSHAD_CENTER_LNG: z.string().optional(),
 })
 
-// Validate environment variables with helpful error messages
-const result = envSchema.safeParse({
-  RESEND_API_KEY: process.env.RESEND_API_KEY,
-  EMAIL_FROM: process.env.EMAIL_FROM,
-  ADMIN_EMAIL: process.env.ADMIN_EMAIL,
-  REPLY_TO_EMAIL: process.env.REPLY_TO_EMAIL,
-  NODE_ENV: process.env.NODE_ENV,
-})
+const result = envSchema.safeParse(process.env)
 
 if (!result.success) {
   console.error('❌ Environment validation failed:')
@@ -41,17 +160,6 @@ if (!result.success) {
   )
 }
 
-/**
- * Validated and type-safe environment variables
- * Safe to use throughout the application
- *
- * @example
- * import { env } from '@/lib/env'
- * const apiKey = env.RESEND_API_KEY // Type-safe!
- */
 export const env = result.data
 
-/**
- * Type for validated environment variables
- */
 export type Env = z.infer<typeof envSchema>

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -24,18 +24,8 @@ const envSchema = z
     DIRECT_URL: z.string().optional(),
 
     // ── Admin Auth ───────────────────────────────────────────────────────────────
-    ADMIN_PIN: z
-      .string()
-      .min(
-        16,
-        'ADMIN_PIN must be at least 16 characters (use: openssl rand -base64 32)'
-      ),
-    ADMIN_PASSWORD: z
-      .string()
-      .min(
-        16,
-        'ADMIN_PASSWORD must be at least 16 characters (use: openssl rand -base64 32)'
-      ),
+    ADMIN_PIN: z.string().min(1, 'ADMIN_PIN is required'),
+    ADMIN_PASSWORD: z.string().min(1, 'ADMIN_PASSWORD is required'),
 
     // ── App Config ───────────────────────────────────────────────────────────────
     // NEXT_PUBLIC_* vars are inlined by Next.js at build time. Client-side code

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -24,8 +24,18 @@ const envSchema = z
     DIRECT_URL: z.string().optional(),
 
     // ── Admin Auth ───────────────────────────────────────────────────────────────
-    ADMIN_PIN: z.string().min(1, 'ADMIN_PIN is required'),
-    ADMIN_PASSWORD: z.string().min(1, 'ADMIN_PASSWORD is required'),
+    ADMIN_PIN: z
+      .string()
+      .min(
+        16,
+        'ADMIN_PIN must be at least 16 characters (use: openssl rand -base64 32)'
+      ),
+    ADMIN_PASSWORD: z
+      .string()
+      .min(
+        16,
+        'ADMIN_PASSWORD must be at least 16 characters (use: openssl rand -base64 32)'
+      ),
 
     // ── App Config ───────────────────────────────────────────────────────────────
     // NEXT_PUBLIC_* vars are inlined by Next.js at build time. Client-side code
@@ -86,7 +96,14 @@ const envSchema = z
     NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_LIVE: stripeField('pk_live_'),
     NEXT_PUBLIC_STRIPE_DUGSI_PAYMENT_LINK: z.preprocess(
       (v) => (v === '' ? undefined : v),
-      z.string().url().optional()
+      z
+        .string()
+        .url()
+        .startsWith(
+          'https://',
+          'NEXT_PUBLIC_STRIPE_DUGSI_PAYMENT_LINK must use HTTPS'
+        )
+        .optional()
     ),
 
     // ── Stripe — Zakat / Donation ────────────────────────────────────────────────
@@ -220,8 +237,10 @@ const envSchema = z
       const requiredInProduction = [
         'STRIPE_MAHAD_SECRET_KEY_LIVE',
         'STRIPE_MAHAD_WEBHOOK_SECRET_LIVE',
+        'NEXT_PUBLIC_STRIPE_MAHAD_PUBLISHABLE_KEY_LIVE',
         'STRIPE_DUGSI_SECRET_KEY_LIVE',
         'STRIPE_DUGSI_WEBHOOK_SECRET_LIVE',
+        'NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_LIVE',
       ] as const
       for (const key of requiredInProduction) {
         if (!data[key]) {

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -150,8 +150,14 @@ const envSchema = z
     SENTRY_ORG: z.string().optional(),
     SENTRY_PROJECT: z.string().optional(),
     SENTRY_RELEASE: z.string().optional(),
-    SENTRY_DEBUG: z.string().optional(),
-    NEXT_PUBLIC_SENTRY_DEBUG: z.string().optional(),
+    SENTRY_DEBUG: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.enum(['true', 'false']).optional()
+    ),
+    NEXT_PUBLIC_SENTRY_DEBUG: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.enum(['true', 'false']).optional()
+    ),
     NEXT_PUBLIC_SENTRY_RELEASE: z.string().optional(),
 
     // ── Axiom ────────────────────────────────────────────────────────────────────
@@ -196,6 +202,7 @@ const envSchema = z
 
     if (
       data.NODE_ENV === 'production' &&
+      data.VERCEL_ENV !== 'preview' &&
       data.NEXT_PUBLIC_APP_URL != null &&
       /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/.test(
         data.NEXT_PUBLIC_APP_URL
@@ -208,7 +215,8 @@ const envSchema = z
       })
     }
 
-    if (data.NODE_ENV === 'production') {
+    // Donation keys are intentionally excluded — the feature is opt-in and absent keys disable it gracefully.
+    if (data.NODE_ENV === 'production' && data.VERCEL_ENV !== 'preview') {
       const requiredInProduction = [
         'STRIPE_MAHAD_SECRET_KEY_LIVE',
         'STRIPE_MAHAD_WEBHOOK_SECRET_LIVE',

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -13,8 +13,10 @@ const envSchema = z.object({
   DIRECT_URL: z.string().optional(),
 
   // ── Admin Auth ───────────────────────────────────────────────────────────────
-  ADMIN_PIN: z.string().min(1, 'ADMIN_PIN is required'),
-  ADMIN_PASSWORD: z.string().min(1, 'ADMIN_PASSWORD is required'),
+  ADMIN_PIN: z.string().min(6, 'ADMIN_PIN must be at least 6 characters'),
+  ADMIN_PASSWORD: z
+    .string()
+    .min(8, 'ADMIN_PASSWORD must be at least 8 characters'),
 
   // ── App Config ───────────────────────────────────────────────────────────────
   NEXT_PUBLIC_APP_URL: z
@@ -25,6 +27,7 @@ const envSchema = z.object({
   RESEND_API_KEY: z.string().min(1, 'RESEND_API_KEY is required'),
   EMAIL_FROM: z
     .string()
+    .min(1)
     .optional()
     .default('Irshad Center <noreply@irshadcenter.com>'),
   ADMIN_EMAIL: z.string().email('ADMIN_EMAIL must be a valid email'),
@@ -48,6 +51,14 @@ const envSchema = z.object({
     .startsWith('whsec_', 'Must start with whsec_')
     .optional(),
   STRIPE_MAHAD_PRODUCT_ID: z
+    .string()
+    .startsWith('prod_', 'Must start with prod_')
+    .optional(),
+  STRIPE_MAHAD_PRODUCT_ID_TEST: z
+    .string()
+    .startsWith('prod_', 'Must start with prod_')
+    .optional(),
+  STRIPE_MAHAD_PRODUCT_ID_LIVE: z
     .string()
     .startsWith('prod_', 'Must start with prod_')
     .optional(),
@@ -113,10 +124,16 @@ const envSchema = z.object({
     .string()
     .startsWith('whsec_', 'Must start with whsec_')
     .optional(),
+  STRIPE_DONATION_PRODUCT_ID: z
+    .string()
+    .startsWith('prod_', 'Must start with prod_')
+    .optional(),
 
   // ── WhatsApp ─────────────────────────────────────────────────────────────────
   WHATSAPP_PHONE_NUMBER_ID: z.string().optional(),
   WHATSAPP_ACCESS_TOKEN: z.string().optional(),
+  // Required for webhook signature verification (project rule #11).
+  // If WHATSAPP_PHONE_NUMBER_ID is set, this must also be set.
   WHATSAPP_APP_SECRET: z.string().optional(),
   WHATSAPP_WEBHOOK_VERIFY_TOKEN: z.string().optional(),
   WHATSAPP_DEFAULT_LANGUAGE: z.string().optional().default('en'),
@@ -146,8 +163,8 @@ const envSchema = z.object({
     .optional(),
 
   // ── Geofence ─────────────────────────────────────────────────────────────────
-  IRSHAD_CENTER_LAT: z.string().optional(),
-  IRSHAD_CENTER_LNG: z.string().optional(),
+  IRSHAD_CENTER_LAT: z.coerce.number().min(-90).max(90).optional(),
+  IRSHAD_CENTER_LNG: z.coerce.number().min(-180).max(180).optional(),
 })
 
 const result = envSchema.safeParse(process.env)

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -2,6 +2,14 @@ import 'server-only'
 
 import { z } from 'zod'
 
+// Coerces blank env var values ("") to undefined so optional() works correctly.
+// Node.js loads blank lines from .env files as "" not undefined.
+const stripeField = (prefix: string) =>
+  z.preprocess(
+    (v) => (v === '' ? undefined : v),
+    z.string().startsWith(prefix, `Must start with ${prefix}`).optional()
+  )
+
 const envSchema = z
   .object({
     // ── Node / Vercel ────────────────────────────────────────────────────────────
@@ -20,9 +28,13 @@ const envSchema = z
     ADMIN_PASSWORD: z.string().min(1, 'ADMIN_PASSWORD is required'),
 
     // ── App Config ───────────────────────────────────────────────────────────────
+    // NEXT_PUBLIC_* vars are inlined by Next.js and must still be read via
+    // process.env in server actions/services — server-only prevents importing
+    // this module there. The schema's role for these is startup format-checking.
     NEXT_PUBLIC_APP_URL: z
       .string()
-      .url('NEXT_PUBLIC_APP_URL must be a valid URL'),
+      .url('NEXT_PUBLIC_APP_URL must be a valid URL')
+      .default('http://localhost:3000'),
 
     // ── Email ────────────────────────────────────────────────────────────────────
     RESEND_API_KEY: z.string().min(1, 'RESEND_API_KEY is required'),
@@ -35,106 +47,42 @@ const envSchema = z
     REPLY_TO_EMAIL: z.string().email().optional(),
 
     // ── Stripe — Mahad ───────────────────────────────────────────────────────────
-    STRIPE_MAHAD_SECRET_KEY_TEST: z
-      .string()
-      .startsWith('sk_test_', 'Must start with sk_test_')
-      .optional(),
-    STRIPE_MAHAD_SECRET_KEY_LIVE: z
-      .string()
-      .startsWith('sk_live_', 'Must start with sk_live_')
-      .optional(),
-    STRIPE_MAHAD_WEBHOOK_SECRET_TEST: z
-      .string()
-      .startsWith('whsec_', 'Must start with whsec_')
-      .optional(),
-    STRIPE_MAHAD_WEBHOOK_SECRET_LIVE: z
-      .string()
-      .startsWith('whsec_', 'Must start with whsec_')
-      .optional(),
-    STRIPE_MAHAD_PRODUCT_ID: z
-      .string()
-      .startsWith('prod_', 'Must start with prod_')
-      .optional(),
-    STRIPE_MAHAD_PRODUCT_ID_TEST: z
-      .string()
-      .startsWith('prod_', 'Must start with prod_')
-      .optional(),
-    STRIPE_MAHAD_PRODUCT_ID_LIVE: z
-      .string()
-      .startsWith('prod_', 'Must start with prod_')
-      .optional(),
-    NEXT_PUBLIC_STRIPE_MAHAD_PUBLISHABLE_KEY_TEST: z
-      .string()
-      .startsWith('pk_test_', 'Must start with pk_test_')
-      .optional(),
-    NEXT_PUBLIC_STRIPE_MAHAD_PUBLISHABLE_KEY_LIVE: z
-      .string()
-      .startsWith('pk_live_', 'Must start with pk_live_')
-      .optional(),
+    STRIPE_MAHAD_SECRET_KEY_TEST: stripeField('sk_test_'),
+    STRIPE_MAHAD_SECRET_KEY_LIVE: stripeField('sk_live_'),
+    STRIPE_MAHAD_WEBHOOK_SECRET_TEST: stripeField('whsec_'),
+    STRIPE_MAHAD_WEBHOOK_SECRET_LIVE: stripeField('whsec_'),
+    // Product ID resolution (lib/keys/stripe.ts): production → LIVE || generic,
+    // development → TEST || generic
+    STRIPE_MAHAD_PRODUCT_ID: stripeField('prod_'),
+    STRIPE_MAHAD_PRODUCT_ID_TEST: stripeField('prod_'),
+    STRIPE_MAHAD_PRODUCT_ID_LIVE: stripeField('prod_'),
+    NEXT_PUBLIC_STRIPE_MAHAD_PUBLISHABLE_KEY_TEST: stripeField('pk_test_'),
+    NEXT_PUBLIC_STRIPE_MAHAD_PUBLISHABLE_KEY_LIVE: stripeField('pk_live_'),
     NEXT_PUBLIC_STRIPE_MAHAD_PRICING_TABLE_ID: z.string().optional(),
 
     // ── Stripe — Dugsi ───────────────────────────────────────────────────────────
-    STRIPE_DUGSI_SECRET_KEY_TEST: z
-      .string()
-      .startsWith('sk_test_', 'Must start with sk_test_')
-      .optional(),
-    STRIPE_DUGSI_SECRET_KEY_LIVE: z
-      .string()
-      .startsWith('sk_live_', 'Must start with sk_live_')
-      .optional(),
-    STRIPE_DUGSI_WEBHOOK_SECRET_TEST: z
-      .string()
-      .startsWith('whsec_', 'Must start with whsec_')
-      .optional(),
-    STRIPE_DUGSI_WEBHOOK_SECRET_LIVE: z
-      .string()
-      .startsWith('whsec_', 'Must start with whsec_')
-      .optional(),
-    STRIPE_DUGSI_PRODUCT_ID: z
-      .string()
-      .startsWith('prod_', 'Must start with prod_')
-      .optional(),
-    NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_TEST: z
-      .string()
-      .startsWith('pk_test_', 'Must start with pk_test_')
-      .optional(),
-    NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_LIVE: z
-      .string()
-      .startsWith('pk_live_', 'Must start with pk_live_')
-      .optional(),
+    STRIPE_DUGSI_SECRET_KEY_TEST: stripeField('sk_test_'),
+    STRIPE_DUGSI_SECRET_KEY_LIVE: stripeField('sk_live_'),
+    STRIPE_DUGSI_WEBHOOK_SECRET_TEST: stripeField('whsec_'),
+    STRIPE_DUGSI_WEBHOOK_SECRET_LIVE: stripeField('whsec_'),
+    STRIPE_DUGSI_PRODUCT_ID: stripeField('prod_'),
+    NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_TEST: stripeField('pk_test_'),
+    NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_LIVE: stripeField('pk_live_'),
     NEXT_PUBLIC_STRIPE_DUGSI_PAYMENT_LINK: z.string().url().optional(),
 
     // ── Stripe — Zakat / Donation ────────────────────────────────────────────────
-    STRIPE_ZAKAT_FITR_PRODUCT_ID: z
-      .string()
-      .startsWith('prod_', 'Must start with prod_')
-      .optional(),
-    STRIPE_DONATION_SECRET_KEY_TEST: z
-      .string()
-      .startsWith('sk_test_', 'Must start with sk_test_')
-      .optional(),
-    STRIPE_DONATION_SECRET_KEY_LIVE: z
-      .string()
-      .startsWith('sk_live_', 'Must start with sk_live_')
-      .optional(),
-    STRIPE_DONATION_WEBHOOK_SECRET_TEST: z
-      .string()
-      .startsWith('whsec_', 'Must start with whsec_')
-      .optional(),
-    STRIPE_DONATION_WEBHOOK_SECRET_LIVE: z
-      .string()
-      .startsWith('whsec_', 'Must start with whsec_')
-      .optional(),
-    STRIPE_DONATION_PRODUCT_ID: z
-      .string()
-      .startsWith('prod_', 'Must start with prod_')
-      .optional(),
+    STRIPE_ZAKAT_FITR_PRODUCT_ID: stripeField('prod_'),
+    STRIPE_DONATION_SECRET_KEY_TEST: stripeField('sk_test_'),
+    STRIPE_DONATION_SECRET_KEY_LIVE: stripeField('sk_live_'),
+    STRIPE_DONATION_WEBHOOK_SECRET_TEST: stripeField('whsec_'),
+    STRIPE_DONATION_WEBHOOK_SECRET_LIVE: stripeField('whsec_'),
+    STRIPE_DONATION_PRODUCT_ID: stripeField('prod_'),
 
     // ── WhatsApp ─────────────────────────────────────────────────────────────────
+    // All four vars below are required together when WHATSAPP_PHONE_NUMBER_ID is
+    // set — enforced via superRefine below (project rule #11).
     WHATSAPP_PHONE_NUMBER_ID: z.string().optional(),
     WHATSAPP_ACCESS_TOKEN: z.string().optional(),
-    // Required for webhook signature verification (project rule #11).
-    // If WHATSAPP_PHONE_NUMBER_ID is set, this must also be set.
     WHATSAPP_APP_SECRET: z.string().optional(),
     WHATSAPP_WEBHOOK_VERIFY_TOKEN: z.string().optional(),
     WHATSAPP_DEFAULT_LANGUAGE: z.string().optional().default('en'),
@@ -156,6 +104,8 @@ const envSchema = z
 
     // ── Axiom ────────────────────────────────────────────────────────────────────
     NEXT_PUBLIC_AXIOM_DATASET: z.string().optional(),
+    // NEXT_PUBLIC_AXIOM_TOKEN is a write-only credential scoped to this dataset.
+    // Intentionally public — required by next-axiom for client-side log forwarding.
     NEXT_PUBLIC_AXIOM_TOKEN: z.string().optional(),
 
     // ── Logging ──────────────────────────────────────────────────────────────────
@@ -168,13 +118,21 @@ const envSchema = z
     IRSHAD_CENTER_LNG: z.coerce.number().min(-180).max(180).optional(),
   })
   .superRefine((data, ctx) => {
-    if (data.WHATSAPP_PHONE_NUMBER_ID && !data.WHATSAPP_APP_SECRET) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message:
-          'WHATSAPP_APP_SECRET is required when WHATSAPP_PHONE_NUMBER_ID is set (project rule #11: webhook signatures must be verified)',
-        path: ['WHATSAPP_APP_SECRET'],
-      })
+    if (data.WHATSAPP_PHONE_NUMBER_ID) {
+      const required = [
+        'WHATSAPP_ACCESS_TOKEN',
+        'WHATSAPP_APP_SECRET',
+        'WHATSAPP_WEBHOOK_VERIFY_TOKEN',
+      ] as const
+      for (const key of required) {
+        if (!data[key]) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `${key} is required when WHATSAPP_PHONE_NUMBER_ID is set`,
+            path: [key],
+          })
+        }
+      }
     }
   })
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,169 +1,182 @@
+import 'server-only'
+
 import { z } from 'zod'
 
-const envSchema = z.object({
-  // ── Node / Vercel ────────────────────────────────────────────────────────────
-  NODE_ENV: z
-    .enum(['development', 'production', 'test'])
-    .optional()
-    .default('development'),
-  VERCEL_ENV: z.string().optional(),
+const envSchema = z
+  .object({
+    // ── Node / Vercel ────────────────────────────────────────────────────────────
+    NODE_ENV: z
+      .enum(['development', 'production', 'test'])
+      .optional()
+      .default('development'),
+    VERCEL_ENV: z.string().optional(),
 
-  // ── Database ─────────────────────────────────────────────────────────────────
-  DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
-  DIRECT_URL: z.string().optional(),
+    // ── Database ─────────────────────────────────────────────────────────────────
+    DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
+    DIRECT_URL: z.string().optional(),
 
-  // ── Admin Auth ───────────────────────────────────────────────────────────────
-  ADMIN_PIN: z.string().min(1, 'ADMIN_PIN is required'),
-  ADMIN_PASSWORD: z.string().min(1, 'ADMIN_PASSWORD is required'),
+    // ── Admin Auth ───────────────────────────────────────────────────────────────
+    ADMIN_PIN: z.string().min(1, 'ADMIN_PIN is required'),
+    ADMIN_PASSWORD: z.string().min(1, 'ADMIN_PASSWORD is required'),
 
-  // ── App Config ───────────────────────────────────────────────────────────────
-  NEXT_PUBLIC_APP_URL: z
-    .string()
-    .url('NEXT_PUBLIC_APP_URL must be a valid URL'),
+    // ── App Config ───────────────────────────────────────────────────────────────
+    NEXT_PUBLIC_APP_URL: z
+      .string()
+      .url('NEXT_PUBLIC_APP_URL must be a valid URL'),
 
-  // ── Email ────────────────────────────────────────────────────────────────────
-  RESEND_API_KEY: z.string().min(1, 'RESEND_API_KEY is required'),
-  EMAIL_FROM: z
-    .string()
-    .min(1)
-    .optional()
-    .default('Irshad Center <noreply@irshadcenter.com>'),
-  ADMIN_EMAIL: z.string().email('ADMIN_EMAIL must be a valid email'),
-  REPLY_TO_EMAIL: z.string().email().optional(),
+    // ── Email ────────────────────────────────────────────────────────────────────
+    RESEND_API_KEY: z.string().min(1, 'RESEND_API_KEY is required'),
+    EMAIL_FROM: z
+      .string()
+      .min(1)
+      .optional()
+      .default('Irshad Center <noreply@irshadcenter.com>'),
+    ADMIN_EMAIL: z.string().email('ADMIN_EMAIL must be a valid email'),
+    REPLY_TO_EMAIL: z.string().email().optional(),
 
-  // ── Stripe — Mahad ───────────────────────────────────────────────────────────
-  STRIPE_MAHAD_SECRET_KEY_TEST: z
-    .string()
-    .startsWith('sk_test_', 'Must start with sk_test_')
-    .optional(),
-  STRIPE_MAHAD_SECRET_KEY_LIVE: z
-    .string()
-    .startsWith('sk_live_', 'Must start with sk_live_')
-    .optional(),
-  STRIPE_MAHAD_WEBHOOK_SECRET_TEST: z
-    .string()
-    .startsWith('whsec_', 'Must start with whsec_')
-    .optional(),
-  STRIPE_MAHAD_WEBHOOK_SECRET_LIVE: z
-    .string()
-    .startsWith('whsec_', 'Must start with whsec_')
-    .optional(),
-  STRIPE_MAHAD_PRODUCT_ID: z
-    .string()
-    .startsWith('prod_', 'Must start with prod_')
-    .optional(),
-  STRIPE_MAHAD_PRODUCT_ID_TEST: z
-    .string()
-    .startsWith('prod_', 'Must start with prod_')
-    .optional(),
-  STRIPE_MAHAD_PRODUCT_ID_LIVE: z
-    .string()
-    .startsWith('prod_', 'Must start with prod_')
-    .optional(),
-  NEXT_PUBLIC_STRIPE_MAHAD_PUBLISHABLE_KEY_TEST: z
-    .string()
-    .startsWith('pk_test_', 'Must start with pk_test_')
-    .optional(),
-  NEXT_PUBLIC_STRIPE_MAHAD_PUBLISHABLE_KEY_LIVE: z
-    .string()
-    .startsWith('pk_live_', 'Must start with pk_live_')
-    .optional(),
-  NEXT_PUBLIC_STRIPE_MAHAD_PRICING_TABLE_ID: z.string().optional(),
+    // ── Stripe — Mahad ───────────────────────────────────────────────────────────
+    STRIPE_MAHAD_SECRET_KEY_TEST: z
+      .string()
+      .startsWith('sk_test_', 'Must start with sk_test_')
+      .optional(),
+    STRIPE_MAHAD_SECRET_KEY_LIVE: z
+      .string()
+      .startsWith('sk_live_', 'Must start with sk_live_')
+      .optional(),
+    STRIPE_MAHAD_WEBHOOK_SECRET_TEST: z
+      .string()
+      .startsWith('whsec_', 'Must start with whsec_')
+      .optional(),
+    STRIPE_MAHAD_WEBHOOK_SECRET_LIVE: z
+      .string()
+      .startsWith('whsec_', 'Must start with whsec_')
+      .optional(),
+    STRIPE_MAHAD_PRODUCT_ID: z
+      .string()
+      .startsWith('prod_', 'Must start with prod_')
+      .optional(),
+    STRIPE_MAHAD_PRODUCT_ID_TEST: z
+      .string()
+      .startsWith('prod_', 'Must start with prod_')
+      .optional(),
+    STRIPE_MAHAD_PRODUCT_ID_LIVE: z
+      .string()
+      .startsWith('prod_', 'Must start with prod_')
+      .optional(),
+    NEXT_PUBLIC_STRIPE_MAHAD_PUBLISHABLE_KEY_TEST: z
+      .string()
+      .startsWith('pk_test_', 'Must start with pk_test_')
+      .optional(),
+    NEXT_PUBLIC_STRIPE_MAHAD_PUBLISHABLE_KEY_LIVE: z
+      .string()
+      .startsWith('pk_live_', 'Must start with pk_live_')
+      .optional(),
+    NEXT_PUBLIC_STRIPE_MAHAD_PRICING_TABLE_ID: z.string().optional(),
 
-  // ── Stripe — Dugsi ───────────────────────────────────────────────────────────
-  STRIPE_DUGSI_SECRET_KEY_TEST: z
-    .string()
-    .startsWith('sk_test_', 'Must start with sk_test_')
-    .optional(),
-  STRIPE_DUGSI_SECRET_KEY_LIVE: z
-    .string()
-    .startsWith('sk_live_', 'Must start with sk_live_')
-    .optional(),
-  STRIPE_DUGSI_WEBHOOK_SECRET_TEST: z
-    .string()
-    .startsWith('whsec_', 'Must start with whsec_')
-    .optional(),
-  STRIPE_DUGSI_WEBHOOK_SECRET_LIVE: z
-    .string()
-    .startsWith('whsec_', 'Must start with whsec_')
-    .optional(),
-  STRIPE_DUGSI_PRODUCT_ID: z
-    .string()
-    .startsWith('prod_', 'Must start with prod_')
-    .optional(),
-  NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_TEST: z
-    .string()
-    .startsWith('pk_test_', 'Must start with pk_test_')
-    .optional(),
-  NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_LIVE: z
-    .string()
-    .startsWith('pk_live_', 'Must start with pk_live_')
-    .optional(),
-  NEXT_PUBLIC_STRIPE_DUGSI_PAYMENT_LINK: z.string().url().optional(),
+    // ── Stripe — Dugsi ───────────────────────────────────────────────────────────
+    STRIPE_DUGSI_SECRET_KEY_TEST: z
+      .string()
+      .startsWith('sk_test_', 'Must start with sk_test_')
+      .optional(),
+    STRIPE_DUGSI_SECRET_KEY_LIVE: z
+      .string()
+      .startsWith('sk_live_', 'Must start with sk_live_')
+      .optional(),
+    STRIPE_DUGSI_WEBHOOK_SECRET_TEST: z
+      .string()
+      .startsWith('whsec_', 'Must start with whsec_')
+      .optional(),
+    STRIPE_DUGSI_WEBHOOK_SECRET_LIVE: z
+      .string()
+      .startsWith('whsec_', 'Must start with whsec_')
+      .optional(),
+    STRIPE_DUGSI_PRODUCT_ID: z
+      .string()
+      .startsWith('prod_', 'Must start with prod_')
+      .optional(),
+    NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_TEST: z
+      .string()
+      .startsWith('pk_test_', 'Must start with pk_test_')
+      .optional(),
+    NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_LIVE: z
+      .string()
+      .startsWith('pk_live_', 'Must start with pk_live_')
+      .optional(),
+    NEXT_PUBLIC_STRIPE_DUGSI_PAYMENT_LINK: z.string().url().optional(),
 
-  // ── Stripe — Zakat / Donation ────────────────────────────────────────────────
-  STRIPE_ZAKAT_FITR_PRODUCT_ID: z
-    .string()
-    .startsWith('prod_', 'Must start with prod_')
-    .optional(),
-  STRIPE_DONATION_SECRET_KEY_TEST: z
-    .string()
-    .startsWith('sk_test_', 'Must start with sk_test_')
-    .optional(),
-  STRIPE_DONATION_SECRET_KEY_LIVE: z
-    .string()
-    .startsWith('sk_live_', 'Must start with sk_live_')
-    .optional(),
-  STRIPE_DONATION_WEBHOOK_SECRET_TEST: z
-    .string()
-    .startsWith('whsec_', 'Must start with whsec_')
-    .optional(),
-  STRIPE_DONATION_WEBHOOK_SECRET_LIVE: z
-    .string()
-    .startsWith('whsec_', 'Must start with whsec_')
-    .optional(),
-  STRIPE_DONATION_PRODUCT_ID: z
-    .string()
-    .startsWith('prod_', 'Must start with prod_')
-    .optional(),
+    // ── Stripe — Zakat / Donation ────────────────────────────────────────────────
+    STRIPE_ZAKAT_FITR_PRODUCT_ID: z
+      .string()
+      .startsWith('prod_', 'Must start with prod_')
+      .optional(),
+    STRIPE_DONATION_SECRET_KEY_TEST: z
+      .string()
+      .startsWith('sk_test_', 'Must start with sk_test_')
+      .optional(),
+    STRIPE_DONATION_SECRET_KEY_LIVE: z
+      .string()
+      .startsWith('sk_live_', 'Must start with sk_live_')
+      .optional(),
+    STRIPE_DONATION_WEBHOOK_SECRET_TEST: z
+      .string()
+      .startsWith('whsec_', 'Must start with whsec_')
+      .optional(),
+    STRIPE_DONATION_WEBHOOK_SECRET_LIVE: z
+      .string()
+      .startsWith('whsec_', 'Must start with whsec_')
+      .optional(),
+    STRIPE_DONATION_PRODUCT_ID: z
+      .string()
+      .startsWith('prod_', 'Must start with prod_')
+      .optional(),
 
-  // ── WhatsApp ─────────────────────────────────────────────────────────────────
-  WHATSAPP_PHONE_NUMBER_ID: z.string().optional(),
-  WHATSAPP_ACCESS_TOKEN: z.string().optional(),
-  // Required for webhook signature verification (project rule #11).
-  // If WHATSAPP_PHONE_NUMBER_ID is set, this must also be set.
-  WHATSAPP_APP_SECRET: z.string().optional(),
-  WHATSAPP_WEBHOOK_VERIFY_TOKEN: z.string().optional(),
-  WHATSAPP_DEFAULT_LANGUAGE: z.string().optional().default('en'),
+    // ── WhatsApp ─────────────────────────────────────────────────────────────────
+    WHATSAPP_PHONE_NUMBER_ID: z.string().optional(),
+    WHATSAPP_ACCESS_TOKEN: z.string().optional(),
+    // Required for webhook signature verification (project rule #11).
+    // If WHATSAPP_PHONE_NUMBER_ID is set, this must also be set.
+    WHATSAPP_APP_SECRET: z.string().optional(),
+    WHATSAPP_WEBHOOK_VERIFY_TOKEN: z.string().optional(),
+    WHATSAPP_DEFAULT_LANGUAGE: z.string().optional().default('en'),
 
-  // ── Feature Flags ────────────────────────────────────────────────────────────
-  DUGSI_CARD_PAYMENTS_ENABLED: z.string().optional(),
-  MAHAD_CARD_PAYMENTS_ENABLED: z.string().optional(),
-  NEXT_PUBLIC_SHOW_GRADE_SCHOOL: z.string().optional(),
+    // ── Feature Flags ────────────────────────────────────────────────────────────
+    DUGSI_CARD_PAYMENTS_ENABLED: z.string().optional(),
+    MAHAD_CARD_PAYMENTS_ENABLED: z.string().optional(),
+    NEXT_PUBLIC_SHOW_GRADE_SCHOOL: z.string().optional(),
 
-  // ── Sentry ───────────────────────────────────────────────────────────────────
-  SENTRY_DSN: z.string().optional(),
-  NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
-  SENTRY_ORG: z.string().optional(),
-  SENTRY_PROJECT: z.string().optional(),
-  SENTRY_RELEASE: z.string().optional(),
-  SENTRY_DEBUG: z.string().optional(),
-  NEXT_PUBLIC_SENTRY_DEBUG: z.string().optional(),
-  NEXT_PUBLIC_SENTRY_RELEASE: z.string().optional(),
+    // ── Sentry ───────────────────────────────────────────────────────────────────
+    SENTRY_DSN: z.string().optional(),
+    NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
+    SENTRY_ORG: z.string().optional(),
+    SENTRY_PROJECT: z.string().optional(),
+    SENTRY_RELEASE: z.string().optional(),
+    SENTRY_DEBUG: z.string().optional(),
+    NEXT_PUBLIC_SENTRY_DEBUG: z.string().optional(),
+    NEXT_PUBLIC_SENTRY_RELEASE: z.string().optional(),
 
-  // ── Axiom ────────────────────────────────────────────────────────────────────
-  NEXT_PUBLIC_AXIOM_DATASET: z.string().optional(),
-  NEXT_PUBLIC_AXIOM_TOKEN: z.string().optional(),
+    // ── Axiom ────────────────────────────────────────────────────────────────────
+    NEXT_PUBLIC_AXIOM_DATASET: z.string().optional(),
+    NEXT_PUBLIC_AXIOM_TOKEN: z.string().optional(),
 
-  // ── Logging ──────────────────────────────────────────────────────────────────
-  PINO_LOG_LEVEL: z
-    .enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
-    .optional(),
+    // ── Logging ──────────────────────────────────────────────────────────────────
+    PINO_LOG_LEVEL: z
+      .enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
+      .optional(),
 
-  // ── Geofence ─────────────────────────────────────────────────────────────────
-  IRSHAD_CENTER_LAT: z.coerce.number().min(-90).max(90).optional(),
-  IRSHAD_CENTER_LNG: z.coerce.number().min(-180).max(180).optional(),
-})
+    // ── Geofence ─────────────────────────────────────────────────────────────────
+    IRSHAD_CENTER_LAT: z.coerce.number().min(-90).max(90).optional(),
+    IRSHAD_CENTER_LNG: z.coerce.number().min(-180).max(180).optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.WHATSAPP_PHONE_NUMBER_ID && !data.WHATSAPP_APP_SECRET) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'WHATSAPP_APP_SECRET is required when WHATSAPP_PHONE_NUMBER_ID is set (project rule #11: webhook signatures must be verified)',
+        path: ['WHATSAPP_APP_SECRET'],
+      })
+    }
+  })
 
 const result = envSchema.safeParse(process.env)
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -28,9 +28,10 @@ const envSchema = z
     ADMIN_PASSWORD: z.string().min(1, 'ADMIN_PASSWORD is required'),
 
     // ── App Config ───────────────────────────────────────────────────────────────
-    // NEXT_PUBLIC_* vars are inlined by Next.js and must still be read via
-    // process.env in server actions/services — server-only prevents importing
-    // this module there. The schema's role for these is startup format-checking.
+    // NEXT_PUBLIC_* vars are inlined by Next.js at build time. Client-side code
+    // must read them via process.env directly — server-only prevents this module
+    // from being imported in client components. The schema's role for these is
+    // startup format-checking.
     NEXT_PUBLIC_APP_URL: z
       .string()
       .url('NEXT_PUBLIC_APP_URL must be a valid URL')
@@ -44,7 +45,10 @@ const envSchema = z
       .optional()
       .default('Irshad Center <noreply@irshadcenter.com>'),
     ADMIN_EMAIL: z.string().email('ADMIN_EMAIL must be a valid email'),
-    REPLY_TO_EMAIL: z.string().email().optional(),
+    REPLY_TO_EMAIL: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().email().optional()
+    ),
 
     // ── Stripe — Mahad ───────────────────────────────────────────────────────────
     STRIPE_MAHAD_SECRET_KEY_TEST: stripeField('sk_test_'),
@@ -68,7 +72,10 @@ const envSchema = z
     STRIPE_DUGSI_PRODUCT_ID: stripeField('prod_'),
     NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_TEST: stripeField('pk_test_'),
     NEXT_PUBLIC_STRIPE_DUGSI_PUBLISHABLE_KEY_LIVE: stripeField('pk_live_'),
-    NEXT_PUBLIC_STRIPE_DUGSI_PAYMENT_LINK: z.string().url().optional(),
+    NEXT_PUBLIC_STRIPE_DUGSI_PAYMENT_LINK: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().url().optional()
+    ),
 
     // ── Stripe — Zakat / Donation ────────────────────────────────────────────────
     STRIPE_ZAKAT_FITR_PRODUCT_ID: stripeField('prod_'),
@@ -133,6 +140,28 @@ const envSchema = z
           })
         }
       }
+    }
+
+    if (
+      data.NODE_ENV === 'production' &&
+      data.NEXT_PUBLIC_APP_URL === 'http://localhost:3000'
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'NEXT_PUBLIC_APP_URL must be set to a real URL in production',
+        path: ['NEXT_PUBLIC_APP_URL'],
+      })
+    }
+
+    const hasLat = data.IRSHAD_CENTER_LAT !== undefined
+    const hasLng = data.IRSHAD_CENTER_LNG !== undefined
+    if (hasLat !== hasLng) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'IRSHAD_CENTER_LAT and IRSHAD_CENTER_LNG must both be set or both be absent',
+        path: [hasLat ? 'IRSHAD_CENTER_LNG' : 'IRSHAD_CENTER_LAT'],
+      })
     }
   })
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -3,7 +3,7 @@ import 'server-only'
 import { z } from 'zod'
 
 // Coerces blank env var values ("") to undefined so optional() works correctly.
-// Node.js loads blank lines from .env files as "" not undefined.
+// Node.js (via dotenv) loads vars set to empty values (KEY=) as "" not undefined.
 const stripeField = (prefix: string) =>
   z.preprocess(
     (v) => (v === '' ? undefined : v),
@@ -32,10 +32,14 @@ const envSchema = z
     // must read them via process.env directly — server-only prevents this module
     // from being imported in client components. The schema's role for these is
     // startup format-checking.
-    NEXT_PUBLIC_APP_URL: z
-      .string()
-      .url('NEXT_PUBLIC_APP_URL must be a valid URL')
-      .default('http://localhost:3000'),
+    NEXT_PUBLIC_APP_URL: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z
+        .string()
+        .url('NEXT_PUBLIC_APP_URL must be a valid URL')
+        .optional()
+        .default('http://localhost:3000')
+    ),
 
     // ── Email ────────────────────────────────────────────────────────────────────
     RESEND_API_KEY: z.string().min(1, 'RESEND_API_KEY is required'),
@@ -58,14 +62,17 @@ const envSchema = z
     STRIPE_MAHAD_SECRET_KEY_LIVE: stripeField('sk_live_'),
     STRIPE_MAHAD_WEBHOOK_SECRET_TEST: stripeField('whsec_'),
     STRIPE_MAHAD_WEBHOOK_SECRET_LIVE: stripeField('whsec_'),
-    // Product ID resolution (lib/keys/stripe.ts): production → LIVE || generic,
-    // development → TEST || generic
+    // Mahad product ID resolution (lib/keys/stripe.ts): production → LIVE || generic,
+    // non-production → TEST || generic. Dugsi uses a single STRIPE_DUGSI_PRODUCT_ID.
     STRIPE_MAHAD_PRODUCT_ID: stripeField('prod_'),
     STRIPE_MAHAD_PRODUCT_ID_TEST: stripeField('prod_'),
     STRIPE_MAHAD_PRODUCT_ID_LIVE: stripeField('prod_'),
     NEXT_PUBLIC_STRIPE_MAHAD_PUBLISHABLE_KEY_TEST: stripeField('pk_test_'),
     NEXT_PUBLIC_STRIPE_MAHAD_PUBLISHABLE_KEY_LIVE: stripeField('pk_live_'),
-    NEXT_PUBLIC_STRIPE_MAHAD_PRICING_TABLE_ID: z.string().optional(),
+    NEXT_PUBLIC_STRIPE_MAHAD_PRICING_TABLE_ID: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().optional()
+    ),
 
     // ── Stripe — Dugsi ───────────────────────────────────────────────────────────
     STRIPE_DUGSI_SECRET_KEY_TEST: stripeField('sk_test_'),
@@ -90,12 +97,15 @@ const envSchema = z
 
     // ── WhatsApp ─────────────────────────────────────────────────────────────────
     // All four vars below are required together when WHATSAPP_PHONE_NUMBER_ID is
-    // set — enforced via superRefine below (project rule #11).
+    // set — enforced via superRefine below.
     WHATSAPP_PHONE_NUMBER_ID: z.string().optional(),
     WHATSAPP_ACCESS_TOKEN: z.string().optional(),
     WHATSAPP_APP_SECRET: z.string().optional(),
     WHATSAPP_WEBHOOK_VERIFY_TOKEN: z.string().optional(),
-    WHATSAPP_DEFAULT_LANGUAGE: z.string().optional().default('en'),
+    WHATSAPP_DEFAULT_LANGUAGE: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().optional().default('en')
+    ),
 
     // ── Feature Flags ────────────────────────────────────────────────────────────
     DUGSI_CARD_PAYMENTS_ENABLED: z.string().optional(),
@@ -119,13 +129,20 @@ const envSchema = z
     NEXT_PUBLIC_AXIOM_TOKEN: z.string().optional(),
 
     // ── Logging ──────────────────────────────────────────────────────────────────
-    PINO_LOG_LEVEL: z
-      .enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal'])
-      .optional(),
+    PINO_LOG_LEVEL: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.enum(['trace', 'debug', 'info', 'warn', 'error', 'fatal']).optional()
+    ),
 
     // ── Geofence ─────────────────────────────────────────────────────────────────
-    IRSHAD_CENTER_LAT: z.coerce.number().min(-90).max(90).optional(),
-    IRSHAD_CENTER_LNG: z.coerce.number().min(-180).max(180).optional(),
+    IRSHAD_CENTER_LAT: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.coerce.number().min(-90).max(90).optional()
+    ),
+    IRSHAD_CENTER_LNG: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.coerce.number().min(-180).max(180).optional()
+    ),
   })
   .superRefine((data, ctx) => {
     if (data.WHATSAPP_PHONE_NUMBER_ID) {

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -94,27 +94,57 @@ const envSchema = z
     STRIPE_DONATION_WEBHOOK_SECRET_TEST: stripeField('whsec_'),
     STRIPE_DONATION_WEBHOOK_SECRET_LIVE: stripeField('whsec_'),
     STRIPE_DONATION_PRODUCT_ID: stripeField('prod_'),
+    NEXT_PUBLIC_STRIPE_DONATION_PUBLISHABLE_KEY_TEST: stripeField('pk_test_'),
+    NEXT_PUBLIC_STRIPE_DONATION_PUBLISHABLE_KEY_LIVE: stripeField('pk_live_'),
 
     // ── WhatsApp ─────────────────────────────────────────────────────────────────
     // All four vars below are required together when WHATSAPP_PHONE_NUMBER_ID is
     // set — enforced via superRefine below.
-    WHATSAPP_PHONE_NUMBER_ID: z.string().optional(),
-    WHATSAPP_ACCESS_TOKEN: z.string().optional(),
-    WHATSAPP_APP_SECRET: z.string().optional(),
-    WHATSAPP_WEBHOOK_VERIFY_TOKEN: z.string().optional(),
+    WHATSAPP_PHONE_NUMBER_ID: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().optional()
+    ),
+    WHATSAPP_ACCESS_TOKEN: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().optional()
+    ),
+    WHATSAPP_APP_SECRET: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().optional()
+    ),
+    WHATSAPP_WEBHOOK_VERIFY_TOKEN: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().optional()
+    ),
     WHATSAPP_DEFAULT_LANGUAGE: z.preprocess(
       (v) => (v === '' ? undefined : v),
       z.string().optional().default('en')
     ),
 
     // ── Feature Flags ────────────────────────────────────────────────────────────
-    DUGSI_CARD_PAYMENTS_ENABLED: z.string().optional(),
-    MAHAD_CARD_PAYMENTS_ENABLED: z.string().optional(),
-    NEXT_PUBLIC_SHOW_GRADE_SCHOOL: z.string().optional(),
+    // Consumed as === 'true' in lib/config/feature-flags.ts — enum catches typos at startup.
+    DUGSI_CARD_PAYMENTS_ENABLED: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.enum(['true', 'false']).optional()
+    ),
+    MAHAD_CARD_PAYMENTS_ENABLED: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.enum(['true', 'false']).optional()
+    ),
+    NEXT_PUBLIC_SHOW_GRADE_SCHOOL: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.enum(['true', 'false']).optional()
+    ),
 
     // ── Sentry ───────────────────────────────────────────────────────────────────
-    SENTRY_DSN: z.string().optional(),
-    NEXT_PUBLIC_SENTRY_DSN: z.string().optional(),
+    SENTRY_DSN: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().url().optional()
+    ),
+    NEXT_PUBLIC_SENTRY_DSN: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().url().optional()
+    ),
     SENTRY_ORG: z.string().optional(),
     SENTRY_PROJECT: z.string().optional(),
     SENTRY_RELEASE: z.string().optional(),
@@ -164,7 +194,10 @@ const envSchema = z
 
     if (
       data.NODE_ENV === 'production' &&
-      data.NEXT_PUBLIC_APP_URL === 'http://localhost:3000'
+      data.NEXT_PUBLIC_APP_URL != null &&
+      /^https?:\/\/(localhost|127\.0\.0\.1)(:\d+)?(\/|$)/.test(
+        data.NEXT_PUBLIC_APP_URL
+      )
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -17,11 +17,17 @@ const envSchema = z
       .enum(['development', 'production', 'test'])
       .optional()
       .default('development'),
-    VERCEL_ENV: z.string().optional(),
+    VERCEL_ENV: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().optional()
+    ),
 
     // ── Database ─────────────────────────────────────────────────────────────────
     DATABASE_URL: z.string().min(1, 'DATABASE_URL is required'),
-    DIRECT_URL: z.string().optional(),
+    DIRECT_URL: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().optional()
+    ),
 
     // ── Admin Auth ───────────────────────────────────────────────────────────────
     ADMIN_PIN: z.string().min(1, 'ADMIN_PIN is required'),
@@ -154,9 +160,18 @@ const envSchema = z
       (v) => (v === '' ? undefined : v),
       z.string().url().optional()
     ),
-    SENTRY_ORG: z.string().optional(),
-    SENTRY_PROJECT: z.string().optional(),
-    SENTRY_RELEASE: z.string().optional(),
+    SENTRY_ORG: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().optional()
+    ),
+    SENTRY_PROJECT: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().optional()
+    ),
+    SENTRY_RELEASE: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().optional()
+    ),
     SENTRY_DEBUG: z.preprocess(
       (v) => (v === '' ? undefined : v),
       z.enum(['true', 'false']).optional()
@@ -165,13 +180,22 @@ const envSchema = z
       (v) => (v === '' ? undefined : v),
       z.enum(['true', 'false']).optional()
     ),
-    NEXT_PUBLIC_SENTRY_RELEASE: z.string().optional(),
+    NEXT_PUBLIC_SENTRY_RELEASE: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().optional()
+    ),
 
     // ── Axiom ────────────────────────────────────────────────────────────────────
-    NEXT_PUBLIC_AXIOM_DATASET: z.string().optional(),
+    NEXT_PUBLIC_AXIOM_DATASET: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().optional()
+    ),
     // NEXT_PUBLIC_AXIOM_TOKEN is a write-only credential scoped to this dataset.
     // Intentionally public — required by next-axiom for client-side log forwarding.
-    NEXT_PUBLIC_AXIOM_TOKEN: z.string().optional(),
+    NEXT_PUBLIC_AXIOM_TOKEN: z.preprocess(
+      (v) => (v === '' ? undefined : v),
+      z.string().optional()
+    ),
 
     // ── Logging ──────────────────────────────────────────────────────────────────
     PINO_LOG_LEVEL: z.preprocess(


### PR DESCRIPTION
### Why?

42 of 47 environment variables were accessed via raw `process.env` with no format checking or presence guarantees. Two auth secrets (`ADMIN_PIN`, `ADMIN_PASSWORD`) were missing from `.env.example` entirely, leaving them undocumented. A misconfigured env var (e.g., a Stripe key with a wrong prefix) would only surface as a cryptic runtime error deep in a request — not at startup.

Closes #201

### How?

Expand the Zod schema in `lib/env.ts` to cover all 47 vars grouped by module, add a guaranteed startup import via `instrumentation.ts`, and document the four previously undocumented vars in `.env.example`.

<details>
<summary>Implementation Plan</summary>

# Plan: Issue #201 — Expand env validation in lib/env.ts

## Context

`lib/env.ts` validates only 5 of ~47 environment variables at startup. The remaining 42 are accessed raw via `process.env` with no format checking or presence guarantees. Two auth secrets (`ADMIN_PIN`, `ADMIN_PASSWORD`) are missing from `.env.example` entirely. The issue is isolated to `lib/env.ts` and `.env.example` with a minor touch to `instrumentation.ts`.

---

## Files to Change

| File | Change |
|------|--------|
| `lib/env.ts` | Expand Zod schema from 5 to ~49 vars, grouped by module |
| `instrumentation.ts` | Add `import '@/lib/env'` in `nodejs` branch to guarantee startup validation |
| `.env.example` | Add 4 missing vars: `ADMIN_PIN`, `ADMIN_PASSWORD`, `IRSHAD_CENTER_LAT`, `IRSHAD_CENTER_LNG` |

No caller files change. Existing validators in `lib/keys/stripe.ts` and `lib/services/whatsapp/whatsapp-client.ts` stay untouched — they validate at call time, which remains unchanged.

---

## Required at Startup (z.string().min(1) — crash if absent)

These 6 vars are unconditionally required in all environments:

| Var | Why required |
|-----|-------------|
| `DATABASE_URL` | Prisma fails instantly without it |
| `ADMIN_PIN` | Auth is broken without it (currently throws at first auth request) |
| `ADMIN_PASSWORD` | Auth is broken without it |
| `NEXT_PUBLIC_APP_URL` | Used for Stripe return URLs and WhatsApp links |
| `RESEND_API_KEY` | Already required ✓ |
| `ADMIN_EMAIL` | Already required ✓ |

---

## Optional Vars with Format Validation (z.string().startsWith(...).optional())

These fail at startup if set but malformed — silently ignored if absent.

**Stripe — Mahad (8 vars)**: secret keys validated for `sk_test_`/`sk_live_` prefix, webhook secrets for `whsec_`, product IDs for `prod_`, publishable keys for `pk_test_`/`pk_live_`.

**Stripe — Dugsi (8 vars)**: same pattern.

**Stripe — Zakat / Donation (5 vars)**: format validated if set.

---

## Optional Plain Strings

No format validation — presence documented but not enforced.

WhatsApp (5), Sentry (8), Axiom (2), Vercel (2), Feature Flags (3), Logging (1), Geofence (2).

---

## Startup Guarantee via instrumentation.ts

The module-level `safeParse` in `lib/env.ts` runs at import time. Currently nothing imports `lib/env.ts` at server boot. Adding `await import('@/lib/env')` in the `nodejs` branch of `instrumentation.ts` guarantees validation runs before any request is handled.

</details>

<sub>Generated with Claude Code</sub>