### PR TITLE
feat: cache mahad student list + migrate registration actions to safe-action

### DIFF
--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -33,20 +33,31 @@ export async function getBillingAccount(
 
 ### Action Pattern
 
+All actions use next-safe-action v8 clients from `lib/safe-action.ts`:
+
+- `adminActionClient` — admin-only mutations
+- `rateLimitedActionClient` — public-facing mutations (rate limited)
+
 ```typescript
 'use server'
-export async function myAction(input: Input): Promise<ActionResult<Output>> {
-  try {
-    const validated = schema.parse(input)
-    const result = await service(validated)
-    revalidatePath('/path')
-    return { success: true, data: result }
-  } catch (error) {
-    await logError(logger, error, 'Action failed')
-    return { success: false, error: 'User-friendly message' }
-  }
+import { after } from 'next/server'
+import { adminActionClient } from '@/lib/safe-action'
+
+const _myAction = adminActionClient
+  .metadata({ actionName: 'myAction' })
+  .schema(mySchema)
+  .action(async ({ parsedInput }) => {
+    const result = await myService(parsedInput)
+    after(() => revalidatePath('/path'))
+    return result
+  })
+
+export async function myAction(...args: Parameters<typeof _myAction>) {
+  return _myAction(...args)
 }
 ```
+
+Errors: throw `ActionError(message, ERROR_CODES.X)` for domain errors — safe-action's `handleServerError` catches and serializes them. Never return `{ success: false }` manually.
 
 ### Mapper Pattern
 

--- a/app/admin/donations/page.tsx
+++ b/app/admin/donations/page.tsx
@@ -1,7 +1,7 @@
 import { type Metadata } from 'next'
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { getDonations, getDonationStats } from '@/lib/db/queries/donation'
+import { getCachedDonationStats, getDonations } from '@/lib/db/queries/donation'
 import { formatCurrency, formatDate } from '@/lib/utils/formatters'
 
 export const dynamic = 'force-dynamic'
@@ -37,7 +37,7 @@ function pluralize(count: number, singular: string): string {
 
 export default async function DonationsPage() {
   const [stats, { donations }] = await Promise.all([
-    getDonationStats(),
+    getCachedDonationStats(),
     getDonations({ pageSize: 50 }),
   ])
 

--- a/app/admin/dugsi/actions.ts
+++ b/app/admin/dugsi/actions.ts
@@ -693,6 +693,7 @@ const _updateChildInfo = adminActionClient
     await updateChildInfoService(parsedInput)
     after(() => {
       revalidatePath('/admin/dugsi')
+      revalidateTag('dugsi-registrations')
     })
     return { message: 'Successfully updated child information' }
   })
@@ -707,6 +708,7 @@ const _updateFamilyShift = adminActionClient
     })
     after(() => {
       revalidatePath('/admin/dugsi')
+      revalidateTag('dugsi-registrations')
     })
     return { message: 'Successfully updated family shift' }
   })

--- a/app/admin/dugsi/actions.ts
+++ b/app/admin/dugsi/actions.ts
@@ -235,7 +235,7 @@ export interface WhatsAppSendResult {
 
 const _getDugsiRegistrations = adminActionClient
   .metadata({ actionName: 'getDugsiRegistrations' })
-  .inputSchema(ShiftFilterSchema)
+  .schema(ShiftFilterSchema)
   .action(async ({ parsedInput }): Promise<DugsiRegistration[]> => {
     return await getAllDugsiRegistrations(undefined, parsedInput)
   })
@@ -402,14 +402,14 @@ const _getAllTeachersForClassAssignmentAction = adminActionClient
 
 const _getFamilyMembers = adminActionClient
   .metadata({ actionName: 'getFamilyMembers' })
-  .inputSchema(StudentIdSchema)
+  .schema(StudentIdSchema)
   .action(async ({ parsedInput }): Promise<DugsiRegistration[]> => {
     return await getFamilyMembersService(parsedInput.studentId)
   })
 
 const _getDeleteFamilyPreview = adminActionClient
   .metadata({ actionName: 'getDeleteFamilyPreview' })
-  .inputSchema(StudentIdSchema)
+  .schema(StudentIdSchema)
   .action(
     async ({
       parsedInput,
@@ -423,21 +423,21 @@ const _getDeleteFamilyPreview = adminActionClient
 
 const _validateDugsiSubscription = adminActionClient
   .metadata({ actionName: 'validateDugsiSubscription' })
-  .inputSchema(SubscriptionIdSchema)
+  .schema(SubscriptionIdSchema)
   .action(async ({ parsedInput }): Promise<SubscriptionValidationData> => {
     return await validateDugsiSubscriptionService(parsedInput.subscriptionId)
   })
 
 const _getDugsiPaymentStatus = adminActionClient
   .metadata({ actionName: 'getDugsiPaymentStatus' })
-  .inputSchema(ParentEmailSchema)
+  .schema(ParentEmailSchema)
   .action(async ({ parsedInput }): Promise<PaymentStatusData> => {
     return await getPaymentStatus(parsedInput.parentEmail)
   })
 
 const _getFamilyPaymentHistory = adminActionClient
   .metadata({ actionName: 'getFamilyPaymentHistory' })
-  .inputSchema(PaymentHistorySchema)
+  .schema(PaymentHistorySchema)
   .action(async ({ parsedInput }): Promise<StripePaymentHistoryItem[]> => {
     const stripe = getDugsiStripeClient()
     const invoices = await stripe.invoices.list({
@@ -468,14 +468,14 @@ const _getFamilyPaymentHistory = adminActionClient
 
 const _getAvailableStudentsForClassAction = adminActionClient
   .metadata({ actionName: 'getAvailableStudentsForClassAction' })
-  .inputSchema(z.object({ shift: z.nativeEnum(Shift) }))
+  .schema(z.object({ shift: z.nativeEnum(Shift) }))
   .action(async ({ parsedInput }): Promise<StudentForEnrollment[]> => {
     return await getAvailableStudentsForClass(parsedInput.shift)
   })
 
 const _getClassDeletePreviewAction = adminActionClient
   .metadata({ actionName: 'getClassDeletePreviewAction' })
-  .inputSchema(ClassIdSchema)
+  .schema(ClassIdSchema)
   .action(
     async ({
       parsedInput,
@@ -499,7 +499,7 @@ const _getClassDeletePreviewAction = adminActionClient
 
 const _deleteDugsiFamily = adminActionClient
   .metadata({ actionName: 'deleteDugsiFamily' })
-  .inputSchema(StudentIdSchema)
+  .schema(StudentIdSchema)
   .action(
     async ({
       parsedInput,
@@ -536,7 +536,7 @@ const _deleteDugsiFamily = adminActionClient
 
 const _linkDugsiSubscription = adminActionClient
   .metadata({ actionName: 'linkDugsiSubscription' })
-  .inputSchema(LinkSubscriptionSchema)
+  .schema(LinkSubscriptionSchema)
   .action(
     async ({
       parsedInput,
@@ -571,7 +571,7 @@ const _linkDugsiSubscription = adminActionClient
 
 const _verifyDugsiBankAccount = adminActionClient
   .metadata({ actionName: 'verifyDugsiBankAccount' })
-  .inputSchema(VerifyBankSchema)
+  .schema(VerifyBankSchema)
   .action(async ({ parsedInput }): Promise<BankVerificationData> => {
     const { paymentIntentId, descriptorCode } = parsedInput
 
@@ -627,7 +627,7 @@ const _verifyDugsiBankAccount = adminActionClient
 
 const _updateParentInfo = adminActionClient
   .metadata({ actionName: 'updateParentInfo' })
-  .inputSchema(UpdateParentInfoSchema)
+  .schema(UpdateParentInfoSchema)
   .action(
     async ({ parsedInput }): Promise<{ updated: number; message: string }> => {
       const result = await updateParentInfoService(parsedInput)
@@ -641,7 +641,7 @@ const _updateParentInfo = adminActionClient
 
 const _addSecondParent = adminActionClient
   .metadata({ actionName: 'addSecondParent' })
-  .inputSchema(AddSecondParentSchema)
+  .schema(AddSecondParentSchema)
   .action(
     async ({ parsedInput }): Promise<{ updated: number; message: string }> => {
       const result = await addSecondParentService(parsedInput)
@@ -655,7 +655,7 @@ const _addSecondParent = adminActionClient
 
 const _setPrimaryPayer = adminActionClient
   .metadata({ actionName: 'setPrimaryPayer' })
-  .inputSchema(SetPrimaryPayerSchema)
+  .schema(SetPrimaryPayerSchema)
   .action(
     async ({ parsedInput }): Promise<{ updated: number; message: string }> => {
       const result = await setPrimaryPayerService(parsedInput)
@@ -669,7 +669,7 @@ const _setPrimaryPayer = adminActionClient
 
 const _updateChildInfo = adminActionClient
   .metadata({ actionName: 'updateChildInfo' })
-  .inputSchema(UpdateChildInfoSchema)
+  .schema(UpdateChildInfoSchema)
   .action(async ({ parsedInput }): Promise<{ message: string }> => {
     await updateChildInfoService(parsedInput)
     revalidatePath('/admin/dugsi')
@@ -678,7 +678,7 @@ const _updateChildInfo = adminActionClient
 
 const _updateFamilyShift = adminActionClient
   .metadata({ actionName: 'updateFamilyShift' })
-  .inputSchema(UpdateFamilyShiftSchema)
+  .schema(UpdateFamilyShiftSchema)
   .action(async ({ parsedInput }): Promise<{ message: string }> => {
     await updateFamilyShiftService({
       familyReferenceId: parsedInput.familyReferenceId,
@@ -690,7 +690,7 @@ const _updateFamilyShift = adminActionClient
 
 const _addChildToFamily = adminActionClient
   .metadata({ actionName: 'addChildToFamily' })
-  .inputSchema(AddChildToFamilySchema)
+  .schema(AddChildToFamilySchema)
   .action(
     async ({ parsedInput }): Promise<{ childId: string; message: string }> => {
       const result = await addChildToFamilyService(parsedInput)
@@ -701,7 +701,7 @@ const _addChildToFamily = adminActionClient
 
 const _generateFamilyPaymentLinkAction = adminActionClient
   .metadata({ actionName: 'generateFamilyPaymentLinkAction' })
-  .inputSchema(GenerateFamilyPaymentLinkSchema)
+  .schema(GenerateFamilyPaymentLinkSchema)
   .action(async ({ parsedInput }): Promise<FamilyPaymentLinkData> => {
     const { familyId, overrideAmount, billingStartDate } = parsedInput
     const result = await createDugsiCheckoutSession({
@@ -732,7 +732,7 @@ const _generateFamilyPaymentLinkAction = adminActionClient
 
 const _bulkGeneratePaymentLinksAction = adminActionClient
   .metadata({ actionName: 'bulkGeneratePaymentLinksAction' })
-  .inputSchema(BulkPaymentLinksSchema)
+  .schema(BulkPaymentLinksSchema)
   .action(
     async ({
       parsedInput,
@@ -820,7 +820,7 @@ const _bulkGeneratePaymentLinksAction = adminActionClient
 
 const _assignTeacherToClassAction = adminActionClient
   .metadata({ actionName: 'assignTeacherToClassAction' })
-  .inputSchema(AssignTeacherToClassSchema)
+  .schema(AssignTeacherToClassSchema)
   .action(async ({ parsedInput }): Promise<{ message: string }> => {
     const { classId, teacherId } = parsedInput
     try {
@@ -858,7 +858,7 @@ const _assignTeacherToClassAction = adminActionClient
 
 const _removeTeacherFromClassAction = adminActionClient
   .metadata({ actionName: 'removeTeacherFromClassAction' })
-  .inputSchema(RemoveTeacherFromClassSchema)
+  .schema(RemoveTeacherFromClassSchema)
   .action(async ({ parsedInput }): Promise<{ message: string }> => {
     const { classId, teacherId } = parsedInput
     await removeTeacherFromClass(classId, teacherId)
@@ -870,7 +870,7 @@ const _removeTeacherFromClassAction = adminActionClient
 
 const _enrollStudentInClassAction = adminActionClient
   .metadata({ actionName: 'enrollStudentInClassAction' })
-  .inputSchema(EnrollStudentInClassSchema)
+  .schema(EnrollStudentInClassSchema)
   .action(async ({ parsedInput }): Promise<{ message: string }> => {
     const { classId, programProfileId } = parsedInput
     try {
@@ -896,7 +896,7 @@ const _enrollStudentInClassAction = adminActionClient
 
 const _removeStudentFromClassAction = adminActionClient
   .metadata({ actionName: 'removeStudentFromClassAction' })
-  .inputSchema(RemoveStudentFromClassSchema)
+  .schema(RemoveStudentFromClassSchema)
   .action(async ({ parsedInput }): Promise<{ message: string }> => {
     const { programProfileId } = parsedInput
     await removeStudentFromClass(programProfileId)
@@ -907,7 +907,7 @@ const _removeStudentFromClassAction = adminActionClient
 
 const _bulkEnrollStudentsAction = adminActionClient
   .metadata({ actionName: 'bulkEnrollStudentsAction' })
-  .inputSchema(BulkEnrollStudentsSchema)
+  .schema(BulkEnrollStudentsSchema)
   .action(
     async ({
       parsedInput,
@@ -928,7 +928,7 @@ const _bulkEnrollStudentsAction = adminActionClient
 
 const _createClassAction = adminActionClient
   .metadata({ actionName: 'createClassAction' })
-  .inputSchema(CreateClassSchema)
+  .schema(CreateClassSchema)
   .action(
     async ({
       parsedInput,
@@ -968,7 +968,7 @@ const _createClassAction = adminActionClient
 
 const _updateClassAction = adminActionClient
   .metadata({ actionName: 'updateClassAction' })
-  .inputSchema(UpdateClassSchema)
+  .schema(UpdateClassSchema)
   .action(
     async ({
       parsedInput,
@@ -1030,7 +1030,7 @@ const _updateClassAction = adminActionClient
 
 const _deleteClassAction = adminActionClient
   .metadata({ actionName: 'deleteClassAction' })
-  .inputSchema(DeleteClassSchema)
+  .schema(DeleteClassSchema)
   .action(async ({ parsedInput }): Promise<{ message: string }> => {
     const { classId } = parsedInput
     try {
@@ -1056,7 +1056,7 @@ const _deleteClassAction = adminActionClient
 
 const _previewStripeSubscriptionForConsolidation = adminActionClient
   .metadata({ actionName: 'previewStripeSubscriptionForConsolidation' })
-  .inputSchema(previewSubscriptionInputSchema)
+  .schema(previewSubscriptionInputSchema)
   .action(async ({ parsedInput }): Promise<StripeSubscriptionPreview> => {
     return await previewStripeSubscriptionService(
       parsedInput.subscriptionId,
@@ -1066,7 +1066,7 @@ const _previewStripeSubscriptionForConsolidation = adminActionClient
 
 const _consolidateDugsiSubscription = adminActionClient
   .metadata({ actionName: 'consolidateDugsiSubscription' })
-  .inputSchema(consolidateSubscriptionInputSchema)
+  .schema(consolidateSubscriptionInputSchema)
   .action(
     async ({
       parsedInput,
@@ -1108,7 +1108,7 @@ const _consolidateDugsiSubscription = adminActionClient
 
 const _sendPaymentLinkViaWhatsAppAction = adminActionClient
   .metadata({ actionName: 'sendPaymentLinkViaWhatsAppAction' })
-  .inputSchema(SendPaymentLinkViaWhatsAppSchema)
+  .schema(SendPaymentLinkViaWhatsAppSchema)
   .action(
     async ({
       parsedInput,

--- a/app/admin/dugsi/actions.ts
+++ b/app/admin/dugsi/actions.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { revalidatePath } from 'next/cache'
+import { revalidatePath, revalidateTag } from 'next/cache'
 import { after } from 'next/server'
 
 import { GradeLevel, Prisma, Shift } from '@prisma/client'
@@ -512,6 +512,7 @@ const _deleteDugsiFamily = adminActionClient
       const result = await deleteDugsiFamilyService(parsedInput.studentId)
       after(() => {
         revalidatePath('/admin/dugsi')
+        revalidateTag('dugsi-registrations')
       })
 
       await logInfo(logger, 'Dugsi family deleted', {
@@ -559,6 +560,7 @@ const _linkDugsiSubscription = adminActionClient
       )
       after(() => {
         revalidatePath('/admin/dugsi')
+        revalidateTag('dugsi-registrations')
       })
 
       await logInfo(logger, 'Dugsi subscription linked', {
@@ -599,6 +601,7 @@ const _verifyDugsiBankAccount = adminActionClient
       const result = await verifyBankAccount(paymentIntentId, cleanCode)
       after(() => {
         revalidatePath('/admin/dugsi')
+        revalidateTag('dugsi-registrations')
       })
       return result
     } catch (error: unknown) {
@@ -640,6 +643,7 @@ const _updateParentInfo = adminActionClient
       const result = await updateParentInfoService(parsedInput)
       after(() => {
         revalidatePath('/admin/dugsi')
+        revalidateTag('dugsi-registrations')
       })
       return {
         ...result,
@@ -656,6 +660,7 @@ const _addSecondParent = adminActionClient
       const result = await addSecondParentService(parsedInput)
       after(() => {
         revalidatePath('/admin/dugsi')
+        revalidateTag('dugsi-registrations')
       })
       return {
         ...result,
@@ -672,6 +677,7 @@ const _setPrimaryPayer = adminActionClient
       const result = await setPrimaryPayerService(parsedInput)
       after(() => {
         revalidatePath('/admin/dugsi')
+        revalidateTag('dugsi-registrations')
       })
       return {
         ...result,
@@ -713,6 +719,7 @@ const _addChildToFamily = adminActionClient
       const result = await addChildToFamilyService(parsedInput)
       after(() => {
         revalidatePath('/admin/dugsi')
+        revalidateTag('dugsi-registrations')
       })
       return { ...result, message: 'Successfully added child to family' }
     }
@@ -1109,6 +1116,7 @@ const _consolidateDugsiSubscription = adminActionClient
       const result = await consolidateStripeSubscriptionService(parsedInput)
       after(() => {
         revalidatePath('/admin/dugsi')
+        revalidateTag('dugsi-registrations')
       })
 
       await logInfo(logger, 'Dugsi subscription consolidated', {
@@ -1170,6 +1178,7 @@ const _sendPaymentLinkViaWhatsAppAction = adminActionClient
 
       after(() => {
         revalidatePath('/admin/dugsi')
+        revalidateTag('dugsi-registrations')
       })
       return {
         waMessageId: result.waMessageId,

--- a/app/admin/dugsi/actions.ts
+++ b/app/admin/dugsi/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
+import { after } from 'next/server'
 
 import { GradeLevel, Prisma, Shift } from '@prisma/client'
 import { z } from 'zod'
@@ -509,7 +510,9 @@ const _deleteDugsiFamily = adminActionClient
       message: string
     }> => {
       const result = await deleteDugsiFamilyService(parsedInput.studentId)
-      revalidatePath('/admin/dugsi')
+      after(() => {
+        revalidatePath('/admin/dugsi')
+      })
 
       await logInfo(logger, 'Dugsi family deleted', {
         studentId: parsedInput.studentId,
@@ -554,7 +557,9 @@ const _linkDugsiSubscription = adminActionClient
         parentEmail,
         subscriptionId
       )
-      revalidatePath('/admin/dugsi')
+      after(() => {
+        revalidatePath('/admin/dugsi')
+      })
 
       await logInfo(logger, 'Dugsi subscription linked', {
         parentEmail,
@@ -592,7 +597,9 @@ const _verifyDugsiBankAccount = adminActionClient
 
     try {
       const result = await verifyBankAccount(paymentIntentId, cleanCode)
-      revalidatePath('/admin/dugsi')
+      after(() => {
+        revalidatePath('/admin/dugsi')
+      })
       return result
     } catch (error: unknown) {
       if (
@@ -631,7 +638,9 @@ const _updateParentInfo = adminActionClient
   .action(
     async ({ parsedInput }): Promise<{ updated: number; message: string }> => {
       const result = await updateParentInfoService(parsedInput)
-      revalidatePath('/admin/dugsi')
+      after(() => {
+        revalidatePath('/admin/dugsi')
+      })
       return {
         ...result,
         message: `Successfully updated parent information for ${result.updated} ${result.updated === 1 ? 'student' : 'students'}`,
@@ -645,7 +654,9 @@ const _addSecondParent = adminActionClient
   .action(
     async ({ parsedInput }): Promise<{ updated: number; message: string }> => {
       const result = await addSecondParentService(parsedInput)
-      revalidatePath('/admin/dugsi')
+      after(() => {
+        revalidatePath('/admin/dugsi')
+      })
       return {
         ...result,
         message: `Successfully added second parent to ${result.updated} ${result.updated === 1 ? 'student' : 'students'}`,
@@ -659,7 +670,9 @@ const _setPrimaryPayer = adminActionClient
   .action(
     async ({ parsedInput }): Promise<{ updated: number; message: string }> => {
       const result = await setPrimaryPayerService(parsedInput)
-      revalidatePath('/admin/dugsi')
+      after(() => {
+        revalidatePath('/admin/dugsi')
+      })
       return {
         ...result,
         message: `Parent ${parsedInput.parentNumber} is now the primary payer`,
@@ -672,7 +685,9 @@ const _updateChildInfo = adminActionClient
   .schema(UpdateChildInfoSchema)
   .action(async ({ parsedInput }): Promise<{ message: string }> => {
     await updateChildInfoService(parsedInput)
-    revalidatePath('/admin/dugsi')
+    after(() => {
+      revalidatePath('/admin/dugsi')
+    })
     return { message: 'Successfully updated child information' }
   })
 
@@ -684,7 +699,9 @@ const _updateFamilyShift = adminActionClient
       familyReferenceId: parsedInput.familyReferenceId,
       shift: parsedInput.shift,
     })
-    revalidatePath('/admin/dugsi')
+    after(() => {
+      revalidatePath('/admin/dugsi')
+    })
     return { message: 'Successfully updated family shift' }
   })
 
@@ -694,7 +711,9 @@ const _addChildToFamily = adminActionClient
   .action(
     async ({ parsedInput }): Promise<{ childId: string; message: string }> => {
       const result = await addChildToFamilyService(parsedInput)
-      revalidatePath('/admin/dugsi')
+      after(() => {
+        revalidatePath('/admin/dugsi')
+      })
       return { ...result, message: 'Successfully added child to family' }
     }
   )
@@ -850,8 +869,10 @@ const _assignTeacherToClassAction = adminActionClient
       throw error
     }
 
-    revalidatePath('/admin/dugsi/classes')
-    revalidatePath('/teacher/checkin')
+    after(() => {
+      revalidatePath('/admin/dugsi/classes')
+      revalidatePath('/teacher/checkin')
+    })
     logger.info({ classId, teacherId }, 'Teacher assigned to class')
     return { message: 'Teacher assigned to class' }
   })
@@ -862,8 +883,10 @@ const _removeTeacherFromClassAction = adminActionClient
   .action(async ({ parsedInput }): Promise<{ message: string }> => {
     const { classId, teacherId } = parsedInput
     await removeTeacherFromClass(classId, teacherId)
-    revalidatePath('/admin/dugsi/classes')
-    revalidatePath('/teacher/checkin')
+    after(() => {
+      revalidatePath('/admin/dugsi/classes')
+      revalidatePath('/teacher/checkin')
+    })
     logger.info({ classId, teacherId }, 'Teacher removed from class')
     return { message: 'Teacher removed from class' }
   })
@@ -889,7 +912,9 @@ const _enrollStudentInClassAction = adminActionClient
       }
       throw error
     }
-    revalidatePath('/admin/dugsi/classes')
+    after(() => {
+      revalidatePath('/admin/dugsi/classes')
+    })
     logger.info({ classId, programProfileId }, 'Student enrolled in class')
     return { message: 'Student enrolled in class' }
   })
@@ -900,7 +925,9 @@ const _removeStudentFromClassAction = adminActionClient
   .action(async ({ parsedInput }): Promise<{ message: string }> => {
     const { programProfileId } = parsedInput
     await removeStudentFromClass(programProfileId)
-    revalidatePath('/admin/dugsi/classes')
+    after(() => {
+      revalidatePath('/admin/dugsi/classes')
+    })
     logger.info({ programProfileId }, 'Student removed from class')
     return { message: 'Student removed from class' }
   })
@@ -914,7 +941,9 @@ const _bulkEnrollStudentsAction = adminActionClient
     }): Promise<{ enrolled: number; moved: number; message: string }> => {
       const { classId, programProfileIds } = parsedInput
       const result = await bulkEnrollStudents(classId, programProfileIds)
-      revalidatePath('/admin/dugsi/classes')
+      after(() => {
+        revalidatePath('/admin/dugsi/classes')
+      })
       logger.info(
         { classId, enrolled: result.enrolled, moved: result.moved },
         'Bulk enrollment completed'
@@ -936,8 +965,10 @@ const _createClassAction = adminActionClient
       const { name, shift, description } = parsedInput
       try {
         const newClass = await createClass(name, shift as Shift, description)
-        revalidatePath('/admin/dugsi/classes')
-        revalidatePath('/teacher/checkin')
+        after(() => {
+          revalidatePath('/admin/dugsi/classes')
+          revalidatePath('/teacher/checkin')
+        })
         logger.info({ classId: newClass.id, name, shift }, 'Class created')
         return {
           id: newClass.id,
@@ -1007,8 +1038,10 @@ const _updateClassAction = adminActionClient
         )
       }
 
-      revalidatePath('/admin/dugsi/classes')
-      revalidatePath('/teacher/checkin')
+      after(() => {
+        revalidatePath('/admin/dugsi/classes')
+        revalidatePath('/teacher/checkin')
+      })
       logger.info({ classId, name }, 'Class updated')
 
       return {
@@ -1044,8 +1077,10 @@ const _deleteClassAction = adminActionClient
       }
       throw error
     }
-    revalidatePath('/admin/dugsi/classes')
-    revalidatePath('/teacher/checkin')
+    after(() => {
+      revalidatePath('/admin/dugsi/classes')
+      revalidatePath('/teacher/checkin')
+    })
     logger.info({ classId }, 'Class deleted')
     return { message: 'Class deleted successfully' }
   })
@@ -1072,7 +1107,9 @@ const _consolidateDugsiSubscription = adminActionClient
       parsedInput,
     }): Promise<ConsolidateSubscriptionResult & { message: string }> => {
       const result = await consolidateStripeSubscriptionService(parsedInput)
-      revalidatePath('/admin/dugsi')
+      after(() => {
+        revalidatePath('/admin/dugsi')
+      })
 
       await logInfo(logger, 'Dugsi subscription consolidated', {
         subscriptionId: parsedInput.stripeSubscriptionId,
@@ -1131,7 +1168,9 @@ const _sendPaymentLinkViaWhatsAppAction = adminActionClient
         )
       }
 
-      revalidatePath('/admin/dugsi')
+      after(() => {
+        revalidatePath('/admin/dugsi')
+      })
       return {
         waMessageId: result.waMessageId,
         message: 'Payment link sent via WhatsApp',

--- a/app/admin/dugsi/actions/__tests__/billing-actions.test.ts
+++ b/app/admin/dugsi/actions/__tests__/billing-actions.test.ts
@@ -1,5 +1,5 @@
-import { z } from 'zod'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { z } from 'zod'
 
 const {
   mockPauseFamilyBilling,
@@ -45,6 +45,11 @@ vi.mock('@/lib/safe-action', () => {
 
 vi.mock('next/cache', () => ({
   revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+  revalidateTag: vi.fn(),
+}))
+
+vi.mock('next/server', () => ({
+  after: vi.fn((cb: () => void) => cb()),
 }))
 
 vi.mock('@/lib/services/dugsi', () => ({

--- a/app/admin/dugsi/actions/billing-actions.ts
+++ b/app/admin/dugsi/actions/billing-actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
-import { revalidatePath } from 'next/cache'
+import { revalidatePath, revalidateTag } from 'next/cache'
+import { after } from 'next/server'
 
 import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
 import { createServiceLogger, logError } from '@/lib/logger'
@@ -23,7 +24,10 @@ const _pauseFamilyBillingAction = adminActionClient
     const { familyReferenceId } = parsedInput
     try {
       const result = await pauseFamilyBillingService(familyReferenceId)
-      revalidatePath('/admin/dugsi')
+      after(() => {
+        revalidatePath('/admin/dugsi')
+        revalidateTag('dugsi-registrations')
+      })
       return {
         message: 'Billing paused successfully',
         warning: result.error
@@ -55,7 +59,10 @@ const _resumeFamilyBillingAction = adminActionClient
     const { familyReferenceId } = parsedInput
     try {
       const result = await resumeFamilyBillingService(familyReferenceId)
-      revalidatePath('/admin/dugsi')
+      after(() => {
+        revalidatePath('/admin/dugsi')
+        revalidateTag('dugsi-registrations')
+      })
       return {
         message: 'Billing resumed successfully',
         warning: result.error

--- a/app/admin/dugsi/actions/billing-actions.ts
+++ b/app/admin/dugsi/actions/billing-actions.ts
@@ -18,7 +18,7 @@ const logger = createServiceLogger('dugsi-billing-actions')
 
 const _pauseFamilyBillingAction = adminActionClient
   .metadata({ actionName: 'pauseFamilyBillingAction' })
-  .inputSchema(PauseFamilyBillingSchema)
+  .schema(PauseFamilyBillingSchema)
   .action(async ({ parsedInput }) => {
     const { familyReferenceId } = parsedInput
     try {
@@ -50,7 +50,7 @@ export async function pauseFamilyBillingAction(
 
 const _resumeFamilyBillingAction = adminActionClient
   .metadata({ actionName: 'resumeFamilyBillingAction' })
-  .inputSchema(ResumeFamilyBillingSchema)
+  .schema(ResumeFamilyBillingSchema)
   .action(async ({ parsedInput }) => {
     const { familyReferenceId } = parsedInput
     try {

--- a/app/admin/dugsi/page.tsx
+++ b/app/admin/dugsi/page.tsx
@@ -3,9 +3,9 @@ import { Suspense } from 'react'
 import { Metadata } from 'next'
 
 import { AppErrorBoundary } from '@/components/error-boundary'
+import { getCachedDugsiRegistrations } from '@/lib/services/dugsi/registration-service'
 import { ShiftFilterSchema } from '@/lib/validations/dugsi'
 
-import { getDugsiRegistrations } from './actions'
 import { DugsiDashboard } from './components/dugsi-dashboard'
 
 function Loading() {
@@ -55,8 +55,10 @@ export default async function DugsiAdminPage({
   const params = await searchParams
   const shift = ShiftFilterSchema.parse(params?.shift)
 
-  const result = await getDugsiRegistrations({ shift })
-  const registrations = result?.data ?? []
+  const registrations = await getCachedDugsiRegistrations(
+    undefined,
+    shift ? { shift } : undefined
+  )
 
   return (
     <main className="container mx-auto space-y-4 p-4 sm:space-y-6 sm:p-6 lg:space-y-8 lg:p-8">

--- a/app/admin/dugsi/teachers/actions.ts
+++ b/app/admin/dugsi/teachers/actions.ts
@@ -194,7 +194,7 @@ const checkinHistoryInputSchema = z.object({
 
 const _getTeachers = adminActionClient
   .metadata({ actionName: 'getTeachers' })
-  .inputSchema(getTeachersSchema)
+  .schema(getTeachersSchema)
   .action(async ({ parsedInput }) => {
     const { program } = parsedInput
     if (program === 'DUGSI_PROGRAM') {
@@ -283,7 +283,7 @@ const _getTeachers = adminActionClient
 
 const _createTeacherAction = adminActionClient
   .metadata({ actionName: 'createTeacherAction' })
-  .inputSchema(createTeacherSchema)
+  .schema(createTeacherSchema)
   .action(async ({ parsedInput }) => {
     const { personId } = parsedInput
     try {
@@ -337,7 +337,7 @@ const _createTeacherAction = adminActionClient
 
 const _createTeacherWithPersonAction = adminActionClient
   .metadata({ actionName: 'createTeacherWithPersonAction' })
-  .inputSchema(createTeacherWithPersonSchema)
+  .schema(createTeacherWithPersonSchema)
   .action(async ({ parsedInput }) => {
     const { name, email, phone } = parsedInput
     try {
@@ -405,7 +405,7 @@ const _createTeacherWithPersonAction = adminActionClient
 
 const _deleteTeacherAction = adminActionClient
   .metadata({ actionName: 'deleteTeacherAction' })
-  .inputSchema(deleteTeacherSchema)
+  .schema(deleteTeacherSchema)
   .action(async ({ parsedInput }) => {
     const { teacherId } = parsedInput
     await deleteTeacher(teacherId)
@@ -417,7 +417,7 @@ const _deleteTeacherAction = adminActionClient
 
 const _updateTeacherDetailsAction = adminActionClient
   .metadata({ actionName: 'updateTeacherDetailsAction' })
-  .inputSchema(updateTeacherDetailsSchema)
+  .schema(updateTeacherDetailsSchema)
   .action(async ({ parsedInput }) => {
     const { teacherId, name, email, phone } = parsedInput
     try {
@@ -488,7 +488,7 @@ const _updateTeacherDetailsAction = adminActionClient
 
 const _updateTeacherShiftsAction = adminActionClient
   .metadata({ actionName: 'updateTeacherShiftsAction' })
-  .inputSchema(updateTeacherShiftsSchema)
+  .schema(updateTeacherShiftsSchema)
   .action(async ({ parsedInput }) => {
     const { teacherId, shifts } = parsedInput
     const teacherProgram = await getTeacherDugsiProgram(teacherId)
@@ -511,7 +511,7 @@ const _updateTeacherShiftsAction = adminActionClient
 
 const _getTeacherShiftsAction = adminActionClient
   .metadata({ actionName: 'getTeacherShiftsAction' })
-  .inputSchema(z.object({ teacherId: uuidSchema }))
+  .schema(z.object({ teacherId: uuidSchema }))
   .action(async ({ parsedInput }) => {
     const { teacherId } = parsedInput
     const teacherProgram = await getTeacherDugsiProgram(teacherId)
@@ -520,7 +520,7 @@ const _getTeacherShiftsAction = adminActionClient
 
 const _deactivateTeacherAction = adminActionClient
   .metadata({ actionName: 'deactivateTeacherAction' })
-  .inputSchema(z.object({ teacherId: z.string().uuid() }))
+  .schema(z.object({ teacherId: z.string().uuid() }))
   .action(async ({ parsedInput }) => {
     const { teacherId } = parsedInput
     const activeClasses = await getActiveClassesForTeacher(teacherId)
@@ -560,7 +560,7 @@ const _deactivateTeacherAction = adminActionClient
 
 const _assignTeacherToProgramAction = adminActionClient
   .metadata({ actionName: 'assignTeacherToProgramAction' })
-  .inputSchema(programAssignmentSchema)
+  .schema(programAssignmentSchema)
   .action(async ({ parsedInput }) => {
     try {
       await assignTeacherToProgram(parsedInput)
@@ -590,7 +590,7 @@ const _assignTeacherToProgramAction = adminActionClient
 
 const _removeTeacherFromProgramAction = adminActionClient
   .metadata({ actionName: 'removeTeacherFromProgramAction' })
-  .inputSchema(programAssignmentSchema)
+  .schema(programAssignmentSchema)
   .action(async ({ parsedInput }) => {
     if (parsedInput.program === 'DUGSI_PROGRAM') {
       const activeClasses = await countActiveClassesForTeacher(
@@ -620,7 +620,7 @@ const _removeTeacherFromProgramAction = adminActionClient
 
 const _bulkAssignProgramsAction = adminActionClient
   .metadata({ actionName: 'bulkAssignProgramsAction' })
-  .inputSchema(bulkProgramAssignmentSchema)
+  .schema(bulkProgramAssignmentSchema)
   .action(async ({ parsedInput }) => {
     const { teacherId, programs } = parsedInput
     await bulkAssignPrograms(teacherId, programs)
@@ -638,7 +638,7 @@ const _bulkAssignProgramsAction = adminActionClient
 
 const _getTeacherProgramsAction = adminActionClient
   .metadata({ actionName: 'getTeacherProgramsAction' })
-  .inputSchema(getTeacherProgramsSchema)
+  .schema(getTeacherProgramsSchema)
   .action(async ({ parsedInput }) => {
     const { teacherId } = parsedInput
     const programs = await getTeacherPrograms(teacherId)
@@ -647,7 +647,7 @@ const _getTeacherProgramsAction = adminActionClient
 
 const _searchPeopleAction = adminActionClient
   .metadata({ actionName: 'searchPeopleAction' })
-  .inputSchema(z.object({ query: z.string() }))
+  .schema(z.object({ query: z.string() }))
   .action(async ({ parsedInput }) => {
     const { query } = parsedInput
     if (!query || query.trim().length < SEARCH_MIN_LENGTH) {
@@ -744,7 +744,7 @@ export interface CheckinHistoryResult {
 
 const _getTeacherCheckinHistoryAction = adminActionClient
   .metadata({ actionName: 'getTeacherCheckinHistoryAction' })
-  .inputSchema(checkinHistoryInputSchema)
+  .schema(checkinHistoryInputSchema)
   .action(async ({ parsedInput }) => {
     const { teacherId, page } = parsedInput
     const thirtyDaysAgo = new Date()
@@ -814,7 +814,7 @@ function mapCheckinToRecord(
 
 const _getCheckinsForDateAction = adminActionClient
   .metadata({ actionName: 'getCheckinsForDateAction' })
-  .inputSchema(DateCheckinFiltersSchema)
+  .schema(DateCheckinFiltersSchema)
   .action(async ({ parsedInput }) => {
     const checkins = await getCheckinsForDate(parsedInput)
     return checkins.map(mapCheckinToRecord)
@@ -822,7 +822,7 @@ const _getCheckinsForDateAction = adminActionClient
 
 const _getCheckinHistoryWithFiltersAction = adminActionClient
   .metadata({ actionName: 'getCheckinHistoryWithFiltersAction' })
-  .inputSchema(CheckinHistoryFiltersSchema)
+  .schema(CheckinHistoryFiltersSchema)
   .action(async ({ parsedInput }) => {
     const { page, limit, ...queryFilters } = parsedInput
     const result = await getCheckinHistory(queryFilters, { page, limit })
@@ -838,7 +838,7 @@ const _getCheckinHistoryWithFiltersAction = adminActionClient
 
 const _getLateArrivalsAction = adminActionClient
   .metadata({ actionName: 'getLateArrivalsAction' })
-  .inputSchema(LateReportFiltersSchema)
+  .schema(LateReportFiltersSchema)
   .action(async ({ parsedInput }) => {
     const checkins = await getLateArrivals(parsedInput)
     return checkins.map(mapCheckinToRecord)
@@ -856,7 +856,7 @@ const _getTeachersForDropdownAction = adminActionClient
 
 const _updateCheckinAction = adminActionClient
   .metadata({ actionName: 'updateCheckinAction' })
-  .inputSchema(UpdateCheckinSchema)
+  .schema(UpdateCheckinSchema)
   .action(async ({ parsedInput }) => {
     try {
       const updated = await updateCheckin(parsedInput)
@@ -880,7 +880,7 @@ const _updateCheckinAction = adminActionClient
 
 const _deleteCheckinAction = adminActionClient
   .metadata({ actionName: 'deleteCheckinAction' })
-  .inputSchema(DeleteCheckinSchema)
+  .schema(DeleteCheckinSchema)
   .action(async ({ parsedInput }) => {
     try {
       await deleteCheckin(parsedInput.checkInId)

--- a/app/admin/dugsi/teachers/actions.ts
+++ b/app/admin/dugsi/teachers/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
+import { after } from 'next/server'
 
 import { Prisma, Program, Shift } from '@prisma/client'
 import { z } from 'zod'
@@ -300,7 +301,7 @@ const _createTeacherAction = adminActionClient
         return newTeacher
       })
 
-      revalidatePath('/admin/dugsi/teachers')
+      after(() => revalidatePath('/admin/dugsi/teachers'))
 
       logger.info(
         {
@@ -364,7 +365,7 @@ const _createTeacherWithPersonAction = adminActionClient
         return newTeacher
       })
 
-      revalidatePath('/admin/dugsi/teachers')
+      after(() => revalidatePath('/admin/dugsi/teachers'))
 
       logger.info(
         {
@@ -410,7 +411,7 @@ const _deleteTeacherAction = adminActionClient
     const { teacherId } = parsedInput
     await deleteTeacher(teacherId)
 
-    revalidatePath('/admin/teachers')
+    after(() => revalidatePath('/admin/teachers'))
 
     logger.info({ teacherId }, 'Teacher deleted')
   })
@@ -435,7 +436,7 @@ const _updateTeacherDetailsAction = adminActionClient
 
       await updatePersonContact(teacher.personId, personData)
 
-      revalidatePath('/admin/dugsi/teachers')
+      after(() => revalidatePath('/admin/dugsi/teachers'))
 
       logger.info({ teacherId, name }, 'Teacher details updated')
 
@@ -502,7 +503,7 @@ const _updateTeacherShiftsAction = adminActionClient
 
     await updateTeacherProgramShifts(teacherProgram.id, shifts)
 
-    revalidatePath('/admin/dugsi/teachers')
+    after(() => revalidatePath('/admin/dugsi/teachers'))
 
     logger.info({ teacherId, shifts }, 'Teacher shifts updated')
 
@@ -549,7 +550,7 @@ const _deactivateTeacherAction = adminActionClient
       })
     })
 
-    revalidatePath('/admin/dugsi/teachers')
+    after(() => revalidatePath('/admin/dugsi/teachers'))
 
     logger.info({ teacherId }, 'Teacher deactivated from Dugsi')
   })
@@ -565,10 +566,12 @@ const _assignTeacherToProgramAction = adminActionClient
     try {
       await assignTeacherToProgram(parsedInput)
 
-      revalidatePath('/admin/teachers')
-      revalidatePath(
-        `/admin/${parsedInput.program.toLowerCase().replace('_program', '')}`
-      )
+      after(() => {
+        revalidatePath('/admin/teachers')
+        revalidatePath(
+          `/admin/${parsedInput.program.toLowerCase().replace('_program', '')}`
+        )
+      })
 
       logger.info(
         { teacherId: parsedInput.teacherId, program: parsedInput.program },
@@ -607,10 +610,12 @@ const _removeTeacherFromProgramAction = adminActionClient
 
     await removeTeacherFromProgram(parsedInput)
 
-    revalidatePath('/admin/teachers')
-    revalidatePath(
-      `/admin/${parsedInput.program.toLowerCase().replace('_program', '')}`
-    )
+    after(() => {
+      revalidatePath('/admin/teachers')
+      revalidatePath(
+        `/admin/${parsedInput.program.toLowerCase().replace('_program', '')}`
+      )
+    })
 
     logger.info(
       { teacherId: parsedInput.teacherId, program: parsedInput.program },
@@ -625,9 +630,13 @@ const _bulkAssignProgramsAction = adminActionClient
     const { teacherId, programs } = parsedInput
     await bulkAssignPrograms(teacherId, programs)
 
-    revalidatePath('/admin/teachers')
-    programs.forEach((program) => {
-      revalidatePath(`/admin/${program.toLowerCase().replace('_program', '')}`)
+    after(() => {
+      revalidatePath('/admin/teachers')
+      programs.forEach((program) => {
+        revalidatePath(
+          `/admin/${program.toLowerCase().replace('_program', '')}`
+        )
+      })
     })
 
     logger.info(
@@ -862,7 +871,7 @@ const _updateCheckinAction = adminActionClient
       const updated = await updateCheckin(parsedInput)
       const record = mapCheckinToRecord(updated)
 
-      revalidatePath('/admin/dugsi/teachers')
+      after(() => revalidatePath('/admin/dugsi/teachers'))
 
       logger.info(
         { checkInId: parsedInput.checkInId },
@@ -885,7 +894,7 @@ const _deleteCheckinAction = adminActionClient
     try {
       await deleteCheckin(parsedInput.checkInId)
 
-      revalidatePath('/admin/dugsi/teachers')
+      after(() => revalidatePath('/admin/dugsi/teachers'))
 
       logger.info(
         { checkInId: parsedInput.checkInId },

--- a/app/admin/link-subscriptions/actions.ts
+++ b/app/admin/link-subscriptions/actions.ts
@@ -58,7 +58,7 @@ const searchStudentsSchema = z.object({
 
 const _searchStudents = adminActionClient
   .metadata({ actionName: 'searchStudents' })
-  .inputSchema(searchStudentsSchema)
+  .schema(searchStudentsSchema)
   .action(async ({ parsedInput }) => {
     return await searchStudentsForLinking(
       parsedInput.query,
@@ -73,7 +73,7 @@ const getPotentialMatchesSchema = z.object({
 
 const _getPotentialMatches = adminActionClient
   .metadata({ actionName: 'getPotentialMatches' })
-  .inputSchema(getPotentialMatchesSchema)
+  .schema(getPotentialMatchesSchema)
   .action(async ({ parsedInput }) => {
     return await getPotentialStudentMatches(
       parsedInput.email,
@@ -89,7 +89,7 @@ const linkSubscriptionToStudentSchema = z.object({
 
 const _linkSubscriptionToStudent = adminActionClient
   .metadata({ actionName: 'linkSubscriptionToStudent' })
-  .inputSchema(linkSubscriptionToStudentSchema)
+  .schema(linkSubscriptionToStudentSchema)
   .action(async ({ parsedInput }) => {
     const { subscriptionId, studentId, program } = parsedInput
     const result = await linkSubscriptionToProfile(
@@ -123,7 +123,7 @@ const ignoreSubscriptionSchema = z.object({
 
 const _ignoreSubscription = adminActionClient
   .metadata({ actionName: 'ignoreSubscription' })
-  .inputSchema(ignoreSubscriptionSchema)
+  .schema(ignoreSubscriptionSchema)
   .action(async ({ parsedInput }) => {
     const { subscriptionId, program, reason } = parsedInput
     const result = await ignoreSubscriptionService(
@@ -155,7 +155,7 @@ const unignoreSubscriptionSchema = z.object({
 
 const _unignoreSubscription = adminActionClient
   .metadata({ actionName: 'unignoreSubscription' })
-  .inputSchema(unignoreSubscriptionSchema)
+  .schema(unignoreSubscriptionSchema)
   .action(async ({ parsedInput }) => {
     const { subscriptionId, program } = parsedInput
     const result = await unignoreSubscriptionService(subscriptionId, program)

--- a/app/admin/login/actions.ts
+++ b/app/admin/login/actions.ts
@@ -17,7 +17,7 @@ const logger = createActionLogger('admin-auth')
 
 const _validateAdminPin = rateLimitedActionClient
   .metadata({ actionName: 'validateAdminPin' })
-  .inputSchema(adminPinSchema)
+  .schema(adminPinSchema)
   .action(async ({ parsedInput: { pin, redirectTo } }) => {
     const expectedPin = process.env.ADMIN_PIN
 

--- a/app/admin/mahad/_actions/index.ts
+++ b/app/admin/mahad/_actions/index.ts
@@ -140,7 +140,7 @@ const paymentLinkWithOverrideInputSchema = z.object({
 
 const _createBatchAction = adminActionClient
   .metadata({ actionName: 'createBatchAction' })
-  .inputSchema(createBatchInputSchema)
+  .schema(createBatchInputSchema)
   .action(async ({ parsedInput }) => {
     const validated = CreateBatchSchema.parse({
       name: parsedInput.name,
@@ -182,7 +182,7 @@ export async function createBatchAction(
 
 const _deleteBatchAction = adminActionClient
   .metadata({ actionName: 'deleteBatchAction' })
-  .inputSchema(deleteBatchInputSchema)
+  .schema(deleteBatchInputSchema)
   .action(async ({ parsedInput }) => {
     const batch = await getBatchById(parsedInput.id)
     if (!batch) {
@@ -226,7 +226,7 @@ export async function deleteBatchAction(
 
 const _updateBatchAction = adminActionClient
   .metadata({ actionName: 'updateBatchAction' })
-  .inputSchema(updateBatchInputSchema)
+  .schema(updateBatchInputSchema)
   .action(async ({ parsedInput }) => {
     const { id, ...data } = parsedInput
     const validated = UpdateBatchSchema.parse(data)
@@ -277,7 +277,7 @@ export async function updateBatchAction(
 
 const _assignStudentsAction = adminActionClient
   .metadata({ actionName: 'assignStudentsAction' })
-  .inputSchema(BatchAssignmentSchema)
+  .schema(BatchAssignmentSchema)
   .action(async ({ parsedInput }) => {
     const batch = await getBatchById(parsedInput.batchId)
     if (!batch) {
@@ -325,7 +325,7 @@ export async function assignStudentsAction(
 
 const _transferStudentsAction = adminActionClient
   .metadata({ actionName: 'transferStudentsAction' })
-  .inputSchema(BatchTransferSchema)
+  .schema(BatchTransferSchema)
   .action(async ({ parsedInput }) => {
     const [fromBatch, toBatch] = await Promise.all([
       getBatchById(parsedInput.fromBatchId),
@@ -404,7 +404,7 @@ export async function transferStudentsAction(
 
 const _resolveDuplicatesAction = adminActionClient
   .metadata({ actionName: 'resolveDuplicatesAction' })
-  .inputSchema(resolveDuplicatesInputSchema)
+  .schema(resolveDuplicatesInputSchema)
   .action(async ({ parsedInput }) => {
     const { keepId, deleteIds, mergeData } = parsedInput
 
@@ -472,7 +472,7 @@ export async function resolveDuplicatesAction(
 
 const _getStudentDeleteWarningsAction = adminActionClient
   .metadata({ actionName: 'getStudentDeleteWarningsAction' })
-  .inputSchema(studentIdInputSchema)
+  .schema(studentIdInputSchema)
   .action(async ({ parsedInput }): Promise<DeleteWarnings> => {
     const warnings = await getStudentDeleteWarnings(parsedInput.id)
     return warnings
@@ -486,7 +486,7 @@ export async function getStudentDeleteWarningsAction(
 
 const _deleteStudentAction = adminActionClient
   .metadata({ actionName: 'deleteStudentAction' })
-  .inputSchema(studentIdInputSchema)
+  .schema(studentIdInputSchema)
   .action(async ({ parsedInput }) => {
     const student = await getStudentById(parsedInput.id)
     if (!student) {
@@ -544,7 +544,7 @@ export async function deleteStudentAction(
 
 const _bulkDeleteStudentsAction = adminActionClient
   .metadata({ actionName: 'bulkDeleteStudentsAction' })
-  .inputSchema(bulkDeleteInputSchema)
+  .schema(bulkDeleteInputSchema)
   .action(async ({ parsedInput }): Promise<BulkDeleteResult> => {
     const { studentIds } = parsedInput
 
@@ -606,7 +606,7 @@ export async function bulkDeleteStudentsAction(
 
 const _updateStudentAction = adminActionClient
   .metadata({ actionName: 'updateStudentAction' })
-  .inputSchema(updateStudentInputSchema)
+  .schema(updateStudentInputSchema)
   .action(async ({ parsedInput }) => {
     const { id, ...data } = parsedInput
     const validated = UpdateStudentSchema.parse(data)
@@ -915,7 +915,7 @@ async function createPaymentLinkSession(
  */
 const _generatePaymentLinkAction = adminActionClient
   .metadata({ actionName: 'generatePaymentLinkAction' })
-  .inputSchema(paymentLinkInputSchema)
+  .schema(paymentLinkInputSchema)
   .action(async ({ parsedInput }): Promise<PaymentLinkData> => {
     return createPaymentLinkSession(parsedInput.profileId)
   })
@@ -928,7 +928,7 @@ export async function generatePaymentLinkAction(
 
 const _generatePaymentLinkWithDefaultsAction = adminActionClient
   .metadata({ actionName: 'generatePaymentLinkWithDefaultsAction' })
-  .inputSchema(paymentLinkInputSchema)
+  .schema(paymentLinkInputSchema)
   .action(async ({ parsedInput }): Promise<PaymentLinkData> => {
     const { profileId } = parsedInput
 
@@ -1005,7 +1005,7 @@ export interface PaymentLinkWithOverrideData {
  */
 const _generatePaymentLinkWithOverrideAction = adminActionClient
   .metadata({ actionName: 'generatePaymentLinkWithOverrideAction' })
-  .inputSchema(paymentLinkWithOverrideInputSchema)
+  .schema(paymentLinkWithOverrideInputSchema)
   .action(async ({ parsedInput }): Promise<PaymentLinkWithOverrideData> => {
     const { profileId, overrideAmount, billingStartDate } = parsedInput
 

--- a/app/admin/mahad/_actions/index.ts
+++ b/app/admin/mahad/_actions/index.ts
@@ -158,6 +158,7 @@ const _createBatchAction = adminActionClient
 
       after(() => {
         revalidateTag('mahad-stats')
+        revalidateTag('mahad-students')
         revalidatePath('/admin/mahad')
       })
 
@@ -212,6 +213,7 @@ const _deleteBatchAction = adminActionClient
 
     after(() => {
       revalidateTag('mahad-stats')
+      revalidateTag('mahad-students')
       revalidatePath('/admin/mahad')
     })
   })
@@ -244,6 +246,7 @@ const _updateBatchAction = adminActionClient
 
       after(() => {
         revalidateTag('mahad-stats')
+        revalidateTag('mahad-students')
         revalidatePath('/admin/mahad')
       })
 
@@ -289,6 +292,7 @@ const _assignStudentsAction = adminActionClient
 
       after(() => {
         revalidateTag('mahad-stats')
+        revalidateTag('mahad-students')
         revalidatePath('/admin/mahad')
       })
 
@@ -362,6 +366,7 @@ const _transferStudentsAction = adminActionClient
 
       after(() => {
         revalidateTag('mahad-stats')
+        revalidateTag('mahad-students')
         revalidatePath('/admin/mahad')
       })
 
@@ -450,6 +455,7 @@ const _resolveDuplicatesAction = adminActionClient
 
     after(() => {
       revalidateTag('mahad-stats')
+      revalidateTag('mahad-students')
       revalidatePath('/admin/mahad')
     })
   })
@@ -525,6 +531,7 @@ const _deleteStudentAction = adminActionClient
 
     after(() => {
       revalidateTag('mahad-stats')
+      revalidateTag('mahad-students')
       revalidatePath('/admin/mahad')
     })
   })
@@ -576,6 +583,7 @@ const _bulkDeleteStudentsAction = adminActionClient
     if (deletedCount > 0) {
       after(() => {
         revalidateTag('mahad-stats')
+        revalidateTag('mahad-students')
         revalidatePath('/admin/mahad')
       })
     }
@@ -721,6 +729,7 @@ const _updateStudentAction = adminActionClient
 
     after(() => {
       revalidateTag('mahad-stats')
+      revalidateTag('mahad-students')
       revalidatePath('/admin/mahad')
     })
   })
@@ -951,6 +960,7 @@ const _generatePaymentLinkWithDefaultsAction = adminActionClient
 
     after(() => {
       revalidateTag('mahad-stats')
+      revalidateTag('mahad-students')
       revalidatePath('/admin/mahad')
     })
 

--- a/app/admin/mahad/_actions/vcard-actions.ts
+++ b/app/admin/mahad/_actions/vcard-actions.ts
@@ -14,7 +14,7 @@ import {
 
 const _generateMahadVCardContent = adminActionClient
   .metadata({ actionName: 'generateMahadVCardContent' })
-  .inputSchema(z.object({ batchId: z.string().uuid().optional() }))
+  .schema(z.object({ batchId: z.string().uuid().optional() }))
   .action(async ({ parsedInput }): Promise<VCardResult> => {
     const { batchId } = parsedInput
     const students = batchId

--- a/app/admin/mahad/page.tsx
+++ b/app/admin/mahad/page.tsx
@@ -4,7 +4,7 @@ import { Metadata } from 'next'
 
 import { AppErrorBoundary } from '@/components/error-boundary'
 import { getBatches } from '@/lib/db/queries/batch'
-import { getStudentsWithBatch } from '@/lib/db/queries/student'
+import { getCachedStudentsWithBatch } from '@/lib/db/queries/student'
 
 import { MahadDashboard } from './components/mahad-dashboard'
 
@@ -43,7 +43,7 @@ function Loading() {
 export default async function MahadCohortsPage() {
   const [batches, students] = await Promise.all([
     getBatches(),
-    getStudentsWithBatch(),
+    getCachedStudentsWithBatch(),
   ])
 
   return (

--- a/app/admin/people/lookup/actions.ts
+++ b/app/admin/people/lookup/actions.ts
@@ -71,6 +71,7 @@ export const deletePersonAction = adminActionClient
       revalidatePath('/admin/people')
       revalidatePath('/admin/teachers')
       revalidatePath('/admin/dugsi')
+      revalidateTag('dugsi-registrations')
       revalidateTag('mahad-stats')
       revalidateTag('mahad-students')
       revalidatePath('/admin/mahad')

--- a/app/admin/people/lookup/actions.ts
+++ b/app/admin/people/lookup/actions.ts
@@ -61,7 +61,7 @@ export interface PersonLookupResult {
 
 export const deletePersonAction = adminActionClient
   .metadata({ actionName: 'deletePersonAction' })
-  .inputSchema(z.object({ personId: z.string().uuid('Invalid person ID') }))
+  .schema(z.object({ personId: z.string().uuid('Invalid person ID') }))
   .action(async ({ parsedInput: { personId } }) => {
     await deletePerson(personId)
 
@@ -76,7 +76,7 @@ export const deletePersonAction = adminActionClient
 
 export const lookupPersonAction = adminActionClient
   .metadata({ actionName: 'lookupPersonAction' })
-  .inputSchema(z.object({ query: z.string().min(1) }))
+  .schema(z.object({ query: z.string().min(1) }))
   .action(async ({ parsedInput: { query } }) => {
     if (query.trim().length < 2) {
       return null

--- a/app/admin/people/lookup/actions.ts
+++ b/app/admin/people/lookup/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { revalidatePath, revalidateTag } from 'next/cache'
+import { after } from 'next/server'
 
 import { Program } from '@prisma/client'
 import { z } from 'zod'
@@ -65,13 +66,15 @@ export const deletePersonAction = adminActionClient
   .action(async ({ parsedInput: { personId } }) => {
     await deletePerson(personId)
 
-    revalidatePath('/admin/people/lookup')
-    revalidatePath('/admin/people')
-    revalidatePath('/admin/teachers')
-    revalidatePath('/admin/dugsi')
-    revalidateTag('mahad-stats')
-    revalidateTag('mahad-students')
-    revalidatePath('/admin/mahad')
+    after(() => {
+      revalidatePath('/admin/people/lookup')
+      revalidatePath('/admin/people')
+      revalidatePath('/admin/teachers')
+      revalidatePath('/admin/dugsi')
+      revalidateTag('mahad-stats')
+      revalidateTag('mahad-students')
+      revalidatePath('/admin/mahad')
+    })
   })
 
 export const lookupPersonAction = adminActionClient

--- a/app/admin/people/lookup/actions.ts
+++ b/app/admin/people/lookup/actions.ts
@@ -70,6 +70,7 @@ export const deletePersonAction = adminActionClient
     revalidatePath('/admin/teachers')
     revalidatePath('/admin/dugsi')
     revalidateTag('mahad-stats')
+    revalidateTag('mahad-students')
     revalidatePath('/admin/mahad')
   })
 

--- a/app/api/dugsi/create-checkout-session/route.ts
+++ b/app/api/dugsi/create-checkout-session/route.ts
@@ -16,6 +16,7 @@ import { NextRequest, NextResponse } from 'next/server'
 
 import { z } from 'zod'
 
+import { assertAdmin } from '@/lib/auth'
 import { ActionError } from '@/lib/errors/action-error'
 import { createServiceLogger, logError, logWarning } from '@/lib/logger'
 import { createDugsiCheckoutSession } from '@/lib/services/dugsi'
@@ -24,6 +25,8 @@ import { DugsiCheckoutRequestSchema } from '@/lib/validations/dugsi-checkout'
 const logger = createServiceLogger('dugsi-checkout')
 
 export async function POST(request: NextRequest) {
+  await assertAdmin()
+
   let requestContext: Record<string, unknown> = {}
 
   try {

--- a/app/donate/actions.ts
+++ b/app/donate/actions.ts
@@ -7,7 +7,7 @@ import { DonationCheckoutSchema } from '@/lib/validations/donation'
 
 const _createDonationAction = rateLimitedActionClient
   .metadata({ actionName: 'createDonationAction' })
-  .inputSchema(DonationCheckoutSchema)
+  .schema(DonationCheckoutSchema)
   .action(async ({ parsedInput }) => {
     const session = await createDonationCheckoutSession(parsedInput)
     if (!session.url) {

--- a/app/dugsi/register/_actions/index.ts
+++ b/app/dugsi/register/_actions/index.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { revalidatePath, revalidateTag } from 'next/cache'
+import { after } from 'next/server'
 
 import { returnValidationErrors } from 'next-safe-action'
 
@@ -34,14 +35,22 @@ const _registerDugsiChildren = rateLimitedActionClient
         parent1LastName: validated.parent1LastName,
         parent2Email: validated.isSingleParent ? null : validated.parent2Email,
         parent2Phone: validated.isSingleParent ? null : validated.parent2Phone,
-        parent2FirstName: validated.isSingleParent ? null : validated.parent2FirstName,
-        parent2LastName: validated.isSingleParent ? null : validated.parent2LastName,
-        primaryPayer: validated.isSingleParent ? 'parent1' : validated.primaryPayer,
+        parent2FirstName: validated.isSingleParent
+          ? null
+          : validated.parent2FirstName,
+        parent2LastName: validated.isSingleParent
+          ? null
+          : validated.parent2LastName,
+        primaryPayer: validated.isSingleParent
+          ? 'parent1'
+          : validated.primaryPayer,
         familyReferenceId,
       })
 
-      revalidatePath('/admin/dugsi')
-      revalidateTag('dugsi-registrations')
+      after(() => {
+        revalidatePath('/admin/dugsi')
+        revalidateTag('dugsi-registrations')
+      })
 
       return {
         familyId: familyReferenceId,

--- a/app/dugsi/register/_actions/index.ts
+++ b/app/dugsi/register/_actions/index.ts
@@ -1,10 +1,12 @@
 'use server'
 
 import { revalidatePath, revalidateTag } from 'next/cache'
+import { headers } from 'next/headers'
 import { after } from 'next/server'
 
 import { returnValidationErrors } from 'next-safe-action'
 
+import { checkRateLimit } from '@/lib/auth/rate-limit'
 import { ActionError } from '@/lib/errors/action-error'
 import { dugsiRegistrationSchema } from '@/lib/registration/schemas/registration'
 import { rateLimitedActionClient } from '@/lib/safe-action'
@@ -81,6 +83,14 @@ export async function registerDugsiChildren(
 
 export async function checkParentEmailExists(email: string): Promise<boolean> {
   try {
+    const headerStore = await headers()
+    const ip = headerStore.get('x-forwarded-for')?.split(',')[0]?.trim()
+    if (ip) {
+      const rateResult = await checkRateLimit(`parent-email-check:${ip}`, 10)
+      if (!rateResult.success) {
+        return false
+      }
+    }
     const existing = await findGuardianByEmail(email)
     return existing !== null
   } catch {

--- a/app/dugsi/register/_actions/index.ts
+++ b/app/dugsi/register/_actions/index.ts
@@ -1,150 +1,81 @@
 'use server'
 
-/**
- * Dugsi Registration Server Actions
- *
- * Handles family registration for the Dugsi program.
- * Creates Person records for parents and children, links them via GuardianRelationship,
- * creates ProgramProfiles with DUGSI_PROGRAM, and sets up billing accounts.
- */
-
 import { revalidatePath, revalidateTag } from 'next/cache'
 
-import { z } from 'zod'
+import { returnValidationErrors } from 'next-safe-action'
 
 import { ActionError } from '@/lib/errors/action-error'
-import { createActionLogger, logError } from '@/lib/logger'
 import { dugsiRegistrationSchema } from '@/lib/registration/schemas/registration'
+import { rateLimitedActionClient } from '@/lib/safe-action'
 import { createFamilyRegistration } from '@/lib/services/registration-service'
 import { findGuardianByEmail } from '@/lib/services/shared/parent-service'
 
-const logger = createActionLogger('dugsi-registration')
-
-export type RegistrationResult = {
-  success: boolean
-  error?: string
-  errors?: Record<string, string[]>
-  redirectUrl?: string
-  data?: {
-    paymentUrl?: string
-    familyId?: string
-    children: { id: string; name: string }[]
-    count: number
-  }
-}
-
-/**
- * Register children for the Dugsi program.
- *
- * Creates:
- * - Parent Person records (email, phone)
- * - Child Person records
- * - ProgramProfiles for each child (program = DUGSI_PROGRAM)
- * - Enrollments (status = REGISTERED)
- * - GuardianRelationships linking parents to children
- * - BillingAccount for the primary parent
- * - SiblingRelationships between children
- *
- * @param input - Validated form data from dugsiRegistrationSchema
- * @returns RegistrationResult with success status and created data
- */
-export async function registerDugsiChildren(
-  input: z.infer<typeof dugsiRegistrationSchema>
-): Promise<RegistrationResult> {
-  try {
-    // Validate input at server boundary
-    const validated = dugsiRegistrationSchema.parse(input)
-
-    // Generate a unique family reference ID to group siblings
+const _registerDugsiChildren = rateLimitedActionClient
+  .metadata({ actionName: 'registerDugsiChildren' })
+  .schema(dugsiRegistrationSchema)
+  .action(async ({ parsedInput: validated }) => {
     const familyReferenceId = crypto.randomUUID()
 
-    // Transform form data to match createFamilyRegistration service expectations
-    const result = await createFamilyRegistration({
-      children: validated.children.map((child) => ({
-        firstName: child.firstName,
-        lastName: child.lastName,
-        dateOfBirth: child.dateOfBirth,
-        gender: child.gender,
-        gradeLevel: child.gradeLevel,
-        shift: child.shift,
-        schoolName: child.schoolName || null,
-        healthInfo: child.healthInfo || null,
-      })),
-      parent1Email: validated.parent1Email,
-      parent1Phone: validated.parent1Phone,
-      parent1FirstName: validated.parent1FirstName,
-      parent1LastName: validated.parent1LastName,
-      // Only include parent 2 if not single parent
-      parent2Email: validated.isSingleParent ? null : validated.parent2Email,
-      parent2Phone: validated.isSingleParent ? null : validated.parent2Phone,
-      parent2FirstName: validated.isSingleParent
-        ? null
-        : validated.parent2FirstName,
-      parent2LastName: validated.isSingleParent
-        ? null
-        : validated.parent2LastName,
-      primaryPayer: validated.isSingleParent
-        ? 'parent1'
-        : validated.primaryPayer,
-      familyReferenceId,
-    })
+    try {
+      const result = await createFamilyRegistration({
+        children: validated.children.map((child) => ({
+          firstName: child.firstName,
+          lastName: child.lastName,
+          dateOfBirth: child.dateOfBirth,
+          gender: child.gender,
+          gradeLevel: child.gradeLevel,
+          shift: child.shift,
+          schoolName: child.schoolName || null,
+          healthInfo: child.healthInfo || null,
+        })),
+        parent1Email: validated.parent1Email,
+        parent1Phone: validated.parent1Phone,
+        parent1FirstName: validated.parent1FirstName,
+        parent1LastName: validated.parent1LastName,
+        parent2Email: validated.isSingleParent ? null : validated.parent2Email,
+        parent2Phone: validated.isSingleParent ? null : validated.parent2Phone,
+        parent2FirstName: validated.isSingleParent ? null : validated.parent2FirstName,
+        parent2LastName: validated.isSingleParent ? null : validated.parent2LastName,
+        primaryPayer: validated.isSingleParent ? 'parent1' : validated.primaryPayer,
+        familyReferenceId,
+      })
 
-    revalidatePath('/admin/dugsi')
-    revalidateTag('dugsi-registrations')
+      revalidatePath('/admin/dugsi')
+      revalidateTag('dugsi-registrations')
 
-    return {
-      success: true,
-      data: {
+      return {
         familyId: familyReferenceId,
         children: result.profiles.map((p) => ({ id: p.id, name: p.name })),
         count: result.profiles.length,
-      },
-    }
-  } catch (error) {
-    if (error instanceof z.ZodError) {
-      return {
-        success: false,
-        errors: error.flatten().fieldErrors as Record<string, string[]>,
       }
+    } catch (error) {
+      if (error instanceof ActionError && error.field) {
+        if (error.field === 'email' || error.field === 'parent1Email') {
+          returnValidationErrors(dugsiRegistrationSchema, {
+            parent1Email: { _errors: [error.message] },
+          })
+        }
+        if (error.field === 'phone' || error.field === 'parent1Phone') {
+          returnValidationErrors(dugsiRegistrationSchema, {
+            parent1Phone: { _errors: [error.message] },
+          })
+        }
+      }
+      throw error
     }
+  })
 
-    if (error instanceof ActionError && error.field) {
-      // Map generic field name to form field; default to parent1 since we
-      // can't know which parent caused the conflict from the P2002 target alone.
-      const fieldMap: Record<string, string> = {
-        email: 'parent1Email',
-        phone: 'parent1Phone',
-      }
-      const formField = fieldMap[error.field] ?? error.field
-      return {
-        success: false,
-        error: error.message,
-        errors: { [formField]: [error.message] },
-      }
-    }
-
-    await logError(logger, error, 'Dugsi registration failed')
-    return {
-      success: false,
-      error: error instanceof Error ? error.message : 'Registration failed',
-    }
-  }
+export async function registerDugsiChildren(
+  ...args: Parameters<typeof _registerDugsiChildren>
+) {
+  return _registerDugsiChildren(...args)
 }
 
-/**
- * Check if a parent email already exists in the system.
- *
- * Used for duplicate detection and family matching during registration.
- *
- * @param email - Email address to check
- * @returns true if email exists, false otherwise
- */
 export async function checkParentEmailExists(email: string): Promise<boolean> {
   try {
     const existing = await findGuardianByEmail(email)
     return existing !== null
   } catch {
-    // If check fails, allow registration to continue
     return false
   }
 }

--- a/app/dugsi/register/_actions/index.ts
+++ b/app/dugsi/register/_actions/index.ts
@@ -63,8 +63,7 @@ const _registerDugsiChildren = rateLimitedActionClient
           returnValidationErrors(dugsiRegistrationSchema, {
             parent1Email: { _errors: [error.message] },
           })
-        }
-        if (error.field === 'phone' || error.field === 'parent1Phone') {
+        } else if (error.field === 'phone' || error.field === 'parent1Phone') {
           returnValidationErrors(dugsiRegistrationSchema, {
             parent1Phone: { _errors: [error.message] },
           })

--- a/app/dugsi/register/_actions/index.ts
+++ b/app/dugsi/register/_actions/index.ts
@@ -70,6 +70,10 @@ const _registerDugsiChildren = rateLimitedActionClient
           returnValidationErrors(dugsiRegistrationSchema, {
             parent1Phone: { _errors: [error.message] },
           })
+        } else {
+          returnValidationErrors(dugsiRegistrationSchema, {
+            parent1Email: { _errors: [error.message] },
+          })
         }
       } else if (
         error instanceof Prisma.PrismaClientKnownRequestError &&

--- a/app/dugsi/register/_actions/index.ts
+++ b/app/dugsi/register/_actions/index.ts
@@ -110,9 +110,10 @@ export async function checkParentEmailExists(email: string): Promise<boolean> {
         return false
       }
     }
-    const existing = await findGuardianByEmail(email)
-    return existing !== null
   } catch {
-    return false
+    // Fail open if headers/rate-limit unavailable
   }
+
+  const existing = await findGuardianByEmail(email)
+  return existing !== null
 }

--- a/app/dugsi/register/_actions/index.ts
+++ b/app/dugsi/register/_actions/index.ts
@@ -7,7 +7,6 @@ import { after } from 'next/server'
 import { Prisma } from '@prisma/client'
 import { returnValidationErrors } from 'next-safe-action'
 
-
 import { checkRateLimit } from '@/lib/auth/rate-limit'
 import { ActionError } from '@/lib/errors/action-error'
 import { dugsiRegistrationSchema } from '@/lib/registration/schemas/registration'

--- a/app/dugsi/register/_actions/index.ts
+++ b/app/dugsi/register/_actions/index.ts
@@ -4,7 +4,9 @@ import { revalidatePath, revalidateTag } from 'next/cache'
 import { headers } from 'next/headers'
 import { after } from 'next/server'
 
+import { Prisma } from '@prisma/client'
 import { returnValidationErrors } from 'next-safe-action'
+
 
 import { checkRateLimit } from '@/lib/auth/rate-limit'
 import { ActionError } from '@/lib/errors/action-error'
@@ -68,6 +70,24 @@ const _registerDugsiChildren = rateLimitedActionClient
         } else if (error.field === 'phone' || error.field === 'parent1Phone') {
           returnValidationErrors(dugsiRegistrationSchema, {
             parent1Phone: { _errors: [error.message] },
+          })
+        }
+      } else if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        const target = (error.meta?.target as string[]) ?? []
+        if (target.some((f) => f.includes('phone'))) {
+          returnValidationErrors(dugsiRegistrationSchema, {
+            parent1Phone: {
+              _errors: ['This phone is already registered to another family'],
+            },
+          })
+        } else {
+          returnValidationErrors(dugsiRegistrationSchema, {
+            parent1Email: {
+              _errors: ['This email is already registered to another family'],
+            },
           })
         }
       }

--- a/app/dugsi/register/_hooks/use-registration.ts
+++ b/app/dugsi/register/_hooks/use-registration.ts
@@ -18,7 +18,6 @@ interface UseDugsiRegistrationProps {
   onSuccess?: (data: {
     children: Array<{ id: string; name: string }>
     count: number
-    paymentUrl?: string
     familyId?: string
   }) => void
 }
@@ -39,63 +38,34 @@ export function useDugsiRegistration({
         try {
           const result = await registerDugsiChildren(formData)
 
-          if (!result.success) {
-            // Handle validation errors
-            if (result.errors) {
-              // Set field errors if available
-              Object.entries(result.errors).forEach(([field, messages]) => {
-                if (messages && messages.length > 0) {
-                  form.setError(field as keyof DugsiRegistrationValues, {
-                    type: 'manual',
-                    message: messages[0],
-                  })
-                }
-              })
+          if (result?.validationErrors) {
+            for (const [field, fieldErrors] of Object.entries(result.validationErrors)) {
+              const errors = fieldErrors as { _errors?: string[] }
+              if (errors._errors?.[0]) {
+                form.setError(field as keyof DugsiRegistrationValues, {
+                  type: 'manual',
+                  message: errors._errors[0],
+                })
+              }
             }
-
-            // Show error toast
-            toast.error(result.error || t('messages.enrollmentError'))
+            toast.error(t('messages.enrollmentError'))
             return
           }
 
-          // Success handling
-          if (result.data?.paymentUrl) {
-            // Show informative message before redirect
-            const childText =
-              formData.children.length === 1
-                ? t('childrenSection.child')
-                : t('childrenSection.children')
-
-            toast.success(
-              `Registration saved for ${formData.children.length} ${childText}. Redirecting to complete payment...`,
-              {
-                duration: 2500,
-              }
-            )
-
-            // Call onSuccess callback if provided
-            if (onSuccess && result.data) {
-              onSuccess(result.data)
-            }
-
-            // Redirect to Stripe payment
-            setTimeout(() => {
-              window.location.href = result.data!.paymentUrl!
-            }, 1500) // Brief delay to show message
-          } else {
-            // Success without payment URL - redirect to success page
-            const familyId = result.data?.familyId
-
-            // Call onSuccess callback if provided
-            if (onSuccess && result.data) {
-              onSuccess(result.data)
-            }
-
-            // Redirect to success page
-            router.push(
-              `/dugsi/register/success${familyId ? `?familyId=${familyId}` : ''}`
-            )
+          if (result?.serverError) {
+            toast.error(result.serverError)
+            return
           }
+
+          if (!result?.data) return
+
+          if (onSuccess) {
+            onSuccess(result.data)
+          }
+
+          router.push(
+            `/dugsi/register/success${result.data.familyId ? `?familyId=${result.data.familyId}` : ''}`
+          )
         } catch (error) {
           logger.error('Unexpected error during registration:', error)
           toast.error(

--- a/app/mahad/register/_actions/__tests__/index.test.ts
+++ b/app/mahad/register/_actions/__tests__/index.test.ts
@@ -65,10 +65,29 @@ vi.mock('@/lib/logger', () => ({
 
 vi.mock('@/lib/safe-action', () => ({
   rateLimitedActionClient: {
-    metadata: () => ({
-      schema: (schema: { safeParse: (input: unknown) => { success: boolean; data?: unknown; error?: { flatten: () => { fieldErrors: Record<string, string[]> } } } }) => ({
-        action: (handler: (opts: { parsedInput: unknown }) => Promise<unknown>) =>
+    metadata: (meta: { actionName: string }) => ({
+      schema: (schema: {
+        safeParse: (input: unknown) => {
+          success: boolean
+          data?: unknown
+          error?: { flatten: () => { fieldErrors: Record<string, string[]> } }
+        }
+      }) => ({
+        action:
+          (handler: (opts: { parsedInput: unknown }) => Promise<unknown>) =>
           async (input: unknown) => {
+            const h = await mockHeaders()
+            const ip = h.get('x-forwarded-for')?.split(',')[0]?.trim()
+            if (ip) {
+              const rateResult = await mockCheckRateLimit(
+                `${meta.actionName}:${ip}`
+              )
+              if (!rateResult.success) {
+                return {
+                  serverError: 'Too many attempts. Please try again later.',
+                }
+              }
+            }
             const parsed = schema.safeParse(input)
             if (!parsed.success) {
               return { validationErrors: parsed.error!.flatten().fieldErrors }
@@ -77,7 +96,10 @@ vi.mock('@/lib/safe-action', () => ({
               return { data: await handler({ parsedInput: parsed.data }) }
             } catch (e) {
               if (e instanceof Error && 'validationErrors' in e) {
-                return { validationErrors: (e as Error & { validationErrors: unknown }).validationErrors }
+                return {
+                  validationErrors: (e as Error & { validationErrors: unknown })
+                    .validationErrors,
+                }
               }
               return { serverError: e instanceof Error ? e.message : String(e) }
             }
@@ -104,7 +126,11 @@ describe('registerStudent', () => {
     vi.clearAllMocks()
     mockAfter.mockImplementation((fn: () => void) => fn())
     mockHeaders.mockResolvedValue(new Headers({ 'x-forwarded-for': '1.2.3.4' }))
-    mockCheckRateLimit.mockResolvedValue({ success: true, remaining: 9, reset: 0 })
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      remaining: 9,
+      reset: 0,
+    })
     mockIsEmailRegistered.mockResolvedValue(false)
   })
 
@@ -150,7 +176,10 @@ describe('registerStudent', () => {
   })
 
   it('should return validationErrors for invalid email', async () => {
-    const result = await registerStudent({ ...validInput, email: 'not-an-email' })
+    const result = await registerStudent({
+      ...validInput,
+      email: 'not-an-email',
+    })
 
     expect(result?.validationErrors?.email).toBeDefined()
   })
@@ -166,7 +195,10 @@ describe('registerStudent', () => {
     const result = await registerStudent(validInput)
 
     expect(result?.validationErrors).toBeDefined()
-    expect((result?.validationErrors as { email?: { _errors: string[] } })?.email?._errors?.[0]).toContain('email')
+    expect(
+      (result?.validationErrors as { email?: { _errors: string[] } })?.email
+        ?._errors?.[0]
+    ).toContain('email')
   })
 
   it('should return validationErrors for P2002 duplicate phone', async () => {
@@ -180,36 +212,51 @@ describe('registerStudent', () => {
     const result = await registerStudent(validInput)
 
     expect(result?.validationErrors).toBeDefined()
-    expect((result?.validationErrors as { phone?: { _errors: string[] } })?.phone?._errors?.[0]).toContain('phone')
+    expect(
+      (result?.validationErrors as { phone?: { _errors: string[] } })?.phone
+        ?._errors?.[0]
+    ).toContain('phone')
   })
 
   it('should return validationErrors for ActionError with email field', async () => {
     const { ActionError } = await import('@/lib/errors/action-error')
     mockCreateMahadStudent.mockRejectedValue(
-      new ActionError('Student already registered for Mahad', 'DUPLICATE_CONTACT', 'email', 409)
+      new ActionError(
+        'Student already registered for Mahad',
+        'DUPLICATE_CONTACT',
+        'email',
+        409
+      )
     )
 
     const result = await registerStudent(validInput)
 
     expect(result?.validationErrors).toBeDefined()
-    expect((result?.validationErrors as { email?: { _errors: string[] } })?.email?._errors?.[0]).toBe(
-      'Student already registered for Mahad'
-    )
+    expect(
+      (result?.validationErrors as { email?: { _errors: string[] } })?.email
+        ?._errors?.[0]
+    ).toBe('Student already registered for Mahad')
     expect(result?.serverError).toBeUndefined()
   })
 
   it('should return validationErrors for ActionError with phone field', async () => {
     const { ActionError } = await import('@/lib/errors/action-error')
     mockCreateMahadStudent.mockRejectedValue(
-      new ActionError('Student already registered for Mahad', 'DUPLICATE_CONTACT', 'phone', 409)
+      new ActionError(
+        'Student already registered for Mahad',
+        'DUPLICATE_CONTACT',
+        'phone',
+        409
+      )
     )
 
     const result = await registerStudent(validInput)
 
     expect(result?.validationErrors).toBeDefined()
-    expect((result?.validationErrors as { phone?: { _errors: string[] } })?.phone?._errors?.[0]).toBe(
-      'Student already registered for Mahad'
-    )
+    expect(
+      (result?.validationErrors as { phone?: { _errors: string[] } })?.phone
+        ?._errors?.[0]
+    ).toBe('Student already registered for Mahad')
   })
 
   it('should not log ActionError as server error', async () => {
@@ -223,8 +270,23 @@ describe('registerStudent', () => {
     expect(mockLogError).not.toHaveBeenCalled()
   })
 
+  it('should return serverError when rate limited', async () => {
+    mockCheckRateLimit.mockResolvedValue({
+      success: false,
+      remaining: 0,
+      reset: 0,
+    })
+
+    const result = await registerStudent(validInput)
+
+    expect(result?.serverError).toContain('Too many attempts')
+    expect(mockCreateMahadStudent).not.toHaveBeenCalled()
+  })
+
   it('should return serverError for unexpected errors', async () => {
-    mockCreateMahadStudent.mockRejectedValue(new Error('Database connection lost'))
+    mockCreateMahadStudent.mockRejectedValue(
+      new Error('Database connection lost')
+    )
 
     const result = await registerStudent(validInput)
 
@@ -237,7 +299,11 @@ describe('checkEmailExists', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockHeaders.mockResolvedValue(new Headers({ 'x-forwarded-for': '1.2.3.4' }))
-    mockCheckRateLimit.mockResolvedValue({ success: true, remaining: 9, reset: 0 })
+    mockCheckRateLimit.mockResolvedValue({
+      success: true,
+      remaining: 9,
+      reset: 0,
+    })
   })
 
   it('should return true when email is registered', async () => {
@@ -246,7 +312,10 @@ describe('checkEmailExists', () => {
     const result = await checkEmailExists('test@example.com')
 
     expect(result).toBe(true)
-    expect(mockIsEmailRegistered).toHaveBeenCalledWith('test@example.com', 'MAHAD_PROGRAM')
+    expect(mockIsEmailRegistered).toHaveBeenCalledWith(
+      'test@example.com',
+      'MAHAD_PROGRAM'
+    )
   })
 
   it('should return false when email does not exist', async () => {
@@ -277,7 +346,11 @@ describe('checkEmailExists', () => {
   })
 
   it('should return false (fail open) when rate limited', async () => {
-    mockCheckRateLimit.mockResolvedValue({ success: false, remaining: 0, reset: 0 })
+    mockCheckRateLimit.mockResolvedValue({
+      success: false,
+      remaining: 0,
+      reset: 0,
+    })
 
     const result = await checkEmailExists('test@example.com')
 

--- a/app/mahad/register/_actions/__tests__/index.test.ts
+++ b/app/mahad/register/_actions/__tests__/index.test.ts
@@ -77,15 +77,14 @@ vi.mock('@/lib/safe-action', () => ({
           (handler: (opts: { parsedInput: unknown }) => Promise<unknown>) =>
           async (input: unknown) => {
             const h = await mockHeaders()
-            const ip = h.get('x-forwarded-for')?.split(',')[0]?.trim()
-            if (ip) {
-              const rateResult = await mockCheckRateLimit(
-                `${meta.actionName}:${ip}`
-              )
-              if (!rateResult.success) {
-                return {
-                  serverError: 'Too many attempts. Please try again later.',
-                }
+            const ip =
+              h.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+            const rateResult = await mockCheckRateLimit(
+              `${meta.actionName}:${ip}`
+            )
+            if (!rateResult.success) {
+              return {
+                serverError: 'Too many attempts. Please try again later.',
               }
             }
             const parsed = schema.safeParse(input)

--- a/app/mahad/register/_actions/__tests__/index.test.ts
+++ b/app/mahad/register/_actions/__tests__/index.test.ts
@@ -100,7 +100,11 @@ vi.mock('@/lib/safe-action', () => ({
                     .validationErrors,
                 }
               }
-              return { serverError: e instanceof Error ? e.message : String(e) }
+              // ActionError extends Error and always has a `code` property
+              if (e instanceof Error && 'code' in e) {
+                return { serverError: e.message }
+              }
+              return { serverError: 'Something went wrong' }
             }
           },
       }),
@@ -289,7 +293,7 @@ describe('registerStudent', () => {
 
     const result = await registerStudent(validInput)
 
-    expect(result?.serverError).toBe('Database connection lost')
+    expect(result?.serverError).toBe('Something went wrong')
     expect(result?.data).toBeUndefined()
   })
 })

--- a/app/mahad/register/_actions/__tests__/index.test.ts
+++ b/app/mahad/register/_actions/__tests__/index.test.ts
@@ -63,6 +63,30 @@ vi.mock('@/lib/logger', () => ({
   logError: (...args: unknown[]) => mockLogError(...args),
 }))
 
+vi.mock('@/lib/safe-action', () => ({
+  rateLimitedActionClient: {
+    metadata: () => ({
+      schema: (schema: { safeParse: (input: unknown) => { success: boolean; data?: unknown; error?: { flatten: () => { fieldErrors: Record<string, string[]> } } } }) => ({
+        action: (handler: (opts: { parsedInput: unknown }) => Promise<unknown>) =>
+          async (input: unknown) => {
+            const parsed = schema.safeParse(input)
+            if (!parsed.success) {
+              return { validationErrors: parsed.error!.flatten().fieldErrors }
+            }
+            try {
+              return { data: await handler({ parsedInput: parsed.data }) }
+            } catch (e) {
+              if (e instanceof Error && 'validationErrors' in e) {
+                return { validationErrors: (e as Error & { validationErrors: unknown }).validationErrors }
+              }
+              return { serverError: e instanceof Error ? e.message : String(e) }
+            }
+          },
+      }),
+    }),
+  },
+}))
+
 import { registerStudent, checkEmailExists } from '../index'
 
 const validInput = {
@@ -80,11 +104,7 @@ describe('registerStudent', () => {
     vi.clearAllMocks()
     mockAfter.mockImplementation((fn: () => void) => fn())
     mockHeaders.mockResolvedValue(new Headers({ 'x-forwarded-for': '1.2.3.4' }))
-    mockCheckRateLimit.mockResolvedValue({
-      success: true,
-      remaining: 9,
-      reset: 0,
-    })
+    mockCheckRateLimit.mockResolvedValue({ success: true, remaining: 9, reset: 0 })
     mockIsEmailRegistered.mockResolvedValue(false)
   })
 
@@ -94,11 +114,7 @@ describe('registerStudent', () => {
 
     const result = await registerStudent(validInput)
 
-    expect(result.success).toBe(true)
-    expect(result.data).toEqual({
-      id: 'profile-123',
-      name: 'Ahmed Mohamed',
-    })
+    expect(result?.data).toEqual({ id: 'profile-123', name: 'Ahmed Mohamed' })
     expect(mockCreateMahadStudent).toHaveBeenCalledWith({
       name: 'Ahmed Mohamed',
       email: 'ahmed@example.com',
@@ -122,104 +138,84 @@ describe('registerStudent', () => {
     const afterCallback = mockAfter.mock.calls[0][0] as () => void
     afterCallback()
     expect(mockRevalidateTag).toHaveBeenCalledWith('mahad-stats')
+    expect(mockRevalidateTag).toHaveBeenCalledWith('mahad-students')
     expect(mockRevalidatePath).toHaveBeenCalledWith('/admin/mahad')
   })
 
-  it('should return validation error for invalid data', async () => {
-    const result = await registerStudent({
-      ...validInput,
-      firstName: '',
-    })
+  it('should return validationErrors for invalid data', async () => {
+    const result = await registerStudent({ ...validInput, firstName: '' })
 
-    expect(result.success).toBe(false)
-    expect(result.error).toBeDefined()
+    expect(result?.validationErrors).toBeDefined()
     expect(mockCreateMahadStudent).not.toHaveBeenCalled()
   })
 
-  it('should return validation error for invalid email', async () => {
-    const result = await registerStudent({
-      ...validInput,
-      email: 'not-an-email',
-    })
+  it('should return validationErrors for invalid email', async () => {
+    const result = await registerStudent({ ...validInput, email: 'not-an-email' })
 
-    expect(result.success).toBe(false)
-    expect(result.errors?.email).toBeDefined()
+    expect(result?.validationErrors?.email).toBeDefined()
   })
 
-  it('should handle P2002 duplicate error from database', async () => {
+  it('should return validationErrors for P2002 duplicate email', async () => {
     const { Prisma } = await import('@prisma/client')
     const prismaError = new Prisma.PrismaClientKnownRequestError(
       'Unique constraint failed',
-      { code: 'P2002', clientVersion: '5.0.0' }
+      { code: 'P2002', clientVersion: '5.0.0', meta: { target: ['email'] } }
     )
     mockCreateMahadStudent.mockRejectedValue(prismaError)
 
     const result = await registerStudent(validInput)
 
-    expect(result.success).toBe(false)
-    expect(result.error).toContain('already exists')
-    expect(result.errors).toBeUndefined()
+    expect(result?.validationErrors).toBeDefined()
+    expect((result?.validationErrors as { email?: { _errors: string[] } })?.email?._errors?.[0]).toContain('email')
   })
 
-  it('should handle ActionError with field-level errors defaulting to email', async () => {
+  it('should return validationErrors for P2002 duplicate phone', async () => {
+    const { Prisma } = await import('@prisma/client')
+    const prismaError = new Prisma.PrismaClientKnownRequestError(
+      'Unique constraint failed',
+      { code: 'P2002', clientVersion: '5.0.0', meta: { target: ['phone'] } }
+    )
+    mockCreateMahadStudent.mockRejectedValue(prismaError)
+
+    const result = await registerStudent(validInput)
+
+    expect(result?.validationErrors).toBeDefined()
+    expect((result?.validationErrors as { phone?: { _errors: string[] } })?.phone?._errors?.[0]).toContain('phone')
+  })
+
+  it('should return validationErrors for ActionError with email field', async () => {
     const { ActionError } = await import('@/lib/errors/action-error')
     mockCreateMahadStudent.mockRejectedValue(
-      new ActionError(
-        'Student already registered for Mahad',
-        'DUPLICATE_CONTACT',
-        'email',
-        409
-      )
+      new ActionError('Student already registered for Mahad', 'DUPLICATE_CONTACT', 'email', 409)
     )
 
     const result = await registerStudent(validInput)
 
-    expect(result.success).toBe(false)
-    expect(result.error).toBe('Student already registered for Mahad')
-    expect(result.errors?.email).toEqual([
-      'Student already registered for Mahad',
-    ])
-    expect(mockLogError).not.toHaveBeenCalled()
+    expect(result?.validationErrors).toBeDefined()
+    expect((result?.validationErrors as { email?: { _errors: string[] } })?.email?._errors?.[0]).toBe(
+      'Student already registered for Mahad'
+    )
+    expect(result?.serverError).toBeUndefined()
   })
 
-  it('should map ActionError field to correct form field for phone duplicates', async () => {
+  it('should return validationErrors for ActionError with phone field', async () => {
     const { ActionError } = await import('@/lib/errors/action-error')
     mockCreateMahadStudent.mockRejectedValue(
-      new ActionError(
-        'Student already registered for Mahad',
-        'DUPLICATE_CONTACT',
-        'phone',
-        409
-      )
+      new ActionError('Student already registered for Mahad', 'DUPLICATE_CONTACT', 'phone', 409)
     )
 
     const result = await registerStudent(validInput)
 
-    expect(result.success).toBe(false)
-    expect(result.errors?.phone).toEqual([
-      'Student already registered for Mahad',
-    ])
-    expect(result.errors?.email).toBeUndefined()
-  })
-
-  it('should rate limit registerStudent', async () => {
-    mockCheckRateLimit.mockResolvedValue({
-      success: false,
-      remaining: 0,
-      reset: 0,
-    })
-
-    const result = await registerStudent(validInput)
-
-    expect(result.success).toBe(false)
-    expect(result.error).toContain('Too many registration attempts')
-    expect(mockCreateMahadStudent).not.toHaveBeenCalled()
+    expect(result?.validationErrors).toBeDefined()
+    expect((result?.validationErrors as { phone?: { _errors: string[] } })?.phone?._errors?.[0]).toBe(
+      'Student already registered for Mahad'
+    )
   })
 
   it('should not log ActionError as server error', async () => {
     const { ActionError } = await import('@/lib/errors/action-error')
     mockCreateMahadStudent.mockRejectedValue(
-      new ActionError('Duplicate', 'DUPLICATE_CONTACT')
+      new ActionError('Duplicate', 'DUPLICATE_CONTACT', 'email')
     )
 
     await registerStudent(validInput)
@@ -227,16 +223,13 @@ describe('registerStudent', () => {
     expect(mockLogError).not.toHaveBeenCalled()
   })
 
-  it('should handle unexpected errors', async () => {
-    mockCreateMahadStudent.mockRejectedValue(
-      new Error('Database connection lost')
-    )
+  it('should return serverError for unexpected errors', async () => {
+    mockCreateMahadStudent.mockRejectedValue(new Error('Database connection lost'))
 
     const result = await registerStudent(validInput)
 
-    expect(result.success).toBe(false)
-    expect(result.error).toBe('Registration failed. Please try again.')
-    expect(mockLogError).toHaveBeenCalled()
+    expect(result?.serverError).toBe('Database connection lost')
+    expect(result?.data).toBeUndefined()
   })
 })
 
@@ -244,11 +237,7 @@ describe('checkEmailExists', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     mockHeaders.mockResolvedValue(new Headers({ 'x-forwarded-for': '1.2.3.4' }))
-    mockCheckRateLimit.mockResolvedValue({
-      success: true,
-      remaining: 9,
-      reset: 0,
-    })
+    mockCheckRateLimit.mockResolvedValue({ success: true, remaining: 9, reset: 0 })
   })
 
   it('should return true when email is registered', async () => {
@@ -257,10 +246,7 @@ describe('checkEmailExists', () => {
     const result = await checkEmailExists('test@example.com')
 
     expect(result).toBe(true)
-    expect(mockIsEmailRegistered).toHaveBeenCalledWith(
-      'test@example.com',
-      'MAHAD_PROGRAM'
-    )
+    expect(mockIsEmailRegistered).toHaveBeenCalledWith('test@example.com', 'MAHAD_PROGRAM')
   })
 
   it('should return false when email does not exist', async () => {
@@ -279,17 +265,6 @@ describe('checkEmailExists', () => {
     expect(mockCheckRateLimit).toHaveBeenCalledWith('email-check:1.2.3.4', 10)
   })
 
-  it('should pass email through to isEmailRegistered for normalization', async () => {
-    mockIsEmailRegistered.mockResolvedValue(true)
-
-    await checkEmailExists('Test@Example.COM')
-
-    expect(mockIsEmailRegistered).toHaveBeenCalledWith(
-      'Test@Example.COM',
-      'MAHAD_PROGRAM'
-    )
-  })
-
   it('should skip rate limiting when IP is unavailable', async () => {
     mockHeaders.mockResolvedValue(new Headers())
     mockIsEmailRegistered.mockResolvedValue(false)
@@ -302,11 +277,7 @@ describe('checkEmailExists', () => {
   })
 
   it('should return false (fail open) when rate limited', async () => {
-    mockCheckRateLimit.mockResolvedValue({
-      success: false,
-      remaining: 0,
-      reset: 0,
-    })
+    mockCheckRateLimit.mockResolvedValue({ success: false, remaining: 0, reset: 0 })
 
     const result = await checkEmailExists('test@example.com')
 

--- a/app/mahad/register/_actions/index.ts
+++ b/app/mahad/register/_actions/index.ts
@@ -1,130 +1,92 @@
 'use server'
 
+import { after } from 'next/server'
 import { revalidatePath, revalidateTag } from 'next/cache'
 import { headers } from 'next/headers'
-import { after } from 'next/server'
 
 import { Prisma } from '@prisma/client'
+import { returnValidationErrors } from 'next-safe-action'
 
 import { checkRateLimit } from '@/lib/auth/rate-limit'
 import { MAHAD_PROGRAM } from '@/lib/constants/mahad'
 import { ActionError } from '@/lib/errors/action-error'
-import { createActionLogger, logError } from '@/lib/logger'
-import {
-  mahadRegistrationSchema,
-  type MahadRegistrationValues,
-} from '@/lib/registration/schemas/registration'
+import { createActionLogger } from '@/lib/logger'
+import { mahadRegistrationSchema } from '@/lib/registration/schemas/registration'
+import { rateLimitedActionClient } from '@/lib/safe-action'
 import { DuplicateDetectionService } from '@/lib/services/duplicate-detection-service'
 import { createMahadStudent } from '@/lib/services/mahad/student-service'
-type RegistrationResult<T = void> = {
-  success: boolean
-  data?: T
-  error?: string
-  errors?: Partial<Record<string, string[]>>
-}
 
 const logger = createActionLogger('mahad-registration')
 
-export async function registerStudent(
-  studentData: MahadRegistrationValues
-): Promise<RegistrationResult<{ id: string; name: string }>> {
-  try {
-    const validationResult = mahadRegistrationSchema.safeParse(studentData)
-    if (!validationResult.success) {
-      const firstError = validationResult.error.errors[0]
-      const field = firstError.path[0] as string
-      return {
-        success: false,
-        error: firstError.message,
-        errors: field ? { [field]: [firstError.message] } : undefined,
-      }
-    }
-
-    try {
-      const headerStore = await headers()
-      const ip = headerStore.get('x-forwarded-for')?.split(',')[0]?.trim()
-      if (ip) {
-        const rateResult = await checkRateLimit(`register:${ip}`)
-        if (!rateResult.success) {
-          return {
-            success: false,
-            error: 'Too many registration attempts. Please try again later.',
-          }
-        }
-      }
-    } catch {
-      // Fail open if headers/rate-limit unavailable
-    }
-
-    const data = validationResult.data
+const _registerStudent = rateLimitedActionClient
+  .metadata({ actionName: 'registerStudent' })
+  .schema(mahadRegistrationSchema)
+  .action(async ({ parsedInput: data }) => {
     const fullName = `${data.firstName} ${data.lastName}`.trim()
 
-    const profile = await createMahadStudent({
-      name: fullName,
-      email: data.email,
-      phone: data.phone,
-      dateOfBirth: data.dateOfBirth,
-      gradeLevel: data.gradeLevel,
-      schoolName: data.schoolName,
-      graduationStatus: data.graduationStatus,
-      paymentFrequency: data.paymentFrequency,
-    })
-
-    after(() => {
-      revalidateTag('mahad-stats')
-      revalidatePath('/admin/mahad')
-    })
-
-    logger.info(
-      { profileId: profile.id, name: fullName },
-      'Student registration completed'
-    )
-
-    return {
-      success: true,
-      data: {
-        id: profile.id,
+    try {
+      const profile = await createMahadStudent({
         name: fullName,
-      },
-    }
-  } catch (error) {
-    if (error instanceof ActionError) {
-      return {
-        success: false,
-        error: error.message,
-        errors: error.field
-          ? { [error.field]: [error.message] }
-          : { email: [error.message] },
+        email: data.email,
+        phone: data.phone,
+        dateOfBirth: data.dateOfBirth,
+        gradeLevel: data.gradeLevel,
+        schoolName: data.schoolName,
+        graduationStatus: data.graduationStatus,
+        paymentFrequency: data.paymentFrequency,
+      })
+
+      after(() => {
+        revalidateTag('mahad-stats')
+        revalidateTag('mahad-students')
+        revalidatePath('/admin/mahad')
+      })
+
+      logger.info({ profileId: profile.id, name: fullName }, 'Student registration completed')
+
+      return { id: profile.id, name: fullName }
+    } catch (error) {
+      if (error instanceof ActionError) {
+        if (error.field === 'phone') {
+          returnValidationErrors(mahadRegistrationSchema, {
+            phone: { _errors: [error.message] },
+          })
+        }
+        returnValidationErrors(mahadRegistrationSchema, {
+          email: { _errors: [error.message] },
+        })
       }
-    }
-    if (
-      error instanceof Prisma.PrismaClientKnownRequestError &&
-      error.code === 'P2002'
-    ) {
-      const target = (error.meta?.target as string[]) ?? []
-      const field = target.includes('email')
-        ? 'email'
-        : target.includes('phone')
-          ? 'phone'
-          : undefined
-      const msg = field
-        ? `This ${field} is already registered to another student`
-        : 'A student with this contact information already exists'
-      return {
-        success: false,
-        error: msg,
-        errors: field ? { [field]: [msg] } : undefined,
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === 'P2002'
+      ) {
+        const target = (error.meta?.target as string[]) ?? []
+        if (target.includes('phone')) {
+          returnValidationErrors(mahadRegistrationSchema, {
+            phone: { _errors: ['This phone is already registered to another student'] },
+          })
+        }
+        returnValidationErrors(mahadRegistrationSchema, {
+          email: {
+            _errors: [
+              target.includes('email')
+                ? 'This email is already registered to another student'
+                : 'A student with this contact information already exists',
+            ],
+          },
+        })
       }
+      throw error
     }
-    await logError(logger, error, 'Mahad registration failed')
-    return {
-      success: false,
-      error: 'Registration failed. Please try again.',
-    }
-  }
+  })
+
+export async function registerStudent(
+  ...args: Parameters<typeof _registerStudent>
+) {
+  return _registerStudent(...args)
 }
 
-// Returns boolean (not ActionResult<boolean>) because the client-side
+// Returns boolean (not a safe-action result) because the client-side
 // useEmailValidation hook expects a plain boolean for inline field validation.
 export async function checkEmailExists(email: string): Promise<boolean> {
   try {

--- a/app/mahad/register/_actions/index.ts
+++ b/app/mahad/register/_actions/index.ts
@@ -59,8 +59,7 @@ const _registerStudent = rateLimitedActionClient
             email: { _errors: [error.message] },
           })
         }
-      }
-      if (
+      } else if (
         error instanceof Prisma.PrismaClientKnownRequestError &&
         error.code === 'P2002'
       ) {

--- a/app/mahad/register/_actions/index.ts
+++ b/app/mahad/register/_actions/index.ts
@@ -1,8 +1,8 @@
 'use server'
 
-import { after } from 'next/server'
 import { revalidatePath, revalidateTag } from 'next/cache'
 import { headers } from 'next/headers'
+import { after } from 'next/server'
 
 import { Prisma } from '@prisma/client'
 import { returnValidationErrors } from 'next-safe-action'
@@ -42,7 +42,10 @@ const _registerStudent = rateLimitedActionClient
         revalidatePath('/admin/mahad')
       })
 
-      logger.info({ profileId: profile.id, name: fullName }, 'Student registration completed')
+      logger.info(
+        { profileId: profile.id, name: fullName },
+        'Student registration completed'
+      )
 
       return { id: profile.id, name: fullName }
     } catch (error) {
@@ -51,10 +54,11 @@ const _registerStudent = rateLimitedActionClient
           returnValidationErrors(mahadRegistrationSchema, {
             phone: { _errors: [error.message] },
           })
+        } else {
+          returnValidationErrors(mahadRegistrationSchema, {
+            email: { _errors: [error.message] },
+          })
         }
-        returnValidationErrors(mahadRegistrationSchema, {
-          email: { _errors: [error.message] },
-        })
       }
       if (
         error instanceof Prisma.PrismaClientKnownRequestError &&
@@ -63,18 +67,21 @@ const _registerStudent = rateLimitedActionClient
         const target = (error.meta?.target as string[]) ?? []
         if (target.includes('phone')) {
           returnValidationErrors(mahadRegistrationSchema, {
-            phone: { _errors: ['This phone is already registered to another student'] },
+            phone: {
+              _errors: ['This phone is already registered to another student'],
+            },
+          })
+        } else {
+          returnValidationErrors(mahadRegistrationSchema, {
+            email: {
+              _errors: [
+                target.includes('email')
+                  ? 'This email is already registered to another student'
+                  : 'A student with this contact information already exists',
+              ],
+            },
           })
         }
-        returnValidationErrors(mahadRegistrationSchema, {
-          email: {
-            _errors: [
-              target.includes('email')
-                ? 'This email is already registered to another student'
-                : 'A student with this contact information already exists',
-            ],
-          },
-        })
       }
       throw error
     }

--- a/app/mahad/register/_actions/index.ts
+++ b/app/mahad/register/_actions/index.ts
@@ -49,7 +49,7 @@ const _registerStudent = rateLimitedActionClient
 
       return { id: profile.id, name: fullName }
     } catch (error) {
-      if (error instanceof ActionError) {
+      if (error instanceof ActionError && error.field) {
         if (error.field === 'phone') {
           returnValidationErrors(mahadRegistrationSchema, {
             phone: { _errors: [error.message] },

--- a/app/mahad/register/_hooks/use-registration.ts
+++ b/app/mahad/register/_hooks/use-registration.ts
@@ -26,29 +26,32 @@ export function useRegistration({
         try {
           const result = await registerStudentAction(formData)
 
-          if (!result.success) {
-            if (result.errors) {
-              for (const [field, messages] of Object.entries(result.errors)) {
-                if (messages?.[0]) {
-                  form.setError(field as FieldPath<MahadRegistrationValues>, {
-                    type: 'manual',
-                    message: messages[0],
-                  })
-                }
+          if (result?.validationErrors) {
+            for (const [field, fieldErrors] of Object.entries(result.validationErrors)) {
+              const errors = fieldErrors as { _errors?: string[] }
+              if (errors._errors?.[0]) {
+                form.setError(field as FieldPath<MahadRegistrationValues>, {
+                  type: 'manual',
+                  message: errors._errors[0],
+                })
               }
             }
-            toast.error(
-              result.error || 'Registration failed. Please try again.'
-            )
+            toast.error('Please correct the errors above.')
             return
           }
 
-          toast.success('Registration complete!')
-          form.reset()
-          const name = result.data?.name ?? ''
-          router.push(
-            `/mahad/register/success?name=${encodeURIComponent(name)}`
-          )
+          if (result?.serverError) {
+            toast.error(result.serverError)
+            return
+          }
+
+          if (result?.data) {
+            toast.success('Registration complete!')
+            form.reset()
+            router.push(
+              `/mahad/register/success?name=${encodeURIComponent(result.data.name)}`
+            )
+          }
         } catch (error) {
           logger.error('Registration error:', error)
           toast.error(

--- a/app/mahad/scholarship/_actions/index.tsx
+++ b/app/mahad/scholarship/_actions/index.tsx
@@ -2,8 +2,11 @@
 
 import React from 'react'
 
+import { headers } from 'next/headers'
+
 import { render } from '@react-email/components'
 
+import { checkRateLimit } from '@/lib/auth/rate-limit'
 import {
   sendEmail,
   sendConfirmationEmail,
@@ -46,6 +49,23 @@ export async function submitScholarshipApplication(
   formData: unknown
 ): Promise<SubmitScholarshipResult> {
   try {
+    try {
+      const headerStore = await headers()
+      const ip = headerStore.get('x-forwarded-for')?.split(',')[0]?.trim()
+      if (ip) {
+        const rateResult = await checkRateLimit(`scholarship-submit:${ip}`, 5)
+        if (!rateResult.success) {
+          return {
+            success: false,
+            error: 'Too many attempts. Please try again later.',
+            code: ERROR_CODES.RATE_LIMIT_EXCEEDED,
+          }
+        }
+      }
+    } catch {
+      // Fail open if headers/rate-limit unavailable
+    }
+
     // 1. Validate data server-side (never trust client - accept unknown, validate runtime)
     const validation = scholarshipApplicationSchema.safeParse(formData)
 

--- a/app/teacher/checkin/__tests__/actions.test.ts
+++ b/app/teacher/checkin/__tests__/actions.test.ts
@@ -1,6 +1,6 @@
 import { Shift } from '@prisma/client'
-import { z } from 'zod'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
+import { z } from 'zod'
 
 import { CHECKIN_ERROR_CODES } from '@/lib/constants/teacher-checkin'
 import { ActionError } from '@/lib/errors/action-error'
@@ -54,6 +54,7 @@ vi.mock('@/lib/safe-action', () => {
 })
 
 const {
+  mockAfter,
   mockRevalidatePath,
   mockGetTeachersForDropdown,
   mockGetTeacherCheckin,
@@ -62,6 +63,7 @@ const {
   mockCalculateDistance,
   mockIsWithinGeofence,
 } = vi.hoisted(() => ({
+  mockAfter: vi.fn(),
   mockRevalidatePath: vi.fn(),
   mockGetTeachersForDropdown: vi.fn(),
   mockGetTeacherCheckin: vi.fn(),
@@ -73,6 +75,10 @@ const {
 
 vi.mock('next/cache', () => ({
   revalidatePath: (...args: unknown[]) => mockRevalidatePath(...args),
+}))
+
+vi.mock('next/server', () => ({
+  after: (fn: () => void) => mockAfter(fn),
 }))
 
 vi.mock('@/lib/db/queries/teacher-checkin', () => ({
@@ -220,6 +226,7 @@ describe('getTeacherCurrentStatus', () => {
 describe('teacherClockInAction', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAfter.mockImplementation((fn: () => void) => fn())
     mockClockIn.mockResolvedValue({ checkIn: mockCheckin })
     mockGetTeacherCheckin.mockResolvedValue(null)
   })
@@ -357,6 +364,7 @@ describe('teacherClockOutAction', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockAfter.mockImplementation((fn: () => void) => fn())
     mockClockOut.mockResolvedValue({ checkIn: clockedOutCheckin })
     mockGetTeacherCheckin.mockResolvedValue(clockedOutCheckin)
   })

--- a/app/teacher/checkin/actions.ts
+++ b/app/teacher/checkin/actions.ts
@@ -70,7 +70,7 @@ export async function getTeacherCurrentStatus(
 
 const _teacherClockInAction = rateLimitedActionClient
   .metadata({ actionName: 'teacherClockInAction' })
-  .inputSchema(ClockInSchema)
+  .schema(ClockInSchema)
   .action(async ({ parsedInput }) => {
     try {
       const result = await clockIn(parsedInput)
@@ -108,7 +108,7 @@ export async function teacherClockInAction(
 
 const _teacherClockOutAction = rateLimitedActionClient
   .metadata({ actionName: 'teacherClockOutAction' })
-  .inputSchema(ClockOutSchema)
+  .schema(ClockOutSchema)
   .action(async ({ parsedInput }) => {
     try {
       await clockOut(parsedInput)

--- a/app/teacher/checkin/actions.ts
+++ b/app/teacher/checkin/actions.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
+import { after } from 'next/server'
 
 import { Shift } from '@prisma/client'
 import { formatInTimeZone } from 'date-fns-tz'
@@ -74,8 +75,10 @@ const _teacherClockInAction = rateLimitedActionClient
   .action(async ({ parsedInput }) => {
     try {
       const result = await clockIn(parsedInput)
-      revalidatePath('/teacher/checkin')
-      revalidatePath('/admin/dugsi/teacher-checkins')
+      after(() => {
+        revalidatePath('/teacher/checkin')
+        revalidatePath('/admin/dugsi/teacher-checkins')
+      })
 
       const status = await getTeacherCurrentStatus(parsedInput.teacherId)
 
@@ -112,8 +115,10 @@ const _teacherClockOutAction = rateLimitedActionClient
   .action(async ({ parsedInput }) => {
     try {
       await clockOut(parsedInput)
-      revalidatePath('/teacher/checkin')
-      revalidatePath('/admin/dugsi/teacher-checkins')
+      after(() => {
+        revalidatePath('/teacher/checkin')
+        revalidatePath('/admin/dugsi/teacher-checkins')
+      })
 
       const status = await getTeacherCurrentStatus(parsedInput.teacherId)
 

--- a/app/zakat-fitr/actions.ts
+++ b/app/zakat-fitr/actions.ts
@@ -7,7 +7,7 @@ import { ZakatFitrCheckoutSchema } from '@/lib/validations/zakat-fitr'
 
 const _createZakatFitrAction = rateLimitedActionClient
   .metadata({ actionName: 'createZakatFitrAction' })
-  .inputSchema(ZakatFitrCheckoutSchema)
+  .schema(ZakatFitrCheckoutSchema)
   .action(async ({ parsedInput }) => {
     const session = await createZakatFitrCheckoutSession(parsedInput)
     if (!session.url) {

--- a/components/ui/data-table.tsx
+++ b/components/ui/data-table.tsx
@@ -49,7 +49,7 @@ export function DataTable<TData, TValue>({
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
     enableRowSelection: true,
-    getRowId: (row, index) => (row as any).id ?? String(index),
+    getRowId: (row, index) => (row as { id?: string }).id ?? String(index),
     onRowSelectionChange: (updaterOrValue) => {
       const newValue =
         typeof updaterOrValue === 'function'
@@ -71,7 +71,8 @@ export function DataTable<TData, TValue>({
           .map((rowId) => {
             // Find the row by ID (not index)
             return data.find((row) => {
-              const id = (row as any).id ?? String(data.indexOf(row))
+              const id =
+                (row as { id?: string }).id ?? String(data.indexOf(row))
               return id === rowId
             })
           })

--- a/lib/actions/get-batch-data.ts
+++ b/lib/actions/get-batch-data.ts
@@ -14,6 +14,7 @@ import {
   StudentBillingType,
 } from '@prisma/client'
 
+import { assertAdmin } from '@/lib/auth'
 import { MAHAD_PROGRAM } from '@/lib/constants/mahad'
 import { prisma } from '@/lib/db'
 import { createActionLogger, logError } from '@/lib/logger'
@@ -80,6 +81,7 @@ export interface DuplicateStudentGroup {
  * Used for batch management and reporting.
  */
 export async function getBatchData(): Promise<BatchStudentData[]> {
+  await assertAdmin()
   // Single query with nested sibling relationships (optimized from 2 queries)
   const enrollments = await prisma.enrollment.findMany({
     where: {
@@ -310,6 +312,7 @@ export async function getBatchData(): Promise<BatchStudentData[]> {
  * Find persons with multiple active Mahad program profiles (duplicate enrollments)
  */
 export async function getDuplicateStudents(): Promise<DuplicateStudentGroup[]> {
+  await assertAdmin()
   const people = await prisma.person.findMany({
     where: {
       programProfiles: {
@@ -356,6 +359,7 @@ export async function getDuplicateStudents(): Promise<DuplicateStudentGroup[]> {
 export async function deleteDuplicateRecords(
   profileIds: string[]
 ): Promise<{ success: boolean; deleted: number; error?: string }> {
+  await assertAdmin()
   try {
     if (profileIds.length === 0) {
       return { success: true, deleted: 0 }

--- a/lib/actions/update-student.ts
+++ b/lib/actions/update-student.ts
@@ -27,7 +27,7 @@ const updateStudentSchema = z.object({
 
 export const updateStudent = adminActionClient
   .metadata({ actionName: 'updateStudent' })
-  .inputSchema(updateStudentSchema)
+  .schema(updateStudentSchema)
   .action(async ({ parsedInput }) => {
     const { studentId, ...data } = parsedInput
     await updateMahadStudent(studentId, data)

--- a/lib/actions/update-student.ts
+++ b/lib/actions/update-student.ts
@@ -1,5 +1,8 @@
 'use server'
 
+import { revalidatePath, revalidateTag } from 'next/cache'
+import { after } from 'next/server'
+
 import {
   GradeLevel,
   GraduationStatus,
@@ -31,4 +34,9 @@ export const updateStudent = adminActionClient
   .action(async ({ parsedInput }) => {
     const { studentId, ...data } = parsedInput
     await updateMahadStudent(studentId, data)
+    after(() => {
+      revalidateTag('mahad-students')
+      revalidateTag('mahad-stats')
+      revalidatePath('/admin/mahad')
+    })
   })

--- a/lib/db/queries/donation.ts
+++ b/lib/db/queries/donation.ts
@@ -1,3 +1,5 @@
+import { unstable_cache } from 'next/cache'
+
 import { DonationStatus, Prisma, type Donation } from '@prisma/client'
 
 import { prisma } from '@/lib/db'
@@ -167,6 +169,12 @@ export async function getDonationStats(
     recurringPaymentCount: recurringCount,
   }
 }
+
+export const getCachedDonationStats = unstable_cache(
+  (options?: DonationStatsOptions) => getDonationStats(options),
+  ['donation-stats'],
+  { revalidate: 300, tags: ['donations'] }
+)
 
 export interface ZakatFitrStats {
   totalCollectedCents: number

--- a/lib/db/queries/person.ts
+++ b/lib/db/queries/person.ts
@@ -2,6 +2,7 @@ import { Prisma, Program } from '@prisma/client'
 
 import { prisma } from '@/lib/db'
 import { DatabaseClient } from '@/lib/db/types'
+import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
 import {
   normalizePhone,
   validateAndNormalizeEmail,
@@ -186,8 +187,28 @@ export async function updatePersonContact(
   data: PersonContactFields,
   client: DatabaseClient = prisma
 ): Promise<void> {
-  await client.person.update({
-    where: { id: personId },
-    data,
-  })
+  try {
+    await client.person.update({
+      where: { id: personId },
+      data,
+    })
+  } catch (error) {
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      if (error.code === 'P2025') {
+        throw new ActionError(
+          'Person not found',
+          ERROR_CODES.NOT_FOUND,
+          undefined,
+          404
+        )
+      }
+      if (error.code === 'P2002') {
+        throw new ActionError(
+          'This email or phone is already in use',
+          ERROR_CODES.DUPLICATE_CONTACT
+        )
+      }
+    }
+    throw error
+  }
 }

--- a/lib/db/queries/student.ts
+++ b/lib/db/queries/student.ts
@@ -23,7 +23,6 @@ import {
   SubscriptionStatus,
 } from '@prisma/client'
 
-
 import { prisma } from '@/lib/db'
 import { ACTIVE_BILLING_ASSIGNMENT_WHERE } from '@/lib/db/query-builders'
 import { DatabaseClient } from '@/lib/db/types'

--- a/lib/db/queries/student.ts
+++ b/lib/db/queries/student.ts
@@ -21,6 +21,8 @@ import {
   SubscriptionStatus,
 } from '@prisma/client'
 
+import { unstable_cache } from 'next/cache'
+
 import { prisma } from '@/lib/db'
 import { ACTIVE_BILLING_ASSIGNMENT_WHERE } from '@/lib/db/query-builders'
 import { DatabaseClient } from '@/lib/db/types'
@@ -244,6 +246,12 @@ export async function getStudentsWithBatch(client: DatabaseClient = prisma) {
 
   return profiles.map(transformToStudent)
 }
+
+export const getCachedStudentsWithBatch = unstable_cache(
+  getStudentsWithBatch,
+  ['mahad-students'],
+  { revalidate: 300, tags: ['mahad-students'] }
+)
 
 /**
  * Get students with batch info, filtering, and pagination

--- a/lib/db/queries/student.ts
+++ b/lib/db/queries/student.ts
@@ -11,6 +11,8 @@
  * - Maintains backward-compatible return types for UI components
  */
 
+import { unstable_cache } from 'next/cache'
+
 import {
   GradeLevel,
   GraduationStatus,
@@ -21,7 +23,6 @@ import {
   SubscriptionStatus,
 } from '@prisma/client'
 
-import { unstable_cache } from 'next/cache'
 
 import { prisma } from '@/lib/db'
 import { ACTIVE_BILLING_ASSIGNMENT_WHERE } from '@/lib/db/query-builders'
@@ -248,7 +249,7 @@ export async function getStudentsWithBatch(client: DatabaseClient = prisma) {
 }
 
 export const getCachedStudentsWithBatch = unstable_cache(
-  getStudentsWithBatch,
+  () => getStudentsWithBatch(),
   ['mahad-students'],
   { revalidate: 300, tags: ['mahad-students'] }
 )

--- a/lib/safe-action.ts
+++ b/lib/safe-action.ts
@@ -35,17 +35,16 @@ export const adminActionClient = actionClient.use(async ({ next }) => {
 export const rateLimitedActionClient = actionClient.use(
   async ({ next, metadata }) => {
     const headersList = await headers()
-    const ip = headersList.get('x-forwarded-for')?.split(',')[0]?.trim()
-    if (ip) {
-      const result = await checkRateLimit(`${metadata.actionName}:${ip}`)
-      if (!result.success) {
-        throw new ActionError(
-          'Too many attempts. Please try again later.',
-          ERROR_CODES.RATE_LIMIT_EXCEEDED,
-          undefined,
-          429
-        )
-      }
+    const ip =
+      headersList.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+    const result = await checkRateLimit(`${metadata.actionName}:${ip}`)
+    if (!result.success) {
+      throw new ActionError(
+        'Too many attempts. Please try again later.',
+        ERROR_CODES.RATE_LIMIT_EXCEEDED,
+        undefined,
+        429
+      )
     }
     return next()
   }
@@ -54,17 +53,16 @@ export const rateLimitedActionClient = actionClient.use(
 export const rateLimitedAdminActionClient = adminActionClient.use(
   async ({ next, metadata }) => {
     const headersList = await headers()
-    const ip = headersList.get('x-forwarded-for')?.split(',')[0]?.trim()
-    if (ip) {
-      const result = await checkRateLimit(`${metadata.actionName}:${ip}`)
-      if (!result.success) {
-        throw new ActionError(
-          'Too many attempts. Please try again later.',
-          ERROR_CODES.RATE_LIMIT_EXCEEDED,
-          undefined,
-          429
-        )
-      }
+    const ip =
+      headersList.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
+    const result = await checkRateLimit(`${metadata.actionName}:${ip}`)
+    if (!result.success) {
+      throw new ActionError(
+        'Too many attempts. Please try again later.',
+        ERROR_CODES.RATE_LIMIT_EXCEEDED,
+        undefined,
+        429
+      )
     }
     return next()
   }

--- a/lib/safe-action.ts
+++ b/lib/safe-action.ts
@@ -1,5 +1,6 @@
 import { headers } from 'next/headers'
 import { unstable_rethrow } from 'next/navigation'
+
 import { createSafeActionClient } from 'next-safe-action'
 import { z } from 'zod'
 
@@ -34,16 +35,17 @@ export const adminActionClient = actionClient.use(async ({ next }) => {
 export const rateLimitedActionClient = actionClient.use(
   async ({ next, metadata }) => {
     const headersList = await headers()
-    const ip = headersList.get('x-forwarded-for')?.split(',')[0] ?? 'unknown'
-    const key = `${metadata.actionName}:${ip}`
-    const result = await checkRateLimit(key)
-    if (!result.success) {
-      throw new ActionError(
-        'Too many attempts. Please try again later.',
-        ERROR_CODES.RATE_LIMIT_EXCEEDED,
-        undefined,
-        429
-      )
+    const ip = headersList.get('x-forwarded-for')?.split(',')[0]?.trim()
+    if (ip) {
+      const result = await checkRateLimit(`${metadata.actionName}:${ip}`)
+      if (!result.success) {
+        throw new ActionError(
+          'Too many attempts. Please try again later.',
+          ERROR_CODES.RATE_LIMIT_EXCEEDED,
+          undefined,
+          429
+        )
+      }
     }
     return next()
   }
@@ -52,16 +54,17 @@ export const rateLimitedActionClient = actionClient.use(
 export const rateLimitedAdminActionClient = adminActionClient.use(
   async ({ next, metadata }) => {
     const headersList = await headers()
-    const ip = headersList.get('x-forwarded-for')?.split(',')[0] ?? 'unknown'
-    const key = `${metadata.actionName}:${ip}`
-    const result = await checkRateLimit(key)
-    if (!result.success) {
-      throw new ActionError(
-        'Too many attempts. Please try again later.',
-        ERROR_CODES.RATE_LIMIT_EXCEEDED,
-        undefined,
-        429
-      )
+    const ip = headersList.get('x-forwarded-for')?.split(',')[0]?.trim()
+    if (ip) {
+      const result = await checkRateLimit(`${metadata.actionName}:${ip}`)
+      if (!result.success) {
+        throw new ActionError(
+          'Too many attempts. Please try again later.',
+          ERROR_CODES.RATE_LIMIT_EXCEEDED,
+          undefined,
+          429
+        )
+      }
     }
     return next()
   }

--- a/lib/safe-action.ts
+++ b/lib/safe-action.ts
@@ -17,13 +17,13 @@ export const actionClient = createSafeActionClient({
   },
   async handleServerError(e, utils) {
     unstable_rethrow(e)
-    if (e instanceof ActionError) {
+    if (e instanceof ActionError && e.statusCode < 500) {
       return e.message
     }
     await logError(logger, e, 'Unhandled action error', {
       actionName: utils.metadata?.actionName,
     })
-    return 'Something went wrong'
+    return e instanceof ActionError ? e.message : 'Something went wrong'
   },
 })
 
@@ -35,16 +35,17 @@ export const adminActionClient = actionClient.use(async ({ next }) => {
 export const rateLimitedActionClient = actionClient.use(
   async ({ next, metadata }) => {
     const headersList = await headers()
-    const ip =
-      headersList.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
-    const result = await checkRateLimit(`${metadata.actionName}:${ip}`)
-    if (!result.success) {
-      throw new ActionError(
-        'Too many attempts. Please try again later.',
-        ERROR_CODES.RATE_LIMIT_EXCEEDED,
-        undefined,
-        429
-      )
+    const ip = headersList.get('x-forwarded-for')?.split(',')[0]?.trim()
+    if (ip) {
+      const result = await checkRateLimit(`${metadata.actionName}:${ip}`)
+      if (!result.success) {
+        throw new ActionError(
+          'Too many attempts. Please try again later.',
+          ERROR_CODES.RATE_LIMIT_EXCEEDED,
+          undefined,
+          429
+        )
+      }
     }
     return next()
   }
@@ -53,16 +54,17 @@ export const rateLimitedActionClient = actionClient.use(
 export const rateLimitedAdminActionClient = adminActionClient.use(
   async ({ next, metadata }) => {
     const headersList = await headers()
-    const ip =
-      headersList.get('x-forwarded-for')?.split(',')[0]?.trim() ?? 'unknown'
-    const result = await checkRateLimit(`${metadata.actionName}:${ip}`)
-    if (!result.success) {
-      throw new ActionError(
-        'Too many attempts. Please try again later.',
-        ERROR_CODES.RATE_LIMIT_EXCEEDED,
-        undefined,
-        429
-      )
+    const ip = headersList.get('x-forwarded-for')?.split(',')[0]?.trim()
+    if (ip) {
+      const result = await checkRateLimit(`${metadata.actionName}:${ip}`)
+      if (!result.success) {
+        throw new ActionError(
+          'Too many attempts. Please try again later.',
+          ERROR_CODES.RATE_LIMIT_EXCEEDED,
+          undefined,
+          429
+        )
+      }
     }
     return next()
   }

--- a/lib/services/mahad/student-service.ts
+++ b/lib/services/mahad/student-service.ts
@@ -269,23 +269,23 @@ export async function getMahadStudentSiblings(studentId: string) {
  * @returns Deleted profile
  */
 export async function deleteMahadStudent(studentId: string) {
-  // Withdraw from active enrollments
-  await prisma.enrollment.updateMany({
-    where: {
-      programProfileId: studentId,
-      status: { not: 'WITHDRAWN' },
-    },
-    data: {
-      status: 'WITHDRAWN',
-      endDate: new Date(),
-    },
-  })
+  return await prisma.$transaction(async (tx) => {
+    await tx.enrollment.updateMany({
+      where: {
+        programProfileId: studentId,
+        status: { not: 'WITHDRAWN' },
+      },
+      data: {
+        status: 'WITHDRAWN',
+        endDate: new Date(),
+      },
+    })
 
-  // Mark program profile as withdrawn
-  return await prisma.programProfile.update({
-    where: { id: studentId },
-    data: {
-      status: 'WITHDRAWN',
-    },
+    return tx.programProfile.update({
+      where: { id: studentId },
+      data: {
+        status: 'WITHDRAWN',
+      },
+    })
   })
 }

--- a/lib/services/registration-service.ts
+++ b/lib/services/registration-service.ts
@@ -528,9 +528,10 @@ export async function createProgramProfileWithEnrollment(
         },
         'Person already has an active enrollment for this program'
       )
-      throw new Error(
+      throw new ActionError(
         `This person already has an active ${program} enrollment. ` +
-          'Withdraw the existing enrollment first before re-registering.'
+          'Withdraw the existing enrollment first before re-registering.',
+        ERROR_CODES.VALIDATION_ERROR
       )
     }
 
@@ -798,9 +799,10 @@ export async function createFamilyRegistration(data: unknown): Promise<{
                   errorRef: generateErrorRef(familyReferenceId),
                 }
               )
-              throw new Error(
+              throw new ActionError(
                 `Registration temporarily unavailable for ${childFullName}. ` +
-                  `Please retry. If the problem persists, contact support with reference: ${generateErrorRef(familyReferenceId)}`
+                  `Please retry. If the problem persists, contact support with reference: ${generateErrorRef(familyReferenceId)}`,
+                ERROR_CODES.SERVER_ERROR
               )
             }
           } else {
@@ -851,9 +853,10 @@ export async function createFamilyRegistration(data: unknown): Promise<{
           existingProfile.familyReferenceId &&
           existingProfile.familyReferenceId !== familyReferenceId
         ) {
-          throw new Error(
+          throw new ActionError(
             `Child ${childFullName} is already registered under a different family. ` +
-              `Contact support to update family relationships.`
+              `Contact support to update family relationships.`,
+            ERROR_CODES.VALIDATION_ERROR
           )
         }
 
@@ -927,9 +930,10 @@ export async function createFamilyRegistration(data: unknown): Promise<{
                   errorRef: generateErrorRef(familyReferenceId),
                 }
               )
-              throw new Error(
+              throw new ActionError(
                 `Unable to register ${childFullName}. This may indicate a data conflict. ` +
-                  `Please contact support with reference: ${generateErrorRef(familyReferenceId)}`
+                  `Please contact support with reference: ${generateErrorRef(familyReferenceId)}`,
+                ERROR_CODES.SERVER_ERROR
               )
             }
           } else {
@@ -1444,9 +1448,10 @@ async function validateFamilyConflicts(
     const childFullName = `${child.firstName} ${child.lastName}`
     const lookupKey = getChildLookupKey(childFullName, child.dateOfBirth)
     if (seenChildren.has(lookupKey)) {
-      throw new Error(
+      throw new ActionError(
         `Duplicate child in submission: ${child.firstName} ${child.lastName}. ` +
-          `Each child can only be registered once per submission.`
+          `Each child can only be registered once per submission.`,
+        ERROR_CODES.VALIDATION_ERROR
       )
     }
     seenChildren.add(lookupKey)
@@ -1482,9 +1487,10 @@ async function validateFamilyConflicts(
         profile?.familyReferenceId &&
         profile.familyReferenceId !== familyReferenceId
       ) {
-        throw new Error(
+        throw new ActionError(
           `Child ${child.firstName} ${child.lastName} is already registered ` +
-            `under a different family. Contact support to update family relationships.`
+            `under a different family. Contact support to update family relationships.`,
+          ERROR_CODES.VALIDATION_ERROR
         )
       }
     }

--- a/lib/services/webhooks/__tests__/rate-validation.test.ts
+++ b/lib/services/webhooks/__tests__/rate-validation.test.ts
@@ -46,6 +46,10 @@ const {
 // Mocks
 // ============================================================================
 
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+}))
+
 vi.mock('@/lib/utils/mahad-tuition', () => ({
   calculateMahadRate: (...args: unknown[]) => mockCalculateMahadRate(...args),
 }))

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -83,7 +83,7 @@ describe('handleSubscriptionUpdated', () => {
     mockGetSubscriptionByStripeId.mockResolvedValue(null)
 
     const subscription = createMockSubscription({ id: 'sub_legacy_123' })
-    const result = await handleSubscriptionUpdated(subscription)
+    const result = await handleSubscriptionUpdated(subscription, 'MAHAD')
 
     expect(result).toEqual({
       subscriptionId: '',

--- a/lib/services/webhooks/event-handlers.ts
+++ b/lib/services/webhooks/event-handlers.ts
@@ -155,7 +155,8 @@ async function handleSubscriptionCreatedEvent(
  * Updates subscription status and period dates
  */
 async function handleSubscriptionUpdatedEvent(
-  event: Stripe.Event
+  event: Stripe.Event,
+  accountType: StripeAccountType
 ): Promise<void> {
   const subscription = extractEventData<Stripe.Subscription>(event)
 
@@ -164,7 +165,7 @@ async function handleSubscriptionUpdatedEvent(
     'Processing customer.subscription.updated'
   )
 
-  await handleSubscriptionUpdated(subscription)
+  await handleSubscriptionUpdated(subscription, accountType)
 }
 
 /**
@@ -173,7 +174,8 @@ async function handleSubscriptionUpdatedEvent(
  * Cancels subscription and unlinks from profiles
  */
 async function handleSubscriptionDeletedEvent(
-  event: Stripe.Event
+  event: Stripe.Event,
+  accountType: StripeAccountType
 ): Promise<void> {
   const subscription = extractEventData<Stripe.Subscription>(event)
 
@@ -182,7 +184,7 @@ async function handleSubscriptionDeletedEvent(
     'Processing customer.subscription.deleted'
   )
 
-  await handleSubscriptionDeleted(subscription)
+  await handleSubscriptionDeleted(subscription, accountType)
 }
 
 /**
@@ -191,7 +193,8 @@ async function handleSubscriptionDeletedEvent(
  * Updates paidUntil date on subscription
  */
 async function handleInvoicePaymentSucceededEvent(
-  event: Stripe.Event
+  event: Stripe.Event,
+  accountType: StripeAccountType
 ): Promise<void> {
   const invoice = extractEventData<Stripe.Invoice>(event)
 
@@ -200,7 +203,7 @@ async function handleInvoicePaymentSucceededEvent(
     'Processing invoice.payment_succeeded'
   )
 
-  await handleInvoiceFinalized(invoice)
+  await handleInvoiceFinalized(invoice, accountType)
 }
 
 /**
@@ -235,12 +238,15 @@ async function handleInvoicePaymentFailedEvent(
  *
  * Updates paidUntil date on subscription
  */
-async function handleInvoiceFinalizedEvent(event: Stripe.Event): Promise<void> {
+async function handleInvoiceFinalizedEvent(
+  event: Stripe.Event,
+  accountType: StripeAccountType
+): Promise<void> {
   const invoice = extractEventData<Stripe.Invoice>(event)
 
   logger.info({ invoiceId: invoice.id }, 'Processing invoice.finalized')
 
-  await handleInvoiceFinalized(invoice)
+  await handleInvoiceFinalized(invoice, accountType)
 }
 
 /**
@@ -257,15 +263,19 @@ export function createEventHandlers(accountType: StripeAccountType) {
     'customer.subscription.created': (event: Stripe.Event) =>
       handleSubscriptionCreatedEvent(event, accountType),
 
-    'customer.subscription.updated': handleSubscriptionUpdatedEvent,
+    'customer.subscription.updated': (event: Stripe.Event) =>
+      handleSubscriptionUpdatedEvent(event, accountType),
 
-    'customer.subscription.deleted': handleSubscriptionDeletedEvent,
+    'customer.subscription.deleted': (event: Stripe.Event) =>
+      handleSubscriptionDeletedEvent(event, accountType),
 
-    'invoice.payment_succeeded': handleInvoicePaymentSucceededEvent,
+    'invoice.payment_succeeded': (event: Stripe.Event) =>
+      handleInvoicePaymentSucceededEvent(event, accountType),
 
     'invoice.payment_failed': handleInvoicePaymentFailedEvent,
 
-    'invoice.finalized': handleInvoiceFinalizedEvent,
+    'invoice.finalized': (event: Stripe.Event) =>
+      handleInvoiceFinalizedEvent(event, accountType),
   }
 }
 

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -13,6 +13,8 @@
  * Uses shared services for DRY implementation.
  */
 
+import { revalidateTag } from 'next/cache'
+
 import { StripeAccountType, SubscriptionStatus } from '@prisma/client'
 import type {
   GraduationStatus,
@@ -23,13 +25,13 @@ import * as Sentry from '@sentry/nextjs'
 import type Stripe from 'stripe'
 
 import { prisma } from '@/lib/db'
-import type { DatabaseClient } from '@/lib/db/types'
 import {
   getBillingAccountByStripeCustomerId,
   getSubscriptionByStripeId,
   getBillingAssignmentsBySubscription,
   updateSubscriptionStatus as updateSubscriptionStatusQuery,
 } from '@/lib/db/queries/billing'
+import type { DatabaseClient } from '@/lib/db/types'
 import { createServiceLogger, logError } from '@/lib/logger'
 import {
   createOrUpdateBillingAccount,
@@ -389,6 +391,10 @@ export async function handleSubscriptionCreated(
     )
   }
 
+  if (accountType === 'MAHAD') {
+    revalidateTag('mahad-students')
+  }
+
   return {
     subscriptionId: dbSubscription.id,
     status: dbSubscription.status,
@@ -441,6 +447,8 @@ export async function handleSubscriptionUpdated(
     paidUntil: periodDates.periodEnd,
   })
 
+  revalidateTag('mahad-students')
+
   return {
     subscriptionId: dbSubscription.id,
     status,
@@ -487,6 +495,8 @@ export async function handleSubscriptionDeleted(
     )
     await unlinkSubscription(dbSubscription.id, tx)
   })
+
+  revalidateTag('mahad-students')
 
   return {
     subscriptionId: dbSubscription.id,

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -393,6 +393,8 @@ export async function handleSubscriptionCreated(
 
   if (accountType === 'MAHAD') {
     revalidateTag('mahad-students')
+  } else if (accountType === 'DUGSI') {
+    revalidateTag('dugsi-registrations')
   }
 
   return {
@@ -450,6 +452,8 @@ export async function handleSubscriptionUpdated(
 
   if (accountType === 'MAHAD') {
     revalidateTag('mahad-students')
+  } else if (accountType === 'DUGSI') {
+    revalidateTag('dugsi-registrations')
   }
 
   return {
@@ -502,6 +506,8 @@ export async function handleSubscriptionDeleted(
 
   if (accountType === 'MAHAD') {
     revalidateTag('mahad-students')
+  } else if (accountType === 'DUGSI') {
+    revalidateTag('dugsi-registrations')
   }
 
   return {
@@ -565,6 +571,8 @@ export async function handleInvoiceFinalized(
 
   if (accountType === 'MAHAD') {
     revalidateTag('mahad-students')
+  } else if (accountType === 'DUGSI') {
+    revalidateTag('dugsi-registrations')
   }
 
   return {

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -412,7 +412,8 @@ export async function handleSubscriptionCreated(
  * @returns Subscription event result
  */
 export async function handleSubscriptionUpdated(
-  subscription: Stripe.Subscription
+  subscription: Stripe.Subscription,
+  accountType: StripeAccountType
 ): Promise<SubscriptionEventResult> {
   const stripeSubscriptionId = subscription.id
 
@@ -447,7 +448,9 @@ export async function handleSubscriptionUpdated(
     paidUntil: periodDates.periodEnd,
   })
 
-  revalidateTag('mahad-students')
+  if (accountType === 'MAHAD') {
+    revalidateTag('mahad-students')
+  }
 
   return {
     subscriptionId: dbSubscription.id,
@@ -466,7 +469,8 @@ export async function handleSubscriptionUpdated(
  * @returns Subscription event result
  */
 export async function handleSubscriptionDeleted(
-  subscription: Stripe.Subscription
+  subscription: Stripe.Subscription,
+  accountType: StripeAccountType
 ): Promise<SubscriptionEventResult> {
   const stripeSubscriptionId = subscription.id
 
@@ -496,7 +500,9 @@ export async function handleSubscriptionDeleted(
     await unlinkSubscription(dbSubscription.id, tx)
   })
 
-  revalidateTag('mahad-students')
+  if (accountType === 'MAHAD') {
+    revalidateTag('mahad-students')
+  }
 
   return {
     subscriptionId: dbSubscription.id,
@@ -515,7 +521,8 @@ export async function handleSubscriptionDeleted(
  * @returns Updated subscription or null
  */
 export async function handleInvoiceFinalized(
-  invoice: Stripe.Invoice
+  invoice: Stripe.Invoice,
+  accountType: StripeAccountType
 ): Promise<{ subscriptionId: string; paidUntil: Date | null } | null> {
   // Extract subscription ID (may be expanded object or just the ID string)
   // Type assertion needed because Stripe's Invoice type doesn't include expanded subscription
@@ -555,6 +562,10 @@ export async function handleInvoiceFinalized(
       paidUntil,
     }
   )
+
+  if (accountType === 'MAHAD') {
+    revalidateTag('mahad-students')
+  }
 
   return {
     subscriptionId: dbSubscription.id,

--- a/lib/validations/checkout.ts
+++ b/lib/validations/checkout.ts
@@ -41,6 +41,10 @@ export const CheckoutRequestSchema = z.object({
       (url) => url.startsWith('http://') || url.startsWith('https://'),
       'Success URL must use HTTP or HTTPS protocol'
     )
+    .refine((url) => {
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL
+      return !appUrl || url.startsWith(appUrl)
+    }, 'Success URL must be on this domain')
     .optional(),
   cancelUrl: z
     .string()
@@ -49,6 +53,10 @@ export const CheckoutRequestSchema = z.object({
       (url) => url.startsWith('http://') || url.startsWith('https://'),
       'Cancel URL must use HTTP or HTTPS protocol'
     )
+    .refine((url) => {
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL
+      return !appUrl || url.startsWith(appUrl)
+    }, 'Cancel URL must be on this domain')
     .optional(),
 })
 

--- a/lib/validations/checkout.ts
+++ b/lib/validations/checkout.ts
@@ -43,8 +43,13 @@ export const CheckoutRequestSchema = z.object({
     )
     .refine((url) => {
       const appUrl = process.env.NEXT_PUBLIC_APP_URL
-      return !appUrl || url.startsWith(appUrl)
-    }, 'Success URL must be on this domain')
+      if (!appUrl) return false
+      try {
+        return new URL(url).origin === new URL(appUrl).origin
+      } catch {
+        return false
+      }
+    }, 'Redirect URL must be on this domain')
     .optional(),
   cancelUrl: z
     .string()
@@ -55,8 +60,13 @@ export const CheckoutRequestSchema = z.object({
     )
     .refine((url) => {
       const appUrl = process.env.NEXT_PUBLIC_APP_URL
-      return !appUrl || url.startsWith(appUrl)
-    }, 'Cancel URL must be on this domain')
+      if (!appUrl) return false
+      try {
+        return new URL(url).origin === new URL(appUrl).origin
+      } catch {
+        return false
+      }
+    }, 'Redirect URL must be on this domain')
     .optional(),
 })
 

--- a/lib/validations/dugsi-checkout.ts
+++ b/lib/validations/dugsi-checkout.ts
@@ -44,6 +44,10 @@ export const DugsiCheckoutRequestSchema = z.object({
       (url) => url.startsWith('http://') || url.startsWith('https://'),
       'Success URL must use HTTP or HTTPS protocol'
     )
+    .refine((url) => {
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL
+      return !appUrl || url.startsWith(appUrl)
+    }, 'Success URL must be on this domain')
     .optional(),
   cancelUrl: z
     .string()
@@ -52,6 +56,10 @@ export const DugsiCheckoutRequestSchema = z.object({
       (url) => url.startsWith('http://') || url.startsWith('https://'),
       'Cancel URL must use HTTP or HTTPS protocol'
     )
+    .refine((url) => {
+      const appUrl = process.env.NEXT_PUBLIC_APP_URL
+      return !appUrl || url.startsWith(appUrl)
+    }, 'Cancel URL must be on this domain')
     .optional(),
 })
 

--- a/lib/validations/dugsi-checkout.ts
+++ b/lib/validations/dugsi-checkout.ts
@@ -46,8 +46,13 @@ export const DugsiCheckoutRequestSchema = z.object({
     )
     .refine((url) => {
       const appUrl = process.env.NEXT_PUBLIC_APP_URL
-      return !appUrl || url.startsWith(appUrl)
-    }, 'Success URL must be on this domain')
+      if (!appUrl) return false
+      try {
+        return new URL(url).origin === new URL(appUrl).origin
+      } catch {
+        return false
+      }
+    }, 'Redirect URL must be on this domain')
     .optional(),
   cancelUrl: z
     .string()
@@ -58,8 +63,13 @@ export const DugsiCheckoutRequestSchema = z.object({
     )
     .refine((url) => {
       const appUrl = process.env.NEXT_PUBLIC_APP_URL
-      return !appUrl || url.startsWith(appUrl)
-    }, 'Cancel URL must be on this domain')
+      if (!appUrl) return false
+      try {
+        return new URL(url).origin === new URL(appUrl).origin
+      } catch {
+        return false
+      }
+    }, 'Redirect URL must be on this domain')
     .optional(),
 })
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
-    "prepare": "husky install",
+    "prepare": "sh -c 'if [ -z \"$VERCEL\" ] && [ -z \"$CI\" ]; then husky install; fi'",
     "cleanup": "bun run format && bun run lint -- --fix && bun run type-check",
     "cleanup-stripe": "tsx scripts/cleanup-stripe.ts",
     "see-active": "ts-node scripts/see-active.ts",


### PR DESCRIPTION
### Why?

A council-refactor audit of the caching and registration actions work identified five categories of issues: unauthenticated admin endpoints, webhook revalidation firing for the wrong program, missing cache tag invalidation for Dugsi mutations, plain \`Error\` throws bypassing the safe-action error pipeline, and atomicity gaps in destructive operations.

### How?

All five phases addressed in sequence: auth guard added to unprotected batch-data actions and the Dugsi checkout route; open redirect protection added to checkout URL validation; \`accountType\` threaded through webhook handlers so \`revalidateTag('mahad-students')\` only fires for Mahad events; \`revalidateTag('dugsi-registrations')\` added to all Dugsi admin mutations and \`after()\` normalized across the teacher actions file; \`ActionError\` with typed \`ERROR_CODES\` replacing bare \`throw new Error()\` in the registration service and P2002/P2025 normalized at the query layer; and \`deleteMahadStudent\` wrapped in a single \`prisma.\$transaction\` to make enrollment + profile updates atomic.

<sub>Generated with Claude Code</sub>