### PR TITLE
refactor: extract 10 direct Prisma callsites from server actions to query/service layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,7 @@ Claude should refuse to write code violating these rules.
 3. **Minimize client components** - extract interactive parts into small client components, keep data fetching server-side
 4. **Never reset production database** - forbidden: `prisma migrate reset`, `DROP TABLE`, `TRUNCATE`
 5. **Use transactions for multi-table operations** - `prisma.$transaction()`
-6. **Handle P2002 race conditions** - use upsert or read-first inside a transaction. Never try-catch P2002 inside `$transaction()` — PostgreSQL aborts the transaction on constraint violations, making recovery code dead
+6. **Explicit pre-validation over constraint-catching** - use a `findFirst` check before writes for user-facing uniqueness validation (email, phone, name). Database constraints (P2002) are safety nets for bugs and race conditions, not primary error reporters. Never try to recover or run additional queries after catching a constraint error inside `$transaction()` — PostgreSQL aborts the transaction on violations. For truly concurrent public flows, use `upsert` (`INSERT ... ON CONFLICT`) instead of check-then-insert.
 7. **Never use `any` type** - always use specific types
 8. **Validate ALL external input with Zod** before database operations
 9. **Always create new files as `.ts`/`.tsx`**, never `.js`/`.jsx`

--- a/app/admin/dugsi/teachers/actions.ts
+++ b/app/admin/dugsi/teachers/actions.ts
@@ -3,10 +3,9 @@
 import { revalidatePath } from 'next/cache'
 import { after } from 'next/server'
 
-import { Prisma, Program, Shift } from '@prisma/client'
+import { Program, Shift } from '@prisma/client'
 import { z } from 'zod'
 
-import { prisma } from '@/lib/db'
 import {
   countActiveClassesForTeacher,
   getActiveClassesForTeacher,
@@ -29,6 +28,7 @@ import {
   getDugsiTeachersForDropdown,
   TeacherCheckinWithRelations,
 } from '@/lib/db/queries/teacher-checkin'
+import { searchPeopleWithRoles } from '@/lib/db/queries/teacher-management'
 import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
 import { createServiceLogger } from '@/lib/logger'
 import {
@@ -41,7 +41,9 @@ import {
   deleteCheckin,
 } from '@/lib/services/dugsi/teacher-checkin-service'
 import {
-  createTeacher,
+  createTeacherAndAssignDugsi,
+  createPersonTeacherAndAssignDugsi,
+  deactivateTeacherFromDugsi,
   deleteTeacher,
   assignTeacherToProgram,
   removeTeacherFromProgram,
@@ -53,8 +55,8 @@ import { ValidationError } from '@/lib/services/validation-service'
 import {
   normalizeEmail,
   normalizePhone,
-  validateAndNormalizeEmail,
 } from '@/lib/utils/contact-normalization'
+import { isPrismaError } from '@/lib/utils/type-guards'
 import {
   UpdateCheckinSchema,
   DeleteCheckinSchema,
@@ -288,18 +290,7 @@ const _createTeacherAction = adminActionClient
   .action(async ({ parsedInput }) => {
     const { personId } = parsedInput
     try {
-      const teacher = await prisma.$transaction(async (tx) => {
-        const newTeacher = await createTeacher(personId, tx)
-
-        await tx.teacherProgram.create({
-          data: {
-            teacherId: newTeacher.id,
-            program: 'DUGSI_PROGRAM',
-          },
-        })
-
-        return newTeacher
-      })
+      const teacher = await createTeacherAndAssignDugsi(personId)
 
       after(() => revalidatePath('/admin/dugsi/teachers'))
 
@@ -323,15 +314,6 @@ const _createTeacherAction = adminActionClient
           ERROR_CODES.VALIDATION_ERROR
         )
       }
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.code === 'P2002'
-      ) {
-        throw new ActionError(
-          'A person with this email or phone already exists',
-          ERROR_CODES.VALIDATION_ERROR
-        )
-      }
       throw error
     }
   })
@@ -342,27 +324,10 @@ const _createTeacherWithPersonAction = adminActionClient
   .action(async ({ parsedInput }) => {
     const { name, email, phone } = parsedInput
     try {
-      const normalizedPhone = phone ? normalizePhone(phone) : null
-
-      const teacher = await prisma.$transaction(async (tx) => {
-        const person = await tx.person.create({
-          data: {
-            name,
-            email: normalizeEmail(email),
-            phone: normalizedPhone,
-          },
-        })
-
-        const newTeacher = await createTeacher(person.id, tx)
-
-        await tx.teacherProgram.create({
-          data: {
-            teacherId: newTeacher.id,
-            program: 'DUGSI_PROGRAM',
-          },
-        })
-
-        return newTeacher
+      const teacher = await createPersonTeacherAndAssignDugsi({
+        name,
+        email: normalizeEmail(email),
+        phone: phone ? normalizePhone(phone) : null,
       })
 
       after(() => revalidatePath('/admin/dugsi/teachers'))
@@ -378,19 +343,6 @@ const _createTeacherWithPersonAction = adminActionClient
 
       return { teacherId: teacher.id }
     } catch (error) {
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.code === 'P2002'
-      ) {
-        logger.warn(
-          { hasEmail: !!email, hasPhone: !!phone },
-          'Duplicate contact on teacher create'
-        )
-        throw new ActionError(
-          'A person with this email or phone already exists',
-          ERROR_CODES.VALIDATION_ERROR
-        )
-      }
       if (
         error instanceof ValidationError &&
         error.code === 'TEACHER_ALREADY_EXISTS'
@@ -473,10 +425,7 @@ const _updateTeacherDetailsAction = adminActionClient
       } satisfies TeacherWithDetails
     } catch (error) {
       if (error instanceof ActionError) throw error
-      if (
-        error instanceof Prisma.PrismaClientKnownRequestError &&
-        error.code === 'P2002'
-      ) {
+      if (isPrismaError(error) && error.code === 'P2002') {
         logger.warn({ teacherId }, 'Duplicate contact on teacher update')
         throw new ActionError(
           'This email or phone is already in use',
@@ -536,23 +485,9 @@ const _deactivateTeacherAction = adminActionClient
       )
     }
 
-    await prisma.$transaction(async (tx) => {
-      await tx.teacherProgram.updateMany({
-        where: {
-          teacherId,
-          program: 'DUGSI_PROGRAM',
-          isActive: true,
-        },
-        data: {
-          shifts: [],
-          isActive: false,
-        },
-      })
-    })
+    await deactivateTeacherFromDugsi(teacherId)
 
     after(() => revalidatePath('/admin/dugsi/teachers'))
-
-    logger.info({ teacherId }, 'Teacher deactivated from Dugsi')
   })
 
 // ============================================================================
@@ -663,70 +598,7 @@ const _searchPeopleAction = adminActionClient
       return [] as PersonSearchResult[]
     }
 
-    const searchTerm = query.trim().toLowerCase()
-    const normalizedSearchTerm = normalizePhone(query.trim())
-
-    const people = await prisma.person.findMany({
-      where: {
-        OR: [
-          { name: { contains: searchTerm, mode: 'insensitive' } },
-          {
-            email: {
-              contains: validateAndNormalizeEmail(query.trim()) ?? searchTerm,
-              mode: 'insensitive',
-            },
-          },
-          ...(normalizedSearchTerm ? [{ phone: normalizedSearchTerm }] : []),
-        ],
-      },
-      relationLoadStrategy: 'join',
-      include: {
-        teacher: {
-          include: {
-            programs: {
-              where: { isActive: true },
-            },
-          },
-        },
-        guardianRelationships: {
-          where: { isActive: true },
-          include: {
-            dependent: {
-              include: {
-                programProfiles: {
-                  select: { program: true },
-                },
-              },
-            },
-          },
-        },
-        programProfiles: {
-          where: {
-            enrollments: {
-              some: {
-                status: { in: ['REGISTERED', 'ENROLLED'] },
-                endDate: null,
-              },
-            },
-          },
-          include: {
-            enrollments: {
-              where: {
-                status: { in: ['REGISTERED', 'ENROLLED'] },
-                endDate: null,
-              },
-              select: {
-                status: true,
-              },
-              take: 1,
-            },
-          },
-        },
-      },
-      take: SEARCH_MAX_RESULTS,
-      orderBy: { name: 'asc' },
-    })
-
+    const people = await searchPeopleWithRoles(query, SEARCH_MAX_RESULTS)
     return people.map((person) => mapPersonToSearchResult(person))
   })
 

--- a/app/admin/dugsi/teachers/actions.ts
+++ b/app/admin/dugsi/teachers/actions.ts
@@ -548,8 +548,11 @@ const _bulkAssignProgramsAction = adminActionClient
     try {
       await bulkAssignPrograms(teacherId, programs)
     } catch (error) {
-      if (error instanceof ValidationError)
+      if (error instanceof ValidationError) {
+        if (error.code === 'TEACHER_NOT_FOUND')
+          throw new ActionError(error.message, ERROR_CODES.NOT_FOUND)
         throw new ActionError(error.message, ERROR_CODES.VALIDATION_ERROR)
+      }
       throw error
     }
 

--- a/app/admin/dugsi/teachers/actions.ts
+++ b/app/admin/dugsi/teachers/actions.ts
@@ -294,15 +294,6 @@ const _createTeacherAction = adminActionClient
 
       after(() => revalidatePath('/admin/dugsi/teachers'))
 
-      logger.info(
-        {
-          teacherId: teacher.id,
-          personId,
-          name: teacher.person.name,
-        },
-        'Teacher created and enrolled in Dugsi'
-      )
-
       return { teacherId: teacher.id }
     } catch (error) {
       if (
@@ -331,15 +322,6 @@ const _createTeacherWithPersonAction = adminActionClient
       })
 
       after(() => revalidatePath('/admin/dugsi/teachers'))
-
-      logger.info(
-        {
-          teacherId: teacher.id,
-          personId: teacher.personId,
-          name: teacher.person.name,
-        },
-        'Teacher created with new person'
-      )
 
       return { teacherId: teacher.id }
     } catch (error) {

--- a/app/admin/dugsi/teachers/actions.ts
+++ b/app/admin/dugsi/teachers/actions.ts
@@ -495,14 +495,14 @@ const _assignTeacherToProgramAction = adminActionClient
         'Teacher assigned to program'
       )
     } catch (error) {
-      if (
-        error instanceof ValidationError &&
-        error.code === 'DUPLICATE_PROGRAM_ENROLLMENT'
-      ) {
-        throw new ActionError(
-          'Teacher is already enrolled in this program',
-          ERROR_CODES.VALIDATION_ERROR
-        )
+      if (error instanceof ValidationError) {
+        if (error.code === 'DUPLICATE_PROGRAM_ENROLLMENT')
+          throw new ActionError(
+            'Teacher is already enrolled in this program',
+            ERROR_CODES.VALIDATION_ERROR
+          )
+        if (error.code === 'TEACHER_NOT_FOUND')
+          throw new ActionError('Teacher not found', ERROR_CODES.NOT_FOUND)
       }
       throw error
     }
@@ -545,7 +545,13 @@ const _bulkAssignProgramsAction = adminActionClient
   .schema(bulkProgramAssignmentSchema)
   .action(async ({ parsedInput }) => {
     const { teacherId, programs } = parsedInput
-    await bulkAssignPrograms(teacherId, programs)
+    try {
+      await bulkAssignPrograms(teacherId, programs)
+    } catch (error) {
+      if (error instanceof ValidationError)
+        throw new ActionError(error.message, ERROR_CODES.VALIDATION_ERROR)
+      throw error
+    }
 
     after(() => {
       revalidatePath('/admin/teachers')

--- a/app/admin/mahad/_actions/__tests__/actions.test.ts
+++ b/app/admin/mahad/_actions/__tests__/actions.test.ts
@@ -1052,7 +1052,7 @@ describe('generatePaymentLinkWithDefaultsAction', () => {
   })
 
   it('should return not found error when profile does not exist', async () => {
-    mockSetProfileBillingDefaults.mockResolvedValue(null)
+    mockSetProfileBillingDefaults.mockResolvedValue(false)
 
     const result = await generatePaymentLinkWithDefaultsAction({
       profileId: VALID_PROFILE_ID,

--- a/app/admin/mahad/_actions/__tests__/actions.test.ts
+++ b/app/admin/mahad/_actions/__tests__/actions.test.ts
@@ -1051,6 +1051,32 @@ describe('generatePaymentLinkWithDefaultsAction', () => {
     mockSetProfileBillingDefaults.mockResolvedValue(true)
   })
 
+  it('should set billing defaults then return payment link', async () => {
+    mockGetProfileForPaymentLink.mockResolvedValue({
+      id: VALID_PROFILE_ID,
+      personId: 'person-1',
+      graduationStatus: 'NON_GRADUATE',
+      paymentFrequency: 'MONTHLY',
+      billingType: 'FULL_TIME',
+      person: {
+        name: 'Test Student',
+        email: 'test@example.com',
+        phone: null,
+      },
+    })
+    mockStripeSessionCreate.mockResolvedValue({
+      id: 'sess_defaults',
+      url: 'https://checkout.stripe.com/defaults-test',
+    })
+
+    const result = await generatePaymentLinkWithDefaultsAction({
+      profileId: VALID_PROFILE_ID,
+    })
+
+    expect(result?.data?.url).toBe('https://checkout.stripe.com/defaults-test')
+    expect(result?.data?.amount).toBe(15000)
+  })
+
   it('should return not found error when profile does not exist', async () => {
     mockSetProfileBillingDefaults.mockResolvedValue(false)
 

--- a/app/admin/mahad/_actions/__tests__/actions.test.ts
+++ b/app/admin/mahad/_actions/__tests__/actions.test.ts
@@ -159,6 +159,12 @@ vi.mock('@/lib/logger', () => ({
     info: vi.fn(),
     debug: vi.fn(),
   })),
+  createServiceLogger: vi.fn(() => ({
+    error: mockLoggerError,
+    warn: mockLoggerWarn,
+    info: vi.fn(),
+    debug: vi.fn(),
+  })),
   logError: (...args: unknown[]) => mockLogError(...args),
 }))
 

--- a/app/admin/mahad/_actions/__tests__/actions.test.ts
+++ b/app/admin/mahad/_actions/__tests__/actions.test.ts
@@ -69,11 +69,14 @@ const {
   mockPrismaDeleteMany,
   mockPersonUpdate,
   mockAfter,
+  mockGetProfileForPaymentLink,
+  mockGetBatchByName,
 } = vi.hoisted(() => ({
   mockCreateBatch: vi.fn(),
   mockUpdateBatch: vi.fn(),
   mockDeleteBatch: vi.fn(),
   mockGetBatchById: vi.fn(),
+  mockGetBatchByName: vi.fn(),
   mockAssignStudentsToBatch: vi.fn(),
   mockTransferStudents: vi.fn(),
   mockGetStudentById: vi.fn(),
@@ -92,6 +95,7 @@ const {
   mockBillingAssignmentFindFirst: vi.fn(),
   mockPersonUpdate: vi.fn(),
   mockAfter: vi.fn((fn: () => void) => fn()),
+  mockGetProfileForPaymentLink: vi.fn(),
 }))
 
 vi.mock('next/cache', () => ({
@@ -131,6 +135,7 @@ vi.mock('@/lib/db/queries/batch', () => ({
   updateBatch: (...args: unknown[]) => mockUpdateBatch(...args),
   deleteBatch: (...args: unknown[]) => mockDeleteBatch(...args),
   getBatchById: (...args: unknown[]) => mockGetBatchById(...args),
+  getBatchByName: (...args: unknown[]) => mockGetBatchByName(...args),
   assignStudentsToBatch: (...args: unknown[]) =>
     mockAssignStudentsToBatch(...args),
   transferStudents: (...args: unknown[]) => mockTransferStudents(...args),
@@ -142,6 +147,9 @@ vi.mock('@/lib/db/queries/student', () => ({
     mockResolveDuplicateStudents(...args),
   getStudentDeleteWarnings: (...args: unknown[]) =>
     mockGetStudentDeleteWarnings(...args),
+  getProfileForPaymentLink: (...args: unknown[]) =>
+    mockGetProfileForPaymentLink(...args),
+  setProfileBillingDefaults: () => Promise.resolve(true),
 }))
 
 vi.mock('@/lib/logger', () => ({
@@ -204,6 +212,7 @@ describe('Batch Actions', () => {
   describe('createBatchAction', () => {
     it('should create a batch with valid data', async () => {
       const mockBatch = { id: 'batch-1', name: 'Test Cohort' }
+      mockGetBatchByName.mockResolvedValue(null)
       mockCreateBatch.mockResolvedValue(mockBatch)
 
       const result = await createBatchAction({
@@ -227,9 +236,11 @@ describe('Batch Actions', () => {
     })
 
     it('should handle duplicate name error', async () => {
-      const prismaError = new Error('Unique constraint failed')
-      Object.assign(prismaError, { code: 'P2002' })
-      mockCreateBatch.mockRejectedValue(prismaError)
+      mockGetBatchByName.mockResolvedValue({
+        id: 'other-batch',
+        name: 'Existing Cohort',
+        studentCount: 0,
+      })
 
       const result = await createBatchAction({ name: 'Existing Cohort' })
 
@@ -284,6 +295,7 @@ describe('Batch Actions', () => {
         startDate: null,
         endDate: null,
       })
+      mockGetBatchByName.mockResolvedValue(null)
       const mockUpdatedBatch = {
         id: VALID_BATCH_ID,
         name: 'Updated Name',
@@ -312,6 +324,7 @@ describe('Batch Actions', () => {
         id: VALID_BATCH_ID,
         name: 'Original Name',
       })
+      mockGetBatchByName.mockResolvedValue(null)
       const mockUpdatedBatch = { id: VALID_BATCH_ID, name: 'New Name' }
       mockUpdateBatch.mockResolvedValue(mockUpdatedBatch)
 
@@ -345,10 +358,11 @@ describe('Batch Actions', () => {
         id: VALID_BATCH_ID,
         name: 'Original Name',
       })
-
-      const prismaError = new Error('Unique constraint failed')
-      Object.assign(prismaError, { code: 'P2002' })
-      mockUpdateBatch.mockRejectedValue(prismaError)
+      mockGetBatchByName.mockResolvedValue({
+        id: 'other-batch',
+        name: 'Existing Cohort',
+        studentCount: 0,
+      })
 
       const result = await updateBatchAction({
         id: VALID_BATCH_ID,
@@ -740,7 +754,7 @@ describe('Payment Link Actions', () => {
 
   describe('generatePaymentLinkAction', () => {
     it('should generate payment link for valid profile', async () => {
-      mockPrismaFindUnique.mockResolvedValue({
+      mockGetProfileForPaymentLink.mockResolvedValue({
         id: 'profile-1',
         personId: 'person-1',
         graduationStatus: 'NON_GRADUATE',
@@ -766,7 +780,7 @@ describe('Payment Link Actions', () => {
     })
 
     it('should reject profile without billing config', async () => {
-      mockPrismaFindUnique.mockResolvedValue({
+      mockGetProfileForPaymentLink.mockResolvedValue({
         id: 'profile-1',
         personId: 'person-1',
         graduationStatus: null,
@@ -787,7 +801,7 @@ describe('Payment Link Actions', () => {
     })
 
     it('should reject exempt students', async () => {
-      mockPrismaFindUnique.mockResolvedValue({
+      mockGetProfileForPaymentLink.mockResolvedValue({
         id: 'profile-1',
         personId: 'person-1',
         graduationStatus: 'NON_GRADUATE',
@@ -810,7 +824,7 @@ describe('Payment Link Actions', () => {
     })
 
     it('should reject profile without email', async () => {
-      mockPrismaFindUnique.mockResolvedValue({
+      mockGetProfileForPaymentLink.mockResolvedValue({
         id: 'profile-1',
         personId: 'person-1',
         graduationStatus: 'NON_GRADUATE',
@@ -831,7 +845,7 @@ describe('Payment Link Actions', () => {
     })
 
     it('should return error for non-existent profile', async () => {
-      mockPrismaFindUnique.mockResolvedValue(null)
+      mockGetProfileForPaymentLink.mockResolvedValue(null)
       const nonExistentId = '550e8400-e29b-41d4-a716-446655449999'
 
       const result = await generatePaymentLinkAction({
@@ -864,7 +878,7 @@ describe('Payment Link Actions', () => {
       }
 
       beforeEach(() => {
-        mockPrismaFindUnique.mockResolvedValue(mockProfile)
+        mockGetProfileForPaymentLink.mockResolvedValue(mockProfile)
         mockStripeSessionCreate.mockResolvedValue({
           id: 'sess_123',
           url: 'https://checkout.stripe.com/test',

--- a/app/admin/mahad/_actions/__tests__/actions.test.ts
+++ b/app/admin/mahad/_actions/__tests__/actions.test.ts
@@ -1075,10 +1075,14 @@ describe('generatePaymentLinkWithDefaultsAction', () => {
 
     expect(result?.data?.url).toBe('https://checkout.stripe.com/defaults-test')
     expect(result?.data?.amount).toBe(15000)
+    expect(mockSetProfileBillingDefaults).toHaveBeenCalledWith(
+      VALID_PROFILE_ID,
+      expect.objectContaining({ graduationStatus: expect.any(String) })
+    )
   })
 
   it('should return not found error when profile does not exist', async () => {
-    mockSetProfileBillingDefaults.mockResolvedValue(false)
+    mockSetProfileBillingDefaults.mockResolvedValueOnce(false)
 
     const result = await generatePaymentLinkWithDefaultsAction({
       profileId: VALID_PROFILE_ID,

--- a/app/admin/mahad/_actions/__tests__/actions.test.ts
+++ b/app/admin/mahad/_actions/__tests__/actions.test.ts
@@ -71,6 +71,7 @@ const {
   mockAfter,
   mockGetProfileForPaymentLink,
   mockGetBatchByName,
+  mockSetProfileBillingDefaults,
 } = vi.hoisted(() => ({
   mockCreateBatch: vi.fn(),
   mockUpdateBatch: vi.fn(),
@@ -96,6 +97,7 @@ const {
   mockPersonUpdate: vi.fn(),
   mockAfter: vi.fn((fn: () => void) => fn()),
   mockGetProfileForPaymentLink: vi.fn(),
+  mockSetProfileBillingDefaults: vi.fn(),
 }))
 
 vi.mock('next/cache', () => ({
@@ -149,7 +151,8 @@ vi.mock('@/lib/db/queries/student', () => ({
     mockGetStudentDeleteWarnings(...args),
   getProfileForPaymentLink: (...args: unknown[]) =>
     mockGetProfileForPaymentLink(...args),
-  setProfileBillingDefaults: () => Promise.resolve(true),
+  setProfileBillingDefaults: (...args: unknown[]) =>
+    mockSetProfileBillingDefaults(...args),
 }))
 
 vi.mock('@/lib/logger', () => ({
@@ -200,6 +203,7 @@ import {
   bulkDeleteStudentsAction,
   getStudentDeleteWarningsAction,
   generatePaymentLinkAction,
+  generatePaymentLinkWithDefaultsAction,
   updateStudentAction,
 } from '../index'
 
@@ -1039,5 +1043,21 @@ describe('Student Update Actions', () => {
 
       expect(result?.serverError).toContain('email or phone')
     })
+  })
+})
+
+describe('generatePaymentLinkWithDefaultsAction', () => {
+  beforeEach(() => {
+    mockSetProfileBillingDefaults.mockResolvedValue(true)
+  })
+
+  it('should return not found error when profile does not exist', async () => {
+    mockSetProfileBillingDefaults.mockResolvedValue(null)
+
+    const result = await generatePaymentLinkWithDefaultsAction({
+      profileId: VALID_PROFILE_ID,
+    })
+
+    expect(result?.serverError).toBe('Student profile not found')
   })
 })

--- a/app/admin/mahad/_actions/index.ts
+++ b/app/admin/mahad/_actions/index.ts
@@ -744,48 +744,60 @@ async function createPaymentLinkSession(
   const stripe = getMahadStripeClient()
   const intervalConfig = getStripeInterval(profile.paymentFrequency)
 
-  const session = await stripe.checkout.sessions.create({
-    mode: 'subscription',
-    // Feature flag: Toggle card payments to manage transaction fees
-    // ACH only: Lower fees for the organization
-    // Card + ACH: More convenience for families
-    payment_method_types: featureFlags.mahadCardPayments()
-      ? ['card', 'us_bank_account']
-      : ['us_bank_account'],
-    customer_email: email,
-    line_items: [
-      {
-        price_data: {
-          currency: 'usd',
-          product: productId,
-          unit_amount: amount,
-          recurring: intervalConfig,
+  let session: Awaited<ReturnType<typeof stripe.checkout.sessions.create>>
+  try {
+    session = await stripe.checkout.sessions.create({
+      mode: 'subscription',
+      // Feature flag: Toggle card payments to manage transaction fees
+      // ACH only: Lower fees for the organization
+      // Card + ACH: More convenience for families
+      payment_method_types: featureFlags.mahadCardPayments()
+        ? ['card', 'us_bank_account']
+        : ['us_bank_account'],
+      customer_email: email,
+      line_items: [
+        {
+          price_data: {
+            currency: 'usd',
+            product: productId,
+            unit_amount: amount,
+            recurring: intervalConfig,
+          },
+          quantity: 1,
         },
-        quantity: 1,
+      ],
+      subscription_data: {
+        metadata: {
+          profileId: profile.id,
+          personId: profile.personId,
+          studentName: profile.person.name,
+          graduationStatus: profile.graduationStatus,
+          paymentFrequency: profile.paymentFrequency,
+          billingType: profile.billingType,
+          calculatedRate: amount.toString(),
+          source: 'admin-generated-link',
+        },
       },
-    ],
-    subscription_data: {
       metadata: {
         profileId: profile.id,
         personId: profile.personId,
         studentName: profile.person.name,
-        graduationStatus: profile.graduationStatus,
-        paymentFrequency: profile.paymentFrequency,
-        billingType: profile.billingType,
-        calculatedRate: amount.toString(),
         source: 'admin-generated-link',
       },
-    },
-    metadata: {
-      profileId: profile.id,
-      personId: profile.personId,
-      studentName: profile.person.name,
-      source: 'admin-generated-link',
-    },
-    success_url: `${appUrl}/mahad/payment-complete?payment=success`,
-    cancel_url: `${appUrl}/mahad/payment-complete?payment=canceled`,
-    allow_promotion_codes: true,
-  })
+      success_url: `${appUrl}/mahad/payment-complete?payment=success`,
+      cancel_url: `${appUrl}/mahad/payment-complete?payment=canceled`,
+      allow_promotion_codes: true,
+    })
+  } catch (error) {
+    await logError(logger, error, 'Stripe checkout session creation failed', {
+      profileId,
+      amount,
+    })
+    throw new ActionError(
+      'Failed to create payment session. Please try again.',
+      ERROR_CODES.SERVER_ERROR
+    )
+  }
 
   const billingPeriod =
     profile.paymentFrequency === 'BI_MONTHLY' ? '/2 months' : '/month'

--- a/app/admin/mahad/_actions/index.ts
+++ b/app/admin/mahad/_actions/index.ts
@@ -1023,10 +1023,10 @@ const _generatePaymentLinkWithOverrideAction = adminActionClient
       try {
         validateBillingCycleAnchor(billingCycleAnchor)
       } catch (error) {
-        await logError(logger, error, 'Invalid billing cycle anchor', {
-          billingCycleAnchor,
-          profileId,
-        })
+        logger.warn(
+          { billingCycleAnchor, profileId },
+          'Invalid billing cycle anchor provided by admin'
+        )
         throw new ActionError(
           error instanceof Error ? error.message : 'Invalid billing start date',
           ERROR_CODES.VALIDATION_ERROR

--- a/app/admin/mahad/_actions/index.ts
+++ b/app/admin/mahad/_actions/index.ts
@@ -259,13 +259,20 @@ const _updateBatchAction = adminActionClient
       }
     }
 
-    let batch
     try {
-      batch = await updateBatch(id, {
+      const batch = await updateBatch(id, {
         name: validated.name,
         startDate: validated.startDate,
         endDate: validated.endDate,
       })
+
+      after(() => {
+        revalidateTag('mahad-stats')
+        revalidateTag('mahad-students')
+        revalidatePath('/admin/mahad')
+      })
+
+      return batch
     } catch (error) {
       if (isPrismaError(error) && error.code === 'P2002') {
         throw new ActionError(
@@ -278,14 +285,6 @@ const _updateBatchAction = adminActionClient
       }
       throw error
     }
-
-    after(() => {
-      revalidateTag('mahad-stats')
-      revalidateTag('mahad-students')
-      revalidatePath('/admin/mahad')
-    })
-
-    return batch
   })
 
 export async function updateBatchAction(

--- a/app/admin/mahad/_actions/index.ts
+++ b/app/admin/mahad/_actions/index.ts
@@ -161,11 +161,22 @@ const _createBatchAction = adminActionClient
       )
     }
 
-    const batch = await createBatch({
-      name: validated.name,
-      startDate: validated.startDate ?? null,
-      endDate: validated.endDate ?? null,
-    })
+    let batch
+    try {
+      batch = await createBatch({
+        name: validated.name,
+        startDate: validated.startDate ?? null,
+        endDate: validated.endDate ?? null,
+      })
+    } catch (error) {
+      if (isPrismaError(error) && error.code === 'P2002') {
+        throw new ActionError(
+          `A cohort with the name "${validated.name}" already exists`,
+          ERROR_CODES.VALIDATION_ERROR
+        )
+      }
+      throw error
+    }
 
     after(() => {
       revalidateTag('mahad-stats')
@@ -248,11 +259,22 @@ const _updateBatchAction = adminActionClient
       }
     }
 
-    const batch = await updateBatch(id, {
-      name: validated.name,
-      startDate: validated.startDate,
-      endDate: validated.endDate,
-    })
+    let batch
+    try {
+      batch = await updateBatch(id, {
+        name: validated.name,
+        startDate: validated.startDate,
+        endDate: validated.endDate,
+      })
+    } catch (error) {
+      if (isPrismaError(error) && error.code === 'P2002') {
+        throw new ActionError(
+          `A cohort with the name "${validated.name}" already exists`,
+          ERROR_CODES.VALIDATION_ERROR
+        )
+      }
+      throw error
+    }
 
     after(() => {
       revalidateTag('mahad-stats')

--- a/app/admin/mahad/_actions/index.ts
+++ b/app/admin/mahad/_actions/index.ts
@@ -273,6 +273,9 @@ const _updateBatchAction = adminActionClient
           ERROR_CODES.VALIDATION_ERROR
         )
       }
+      if (isPrismaError(error) && error.code === 'P2025') {
+        throw new ActionError('Cohort not found', ERROR_CODES.NOT_FOUND)
+      }
       throw error
     }
 

--- a/app/admin/mahad/_actions/index.ts
+++ b/app/admin/mahad/_actions/index.ts
@@ -4,7 +4,6 @@ import { revalidatePath, revalidateTag } from 'next/cache'
 import { after } from 'next/server'
 
 import {
-  Prisma,
   GraduationStatus,
   PaymentFrequency,
   StudentBillingType,
@@ -12,7 +11,6 @@ import {
 import { z } from 'zod'
 
 import { featureFlags } from '@/lib/config/feature-flags'
-import { prisma } from '@/lib/db'
 import {
   createBatch,
   deleteBatch,
@@ -23,14 +21,20 @@ import {
 } from '@/lib/db/queries/batch'
 import {
   getStudentById,
+  getProfileForPaymentLink,
+  setProfileBillingDefaults,
   resolveDuplicateStudents,
   getStudentDeleteWarnings,
 } from '@/lib/db/queries/student'
-import { ACTIVE_BILLING_ASSIGNMENT_WHERE } from '@/lib/db/query-builders'
 import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
 import { getMahadKeys } from '@/lib/keys/stripe'
 import { createActionLogger } from '@/lib/logger'
 import { adminActionClient } from '@/lib/safe-action'
+import {
+  deleteStudentProfile,
+  bulkDeleteStudentProfiles,
+  updateStudentProfile,
+} from '@/lib/services/mahad/student-mutation-service'
 import { getMahadStripeClient } from '@/lib/stripe-mahad'
 import { validateBillingCycleAnchor } from '@/lib/utils/billing-date'
 import {
@@ -496,38 +500,7 @@ const _deleteStudentAction = adminActionClient
     // Best-effort guard under READ COMMITTED — not serializable, but
     // sufficient for admin-only tooling where concurrent subscription
     // creation targeting the same profile is operationally negligible.
-    try {
-      await prisma.$transaction(async (tx) => {
-        const liveAssignment = await tx.billingAssignment.findFirst({
-          where: {
-            programProfileId: parsedInput.id,
-            ...ACTIVE_BILLING_ASSIGNMENT_WHERE,
-          },
-        })
-        if (liveAssignment) {
-          throw new ActionError(
-            'Cannot delete student with active billing subscription. Cancel the subscription first.',
-            ERROR_CODES.ACTIVE_SUBSCRIPTION,
-            undefined,
-            403
-          )
-        }
-
-        await tx.programProfile.delete({ where: { id: parsedInput.id } })
-      })
-    } catch (error) {
-      if (error instanceof ActionError) throw error
-      if (isPrismaError(error)) {
-        if (error.code === 'P2025')
-          throw new ActionError('Student not found', ERROR_CODES.NOT_FOUND)
-        if (error.code === 'P2003')
-          throw new ActionError(
-            'Cannot delete student with related records',
-            ERROR_CODES.VALIDATION_ERROR
-          )
-      }
-      throw error
-    }
+    await deleteStudentProfile(parsedInput.id)
 
     after(() => {
       revalidateTag('mahad-stats')
@@ -548,37 +521,8 @@ const _bulkDeleteStudentsAction = adminActionClient
   .action(async ({ parsedInput }): Promise<BulkDeleteResult> => {
     const { studentIds } = parsedInput
 
-    const { deletedCount, blockedIds } = await prisma.$transaction(
-      async (tx) => {
-        const activeAssignments = await tx.billingAssignment.findMany({
-          where: {
-            programProfileId: { in: studentIds },
-            ...ACTIVE_BILLING_ASSIGNMENT_WHERE,
-          },
-          select: { programProfileId: true },
-        })
-
-        const blockedIdSet = new Set(
-          activeAssignments.map((a) => a.programProfileId)
-        )
-        const safe = studentIds.filter((id) => !blockedIdSet.has(id))
-        const blocked = studentIds.filter((id) => blockedIdSet.has(id))
-
-        let deleted = 0
-
-        if (safe.length > 0) {
-          const result = await tx.programProfile.deleteMany({
-            where: { id: { in: safe } },
-          })
-          deleted = result.count
-        }
-
-        return {
-          deletedCount: deleted,
-          blockedIds: blocked,
-        }
-      }
-    )
+    const { deletedCount, blockedIds } =
+      await bulkDeleteStudentProfiles(studentIds)
 
     if (deletedCount > 0) {
       after(() => {
@@ -586,13 +530,6 @@ const _bulkDeleteStudentsAction = adminActionClient
         revalidateTag('mahad-students')
         revalidatePath('/admin/mahad')
       })
-    }
-
-    if (deletedCount === 0 && blockedIds.length > 0) {
-      throw new ActionError(
-        `All ${blockedIds.length} student(s) have active subscriptions and cannot be deleted`,
-        ERROR_CODES.ACTIVE_SUBSCRIPTION
-      )
     }
 
     return { deletedCount, blockedIds }
@@ -632,100 +569,45 @@ const _updateStudentAction = adminActionClient
       )
     }
 
-    try {
-      await prisma.$transaction(async (tx) => {
-        const profile = await tx.programProfile.findUnique({
-          where: { id },
-          relationLoadStrategy: 'join',
-          include: {
-            person: true,
-            enrollments: { orderBy: { startDate: 'desc' }, take: 1 },
-          },
-        })
-
-        if (!profile) throw new Error('Profile not found')
-
-        const personUpdate: Prisma.PersonUpdateInput = {}
-        if (validated.name !== undefined) personUpdate.name = validated.name
-        if (validated.dateOfBirth !== undefined)
-          personUpdate.dateOfBirth = validated.dateOfBirth || null
-        if (validated.email !== undefined)
-          personUpdate.email = normalizeEmail(validated.email)
-        if (validated.phone !== undefined)
-          personUpdate.phone = normalizedPhone || null
-
-        if (Object.keys(personUpdate).length > 0) {
-          await tx.person.update({
-            where: { id: profile.personId },
-            data: personUpdate,
-          })
-        }
-
-        const profileFields = {
-          ...(validated.gradeLevel !== undefined && {
-            gradeLevel: validated.gradeLevel || null,
-          }),
-          ...(validated.schoolName !== undefined && {
-            schoolName: validated.schoolName || null,
-          }),
-          ...(validated.graduationStatus !== undefined && {
-            graduationStatus: validated.graduationStatus || null,
-          }),
-          ...(validated.paymentFrequency !== undefined && {
-            paymentFrequency: validated.paymentFrequency || null,
-          }),
-          ...(validated.billingType !== undefined && {
-            billingType: validated.billingType || null,
-          }),
-          ...(validated.paymentNotes !== undefined && {
-            paymentNotes: validated.paymentNotes || null,
-          }),
-        }
-
-        if (Object.keys(profileFields).length > 0) {
-          await tx.programProfile.update({
-            where: { id },
-            data: profileFields,
-          })
-        }
-
-        if (validated.batchId !== undefined) {
-          const latestEnrollment = profile.enrollments[0]
-          if (latestEnrollment) {
-            await tx.enrollment.update({
-              where: { id: latestEnrollment.id },
-              data: { batchId: validated.batchId || null },
-            })
-          } else if (validated.batchId) {
-            await tx.enrollment.create({
-              data: {
-                programProfileId: id,
-                batchId: validated.batchId,
-                status: 'REGISTERED',
-                startDate: new Date(),
-              },
-            })
-          }
-        }
-      })
-    } catch (error) {
-      if (error instanceof ActionError) throw error
-      if (isPrismaError(error)) {
-        if (error.code === 'P2002')
-          throw new ActionError(
-            'This email or phone is already associated with another student',
-            ERROR_CODES.VALIDATION_ERROR
-          )
-        if (error.code === 'P2025')
-          throw new ActionError('Student not found', ERROR_CODES.NOT_FOUND)
-        if (error.code === 'P2003')
-          throw new ActionError(
-            'Invalid batch or related record reference',
-            ERROR_CODES.VALIDATION_ERROR
-          )
-      }
-      throw error
-    }
+    await updateStudentProfile(id, {
+      name: validated.name,
+      dateOfBirth:
+        validated.dateOfBirth !== undefined
+          ? validated.dateOfBirth || null
+          : undefined,
+      email:
+        validated.email !== undefined
+          ? normalizeEmail(validated.email)
+          : undefined,
+      phone:
+        validated.phone !== undefined ? normalizedPhone || null : undefined,
+      gradeLevel:
+        validated.gradeLevel !== undefined
+          ? validated.gradeLevel || null
+          : undefined,
+      schoolName:
+        validated.schoolName !== undefined
+          ? validated.schoolName || null
+          : undefined,
+      graduationStatus:
+        validated.graduationStatus !== undefined
+          ? validated.graduationStatus || null
+          : undefined,
+      paymentFrequency:
+        validated.paymentFrequency !== undefined
+          ? validated.paymentFrequency || null
+          : undefined,
+      billingType:
+        validated.billingType !== undefined
+          ? validated.billingType || null
+          : undefined,
+      paymentNotes:
+        validated.paymentNotes !== undefined
+          ? validated.paymentNotes || null
+          : undefined,
+      batchId:
+        validated.batchId !== undefined ? validated.batchId || null : undefined,
+    })
 
     after(() => {
       revalidateTag('mahad-stats')
@@ -764,13 +646,7 @@ async function createPaymentLinkSession(
   profileId: string
 ): Promise<PaymentLinkData> {
   // 1. Fetch profile with billing config and contact info
-  const profile = await prisma.programProfile.findUnique({
-    where: { id: profileId },
-    relationLoadStrategy: 'join',
-    include: {
-      person: true,
-    },
-  })
+  const profile = await getProfileForPaymentLink(profileId)
 
   if (!profile) {
     throw new ActionError('Student profile not found', ERROR_CODES.NOT_FOUND)
@@ -932,31 +808,14 @@ const _generatePaymentLinkWithDefaultsAction = adminActionClient
   .action(async ({ parsedInput }): Promise<PaymentLinkData> => {
     const { profileId } = parsedInput
 
-    // Use transaction to ensure check + update are atomic
-    await prisma.$transaction(async (tx) => {
-      // 1. Check student exists
-      const profile = await tx.programProfile.findUnique({
-        where: { id: profileId },
-        select: { id: true },
-      })
-
-      if (!profile) {
-        throw new ActionError(
-          'Student profile not found',
-          ERROR_CODES.NOT_FOUND
-        )
-      }
-
-      // 2. Update billing config with defaults
-      await tx.programProfile.update({
-        where: { id: profileId },
-        data: {
-          graduationStatus: DEFAULT_BILLING_CONFIG.graduationStatus,
-          billingType: DEFAULT_BILLING_CONFIG.billingType,
-          paymentFrequency: DEFAULT_BILLING_CONFIG.paymentFrequency,
-        },
-      })
-    })
+    // Set defaults atomically; returns null if profile not found
+    const updated = await setProfileBillingDefaults(
+      profileId,
+      DEFAULT_BILLING_CONFIG
+    )
+    if (!updated) {
+      throw new ActionError('Student profile not found', ERROR_CODES.NOT_FOUND)
+    }
 
     after(() => {
       revalidateTag('mahad-stats')
@@ -1032,13 +891,7 @@ const _generatePaymentLinkWithOverrideAction = adminActionClient
     }
 
     // 1. Fetch profile with billing config and contact info
-    const profile = await prisma.programProfile.findUnique({
-      where: { id: profileId },
-      relationLoadStrategy: 'join',
-      include: {
-        person: true,
-      },
-    })
+    const profile = await getProfileForPaymentLink(profileId)
 
     if (!profile) {
       throw new ActionError('Student profile not found', ERROR_CODES.NOT_FOUND)

--- a/app/admin/mahad/_actions/index.ts
+++ b/app/admin/mahad/_actions/index.ts
@@ -29,7 +29,7 @@ import {
 } from '@/lib/db/queries/student'
 import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
 import { getMahadKeys } from '@/lib/keys/stripe'
-import { createActionLogger } from '@/lib/logger'
+import { createActionLogger, logError } from '@/lib/logger'
 import { adminActionClient } from '@/lib/safe-action'
 import {
   deleteStudentProfile,
@@ -1010,9 +1010,13 @@ const _generatePaymentLinkWithOverrideAction = adminActionClient
       billingCycleAnchor = Math.floor(startDate.getTime() / 1000)
       try {
         validateBillingCycleAnchor(billingCycleAnchor)
-      } catch {
+      } catch (error) {
+        await logError(logger, error, 'Invalid billing cycle anchor', {
+          billingCycleAnchor,
+          profileId,
+        })
         throw new ActionError(
-          'Invalid billing start date',
+          error instanceof Error ? error.message : 'Invalid billing start date',
           ERROR_CODES.VALIDATION_ERROR
         )
       }

--- a/app/admin/mahad/_actions/index.ts
+++ b/app/admin/mahad/_actions/index.ts
@@ -15,6 +15,7 @@ import {
   createBatch,
   deleteBatch,
   getBatchById,
+  getBatchByName,
   updateBatch,
   assignStudentsToBatch,
   transferStudents,
@@ -152,30 +153,27 @@ const _createBatchAction = adminActionClient
       endDate: parsedInput.endDate ?? undefined,
     })
 
-    let batchName = validated.name
-    try {
-      const batch = await createBatch({
-        name: validated.name,
-        startDate: validated.startDate ?? null,
-        endDate: validated.endDate ?? null,
-      })
-
-      after(() => {
-        revalidateTag('mahad-stats')
-        revalidateTag('mahad-students')
-        revalidatePath('/admin/mahad')
-      })
-
-      return batch
-    } catch (error) {
-      if (isPrismaError(error) && error.code === 'P2002') {
-        throw new ActionError(
-          `A cohort with the name "${batchName}" already exists`,
-          ERROR_CODES.VALIDATION_ERROR
-        )
-      }
-      throw error
+    const existing = await getBatchByName(validated.name)
+    if (existing) {
+      throw new ActionError(
+        `A cohort with the name "${validated.name}" already exists`,
+        ERROR_CODES.VALIDATION_ERROR
+      )
     }
+
+    const batch = await createBatch({
+      name: validated.name,
+      startDate: validated.startDate ?? null,
+      endDate: validated.endDate ?? null,
+    })
+
+    after(() => {
+      revalidateTag('mahad-stats')
+      revalidateTag('mahad-students')
+      revalidatePath('/admin/mahad')
+    })
+
+    return batch
   })
 
 export async function createBatchAction(
@@ -240,33 +238,29 @@ const _updateBatchAction = adminActionClient
       throw new ActionError('Cohort not found', ERROR_CODES.NOT_FOUND)
     }
 
-    let batchName = data.name
-    try {
-      const batch = await updateBatch(id, {
-        name: validated.name,
-        startDate: validated.startDate,
-        endDate: validated.endDate,
-      })
-
-      after(() => {
-        revalidateTag('mahad-stats')
-        revalidateTag('mahad-students')
-        revalidatePath('/admin/mahad')
-      })
-
-      return batch
-    } catch (error) {
-      if (isPrismaError(error)) {
-        if (error.code === 'P2002')
-          throw new ActionError(
-            `A cohort with the name "${batchName}" already exists`,
-            ERROR_CODES.VALIDATION_ERROR
-          )
-        if (error.code === 'P2025')
-          throw new ActionError('Cohort not found', ERROR_CODES.NOT_FOUND)
+    if (validated.name !== undefined) {
+      const conflict = await getBatchByName(validated.name)
+      if (conflict && conflict.id !== id) {
+        throw new ActionError(
+          `A cohort with the name "${validated.name}" already exists`,
+          ERROR_CODES.VALIDATION_ERROR
+        )
       }
-      throw error
     }
+
+    const batch = await updateBatch(id, {
+      name: validated.name,
+      startDate: validated.startDate,
+      endDate: validated.endDate,
+    })
+
+    after(() => {
+      revalidateTag('mahad-stats')
+      revalidateTag('mahad-students')
+      revalidatePath('/admin/mahad')
+    })
+
+    return batch
   })
 
 export async function updateBatchAction(

--- a/app/admin/mahad/payments/components/stats-cards.tsx
+++ b/app/admin/mahad/payments/components/stats-cards.tsx
@@ -9,91 +9,13 @@ import {
 } from 'lucide-react'
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
-import { MAHAD_PROGRAM } from '@/lib/constants/mahad'
-import { prisma } from '@/lib/db'
+import { getMahadPaymentStats } from '@/lib/db/queries/mahad-payments'
 
 const getCachedStats = unstable_cache(
-  async () => getStats(),
+  async () => getMahadPaymentStats(),
   ['mahad-payment-stats'],
   { revalidate: 60, tags: ['mahad-stats'] }
 )
-
-async function getStats() {
-  // Count Mahad program profiles (excluding Test batch)
-  const [
-    totalStudents,
-    enrolledStudents,
-    registeredStudents,
-    activeSubscriptions,
-    totalRevenue,
-  ] = await Promise.all([
-    // Total non-withdrawn students
-    prisma.enrollment.count({
-      where: {
-        status: { not: 'WITHDRAWN' },
-        programProfile: {
-          program: MAHAD_PROGRAM,
-        },
-        batch: {
-          name: { not: 'Test' },
-        },
-      },
-    }),
-    // Enrolled students
-    prisma.enrollment.count({
-      where: {
-        status: 'ENROLLED',
-        programProfile: {
-          program: MAHAD_PROGRAM,
-        },
-        batch: {
-          name: { not: 'Test' },
-        },
-      },
-    }),
-    // Registered students
-    prisma.enrollment.count({
-      where: {
-        status: 'REGISTERED',
-        programProfile: {
-          program: MAHAD_PROGRAM,
-        },
-        batch: {
-          name: { not: 'Test' },
-        },
-      },
-    }),
-    // Active subscriptions
-    prisma.billingAssignment.count({
-      where: {
-        isActive: true,
-        subscription: {
-          status: 'active',
-        },
-        programProfile: {
-          program: MAHAD_PROGRAM,
-        },
-      },
-    }),
-    // Total revenue from StudentPayment (still uses old model structure)
-    prisma.studentPayment.aggregate({
-      _sum: { amountPaid: true },
-      where: {
-        ProgramProfile: {
-          program: MAHAD_PROGRAM,
-        },
-      },
-    }),
-  ])
-
-  return {
-    totalStudents,
-    activeSubscriptions,
-    registeredStudents,
-    totalRevenue: totalRevenue._sum.amountPaid || 0,
-    enrolledStudents,
-  }
-}
 
 export async function StatsCards() {
   const {

--- a/app/admin/mahad/payments/components/students-table-shell.tsx
+++ b/app/admin/mahad/payments/components/students-table-shell.tsx
@@ -1,3 +1,6 @@
+import { type SearchParams } from 'nuqs/server'
+
+import { paymentsSearchParamsCache } from '@/app/admin/mahad/payments/search-params'
 import {
   Card,
   CardContent,
@@ -16,7 +19,6 @@ import {
   getMahadStudentsPage,
   getSubscriptionMembersBatch,
 } from '@/lib/db/queries/mahad-payments'
-import { SearchParams } from '@/types'
 
 import { PaymentsPagination } from './payments-pagination'
 import { StudentsDataTable } from './students-data-table'
@@ -31,19 +33,16 @@ export async function StudentsTableShell({
   searchParams,
 }: StudentsTableShellProps) {
   const { page, per_page, sort, studentName, batchId, status, needsBilling } =
-    await searchParams
-
-  const pageNumber = Number(page) || 1
-  const take = Number(per_page) || 10
+    await paymentsSearchParamsCache.parse(searchParams)
 
   const { enrollments, totalCount } = await getMahadStudentsPage({
-    page: pageNumber,
-    take,
-    sort: Array.isArray(sort) ? sort[0] : sort,
-    studentName: Array.isArray(studentName) ? studentName[0] : studentName,
-    batchId: Array.isArray(batchId) ? batchId[0] : batchId,
-    status: Array.isArray(status) ? status[0] : status,
-    needsBilling: Array.isArray(needsBilling) ? needsBilling[0] : needsBilling,
+    page,
+    take: per_page,
+    sort: sort ?? undefined,
+    studentName: studentName ?? undefined,
+    batchId: batchId ?? undefined,
+    status: status ?? undefined,
+    needsBilling: needsBilling ?? undefined,
   })
 
   const subscriptionIds = enrollments
@@ -88,7 +87,7 @@ export async function StudentsTableShell({
     }
   })
 
-  const pageCount = Math.ceil(totalCount / take)
+  const pageCount = Math.ceil(totalCount / per_page)
 
   return (
     <Card className="border-border bg-card">

--- a/app/admin/mahad/payments/components/students-table-shell.tsx
+++ b/app/admin/mahad/payments/components/students-table-shell.tsx
@@ -1,5 +1,3 @@
-import { Prisma } from '@prisma/client'
-
 import {
   Card,
   CardContent,
@@ -14,89 +12,16 @@ import {
   TableHead,
   TableBody,
 } from '@/components/ui/table'
-import { MAHAD_PROGRAM } from '@/lib/constants/mahad'
-import { prisma } from '@/lib/db'
+import {
+  getMahadStudentsPage,
+  getSubscriptionMembersBatch,
+} from '@/lib/db/queries/mahad-payments'
 import { SearchParams } from '@/types'
 
 import { PaymentsPagination } from './payments-pagination'
 import { StudentsDataTable } from './students-data-table'
 import { StudentsMobileCards } from './students-mobile-cards'
 import { StudentsTableFilters } from './students-table-filters'
-
-type SubscriptionMember = { id: string; name: string }
-
-/**
- * Batch fetch subscription members for multiple subscriptions.
- * Returns a Map of subscriptionId -> array of other members sharing that subscription.
- * This avoids N+1 queries when loading student lists.
- */
-async function getSubscriptionMembersBatch(
-  subscriptionIds: string[]
-): Promise<Map<string, Map<string, SubscriptionMember[]>>> {
-  if (subscriptionIds.length === 0) {
-    return new Map()
-  }
-
-  // Single query to get all billing assignments for all subscriptions
-  const allAssignments = await prisma.billingAssignment.findMany({
-    where: {
-      subscriptionId: { in: subscriptionIds },
-      isActive: true,
-    },
-    select: {
-      subscriptionId: true,
-      programProfileId: true,
-      programProfile: {
-        select: {
-          id: true,
-          person: {
-            select: {
-              name: true,
-            },
-          },
-        },
-      },
-    },
-  })
-
-  // Step 1: Group assignments by subscriptionId (O(n))
-  const assignmentsBySubscription = new Map<string, typeof allAssignments>()
-  for (const assignment of allAssignments) {
-    if (!assignment.subscriptionId) continue
-
-    const existing = assignmentsBySubscription.get(assignment.subscriptionId)
-    if (existing) {
-      existing.push(assignment)
-    } else {
-      assignmentsBySubscription.set(assignment.subscriptionId, [assignment])
-    }
-  }
-
-  // Step 2: Build member map for each subscription (O(n) total)
-  const subscriptionMap = new Map<string, Map<string, SubscriptionMember[]>>()
-
-  assignmentsBySubscription.forEach(
-    (subscriptionAssignments, subscriptionId) => {
-      const profileMap = new Map<string, SubscriptionMember[]>()
-
-      // For each profile in this subscription, list other members
-      for (const assignment of subscriptionAssignments) {
-        const otherMembers = subscriptionAssignments
-          .filter((a) => a.programProfileId !== assignment.programProfileId)
-          .map((a) => ({
-            id: a.programProfile.id,
-            name: a.programProfile.person.name,
-          }))
-
-        profileMap.set(assignment.programProfileId, otherMembers)
-      }
-
-      subscriptionMap.set(subscriptionId, profileMap)
-    }
-  )
-
-  return subscriptionMap
-}
 
 interface StudentsTableShellProps {
   searchParams: SearchParams
@@ -110,114 +35,21 @@ export async function StudentsTableShell({
 
   const pageNumber = Number(page) || 1
   const take = Number(per_page) || 10
-  const skip = (pageNumber - 1) * take
 
-  const sortString = Array.isArray(sort) ? sort[0] : sort
-  const [column, order] = (sortString?.split('.') || ['name', 'asc']) as [
-    string,
-    'asc' | 'desc',
-  ]
-
-  // Build where clause with proper Prisma typing
-  const whereConditions: Prisma.EnrollmentWhereInput[] = [
-    // Mahad program only
-    { programProfile: { program: MAHAD_PROGRAM } },
-    // Exclude Test batch
-    { batch: { name: { not: 'Test' } } },
-  ]
-
-  // Handle the special "needs billing" filter
-  if (needsBilling === 'true') {
-    whereConditions.push(
-      { status: { not: 'WITHDRAWN' } },
-      // Find profiles without active billing assignments (no subscription linked)
-      // Note: Type assertion to unknown needed due to Prisma limitation with { isNot: null }
-      // See: https://github.com/prisma/prisma/issues/5042
-      {
-        programProfile: {
-          assignments: {
-            none: {
-              isActive: true,
-              subscription: { isNot: null },
-            },
-          },
-        },
-      } as unknown as Prisma.EnrollmentWhereInput
-    )
-  } else {
-    // Regular filters
-    if (studentName) {
-      // Handle case where studentName could be an array
-      const nameFilter = Array.isArray(studentName)
-        ? studentName[0]
-        : studentName
-      if (nameFilter) {
-        whereConditions.push({
-          programProfile: {
-            person: {
-              name: {
-                contains: nameFilter,
-                mode: 'insensitive',
-              },
-            },
-          },
-        })
-      }
-    }
-    if (batchId) {
-      const batchFilter = Array.isArray(batchId) ? batchId[0] : batchId
-      if (batchFilter) {
-        whereConditions.push({ batchId: batchFilter })
-      }
-    }
-    if (status) {
-      const statusValue = Array.isArray(status) ? status[0] : status
-      if (statusValue) {
-        whereConditions.push({
-          status: statusValue.toUpperCase() as
-            | 'REGISTERED'
-            | 'ENROLLED'
-            | 'WITHDRAWN',
-        })
-      }
-    } else {
-      whereConditions.push({ status: { not: 'WITHDRAWN' } })
-    }
-  }
-
-  // Get enrollments with related data
-  const enrollments = await prisma.enrollment.findMany({
-    where: {
-      AND: whereConditions,
-    },
-    include: {
-      batch: true,
-      programProfile: {
-        include: {
-          person: true,
-          assignments: {
-            where: { isActive: true },
-            include: {
-              subscription: true,
-            },
-          },
-        },
-      },
-    },
-    orderBy:
-      column === 'name'
-        ? { programProfile: { person: { name: order } } }
-        : { [column]: order },
+  const { enrollments, totalCount } = await getMahadStudentsPage({
+    page: pageNumber,
     take,
-    skip,
+    sort: Array.isArray(sort) ? sort[0] : sort,
+    studentName: Array.isArray(studentName) ? studentName[0] : studentName,
+    batchId: Array.isArray(batchId) ? batchId[0] : batchId,
+    status: Array.isArray(status) ? status[0] : status,
+    needsBilling: Array.isArray(needsBilling) ? needsBilling[0] : needsBilling,
   })
 
-  // Collect all subscription IDs for batch query (fixes N+1 query)
   const subscriptionIds = enrollments
     .map((e) => e.programProfile.assignments[0]?.subscription?.id)
     .filter((id): id is string => id !== undefined && id !== null)
 
-  // Single batch query for all subscription members
   const subscriptionMembersMap =
     await getSubscriptionMembersBatch(subscriptionIds)
 
@@ -256,13 +88,7 @@ export async function StudentsTableShell({
     }
   })
 
-  // Get total count
-  const totalStudents = await prisma.enrollment.count({
-    where: {
-      AND: whereConditions,
-    },
-  })
-  const pageCount = Math.ceil(totalStudents / take)
+  const pageCount = Math.ceil(totalCount / take)
 
   return (
     <Card className="border-border bg-card">

--- a/app/admin/mahad/payments/search-params.ts
+++ b/app/admin/mahad/payments/search-params.ts
@@ -1,0 +1,26 @@
+import {
+  createSearchParamsCache,
+  parseAsInteger,
+  parseAsString,
+  parseAsStringLiteral,
+} from 'nuqs/server'
+
+const SORT_OPTIONS = ['name.asc', 'name.desc'] as const
+
+const STATUS_OPTIONS = [
+  'registered',
+  'enrolled',
+  'withdrawn',
+  'on_leave',
+  'completed',
+] as const
+
+export const paymentsSearchParamsCache = createSearchParamsCache({
+  page: parseAsInteger.withDefault(1),
+  per_page: parseAsInteger.withDefault(10),
+  sort: parseAsStringLiteral(SORT_OPTIONS),
+  studentName: parseAsString,
+  batchId: parseAsString,
+  status: parseAsStringLiteral(STATUS_OPTIONS),
+  needsBilling: parseAsString,
+})

--- a/app/admin/mahad/payments/search-params.ts
+++ b/app/admin/mahad/payments/search-params.ts
@@ -1,5 +1,6 @@
 import {
   createSearchParamsCache,
+  parseAsBoolean,
   parseAsInteger,
   parseAsString,
   parseAsStringLiteral,
@@ -22,5 +23,5 @@ export const paymentsSearchParamsCache = createSearchParamsCache({
   studentName: parseAsString,
   batchId: parseAsString,
   status: parseAsStringLiteral(STATUS_OPTIONS),
-  needsBilling: parseAsString,
+  needsBilling: parseAsBoolean,
 })

--- a/lib/db/queries/mahad-payments.ts
+++ b/lib/db/queries/mahad-payments.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client'
+import { EnrollmentStatus, Prisma } from '@prisma/client'
 
 import { MAHAD_PROGRAM } from '@/lib/constants/mahad'
 import { prisma } from '@/lib/db'
@@ -136,10 +136,9 @@ export async function getMahadStudentsPage(
     params
   const skip = (page - 1) * take
 
-  const [column, order] = (sort?.split('.') ?? ['name', 'asc']) as [
-    string,
-    'asc' | 'desc',
-  ]
+  const sortParts = sort?.split('.') ?? []
+  const column = sortParts[0] ?? 'name'
+  const order: 'asc' | 'desc' = sortParts[1] === 'desc' ? 'desc' : 'asc'
 
   const whereConditions: Prisma.EnrollmentWhereInput[] = [
     { programProfile: { program: MAHAD_PROGRAM } },
@@ -166,9 +165,10 @@ export async function getMahadStudentsPage(
       whereConditions.push({ batchId })
     }
     if (status) {
-      whereConditions.push({
-        status: status.toUpperCase() as 'REGISTERED' | 'ENROLLED' | 'WITHDRAWN',
-      })
+      const upperStatus = status.toUpperCase() as EnrollmentStatus
+      if ((Object.values(EnrollmentStatus) as string[]).includes(upperStatus)) {
+        whereConditions.push({ status: upperStatus })
+      }
     } else {
       whereConditions.push({ status: { not: 'WITHDRAWN' } })
     }

--- a/lib/db/queries/mahad-payments.ts
+++ b/lib/db/queries/mahad-payments.ts
@@ -3,6 +3,7 @@ import { EnrollmentStatus, Prisma } from '@prisma/client'
 import { MAHAD_PROGRAM } from '@/lib/constants/mahad'
 import { prisma } from '@/lib/db'
 import { DatabaseClient } from '@/lib/db/types'
+import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
 
 // ============================================================================
 // Stats
@@ -134,6 +135,10 @@ export async function getMahadStudentsPage(
 ) {
   const { page, take, sort, studentName, batchId, status, needsBilling } =
     params
+
+  if (page < 1)
+    throw new ActionError('Invalid page number', ERROR_CODES.VALIDATION_ERROR)
+
   const skip = (page - 1) * take
 
   const order: 'asc' | 'desc' = sort === 'name.desc' ? 'desc' : 'asc'

--- a/lib/db/queries/mahad-payments.ts
+++ b/lib/db/queries/mahad-payments.ts
@@ -125,7 +125,7 @@ export interface MahadStudentsPageParams {
   studentName?: string
   batchId?: string
   status?: string
-  needsBilling?: string
+  needsBilling?: boolean
 }
 
 export async function getMahadStudentsPage(
@@ -136,23 +136,22 @@ export async function getMahadStudentsPage(
     params
   const skip = (page - 1) * take
 
-  const sortParts = sort?.split('.') ?? []
-  const column = sortParts[0] ?? 'name'
-  const order: 'asc' | 'desc' = sortParts[1] === 'desc' ? 'desc' : 'asc'
+  const order: 'asc' | 'desc' = sort === 'name.desc' ? 'desc' : 'asc'
 
   const whereConditions: Prisma.EnrollmentWhereInput[] = [
     { programProfile: { program: MAHAD_PROGRAM } },
     { batch: { name: { not: 'Test' } } },
   ]
 
-  if (needsBilling === 'true') {
-    whereConditions.push({ status: { not: 'WITHDRAWN' } }, {
-      programProfile: {
-        assignments: {
-          none: { isActive: true, subscription: { isNot: null } },
+  if (needsBilling) {
+    whereConditions.push(
+      { status: { not: EnrollmentStatus.WITHDRAWN } },
+      {
+        programProfile: {
+          assignments: { none: { isActive: true } },
         },
-      },
-    } as unknown as Prisma.EnrollmentWhereInput)
+      }
+    )
   } else {
     if (studentName) {
       whereConditions.push({
@@ -165,12 +164,13 @@ export async function getMahadStudentsPage(
       whereConditions.push({ batchId })
     }
     if (status) {
-      const upperStatus = status.toUpperCase() as EnrollmentStatus
-      if ((Object.values(EnrollmentStatus) as string[]).includes(upperStatus)) {
-        whereConditions.push({ status: upperStatus })
+      const upperStatus = status.toUpperCase()
+      const enumValues = Object.values(EnrollmentStatus) as string[]
+      if (enumValues.includes(upperStatus)) {
+        whereConditions.push({ status: upperStatus as EnrollmentStatus })
       }
     } else {
-      whereConditions.push({ status: { not: 'WITHDRAWN' } })
+      whereConditions.push({ status: { not: EnrollmentStatus.WITHDRAWN } })
     }
   }
 
@@ -192,10 +192,7 @@ export async function getMahadStudentsPage(
           },
         },
       },
-      orderBy:
-        column === 'name'
-          ? { programProfile: { person: { name: order } } }
-          : { [column]: order },
+      orderBy: { programProfile: { person: { name: order } } },
       take,
       skip,
     }),

--- a/lib/db/queries/mahad-payments.ts
+++ b/lib/db/queries/mahad-payments.ts
@@ -73,6 +73,7 @@ export async function getSubscriptionMembersBatch(
 
   const allAssignments = await client.billingAssignment.findMany({
     where: { subscriptionId: { in: subscriptionIds }, isActive: true },
+    relationLoadStrategy: 'join',
     select: {
       subscriptionId: true,
       programProfileId: true,
@@ -191,6 +192,7 @@ export async function getMahadStudentsPage(
   const [enrollments, totalCount] = await Promise.all([
     client.enrollment.findMany({
       where,
+      relationLoadStrategy: 'join',
       include: {
         batch: true,
         programProfile: {

--- a/lib/db/queries/mahad-payments.ts
+++ b/lib/db/queries/mahad-payments.ts
@@ -1,0 +1,217 @@
+import { Prisma } from '@prisma/client'
+
+import { MAHAD_PROGRAM } from '@/lib/constants/mahad'
+import { prisma } from '@/lib/db'
+import { DatabaseClient } from '@/lib/db/types'
+
+// ============================================================================
+// Stats
+// ============================================================================
+
+export async function getMahadPaymentStats(client: DatabaseClient = prisma) {
+  const [
+    totalStudents,
+    enrolledStudents,
+    registeredStudents,
+    activeSubscriptions,
+    totalRevenue,
+  ] = await Promise.all([
+    client.enrollment.count({
+      where: {
+        status: { not: 'WITHDRAWN' },
+        programProfile: { program: MAHAD_PROGRAM },
+        batch: { name: { not: 'Test' } },
+      },
+    }),
+    client.enrollment.count({
+      where: {
+        status: 'ENROLLED',
+        programProfile: { program: MAHAD_PROGRAM },
+        batch: { name: { not: 'Test' } },
+      },
+    }),
+    client.enrollment.count({
+      where: {
+        status: 'REGISTERED',
+        programProfile: { program: MAHAD_PROGRAM },
+        batch: { name: { not: 'Test' } },
+      },
+    }),
+    client.billingAssignment.count({
+      where: {
+        isActive: true,
+        subscription: { status: 'active' },
+        programProfile: { program: MAHAD_PROGRAM },
+      },
+    }),
+    client.studentPayment.aggregate({
+      _sum: { amountPaid: true },
+      where: { ProgramProfile: { program: MAHAD_PROGRAM } },
+    }),
+  ])
+
+  return {
+    totalStudents,
+    enrolledStudents,
+    registeredStudents,
+    activeSubscriptions,
+    totalRevenue: totalRevenue._sum.amountPaid ?? 0,
+  }
+}
+
+// ============================================================================
+// Subscription members (avoids N+1 on student table)
+// ============================================================================
+
+type SubscriptionMember = { id: string; name: string }
+
+export async function getSubscriptionMembersBatch(
+  subscriptionIds: string[],
+  client: DatabaseClient = prisma
+): Promise<Map<string, Map<string, SubscriptionMember[]>>> {
+  if (subscriptionIds.length === 0) return new Map()
+
+  const allAssignments = await client.billingAssignment.findMany({
+    where: { subscriptionId: { in: subscriptionIds }, isActive: true },
+    select: {
+      subscriptionId: true,
+      programProfileId: true,
+      programProfile: {
+        select: { id: true, person: { select: { name: true } } },
+      },
+    },
+  })
+
+  const assignmentsBySubscription = new Map<string, typeof allAssignments>()
+  for (const assignment of allAssignments) {
+    if (!assignment.subscriptionId) continue
+    const existing = assignmentsBySubscription.get(assignment.subscriptionId)
+    if (existing) {
+      existing.push(assignment)
+    } else {
+      assignmentsBySubscription.set(assignment.subscriptionId, [assignment])
+    }
+  }
+
+  const subscriptionMap = new Map<string, Map<string, SubscriptionMember[]>>()
+  assignmentsBySubscription.forEach(
+    (subscriptionAssignments, subscriptionId) => {
+      const profileMap = new Map<string, SubscriptionMember[]>()
+      for (const assignment of subscriptionAssignments) {
+        const otherMembers = subscriptionAssignments
+          .filter((a) => a.programProfileId !== assignment.programProfileId)
+          .map((a) => ({
+            id: a.programProfile.id,
+            name: a.programProfile.person.name,
+          }))
+        profileMap.set(assignment.programProfileId, otherMembers)
+      }
+      subscriptionMap.set(subscriptionId, profileMap)
+    }
+  )
+
+  return subscriptionMap
+}
+
+// ============================================================================
+// Paginated student list
+// ============================================================================
+
+export interface MahadStudentsPageParams {
+  page: number
+  take: number
+  sort?: string
+  studentName?: string
+  batchId?: string
+  status?: string
+  needsBilling?: string
+}
+
+export async function getMahadStudentsPage(
+  params: MahadStudentsPageParams,
+  client: DatabaseClient = prisma
+) {
+  const { page, take, sort, studentName, batchId, status, needsBilling } =
+    params
+  const skip = (page - 1) * take
+
+  const sortString = Array.isArray(sort) ? sort[0] : sort
+  const [column, order] = (sortString?.split('.') ?? ['name', 'asc']) as [
+    string,
+    'asc' | 'desc',
+  ]
+
+  const whereConditions: Prisma.EnrollmentWhereInput[] = [
+    { programProfile: { program: MAHAD_PROGRAM } },
+    { batch: { name: { not: 'Test' } } },
+  ]
+
+  if (needsBilling === 'true') {
+    whereConditions.push({ status: { not: 'WITHDRAWN' } }, {
+      programProfile: {
+        assignments: {
+          none: { isActive: true, subscription: { isNot: null } },
+        },
+      },
+    } as unknown as Prisma.EnrollmentWhereInput)
+  } else {
+    if (studentName) {
+      const nameFilter = Array.isArray(studentName)
+        ? studentName[0]
+        : studentName
+      if (nameFilter) {
+        whereConditions.push({
+          programProfile: {
+            person: { name: { contains: nameFilter, mode: 'insensitive' } },
+          },
+        })
+      }
+    }
+    if (batchId) {
+      const batchFilter = Array.isArray(batchId) ? batchId[0] : batchId
+      if (batchFilter) whereConditions.push({ batchId: batchFilter })
+    }
+    if (status) {
+      const statusValue = Array.isArray(status) ? status[0] : status
+      if (statusValue) {
+        whereConditions.push({
+          status: statusValue.toUpperCase() as
+            | 'REGISTERED'
+            | 'ENROLLED'
+            | 'WITHDRAWN',
+        })
+      }
+    } else {
+      whereConditions.push({ status: { not: 'WITHDRAWN' } })
+    }
+  }
+
+  const where: Prisma.EnrollmentWhereInput = { AND: whereConditions }
+
+  const [enrollments, totalCount] = await Promise.all([
+    client.enrollment.findMany({
+      where,
+      include: {
+        batch: true,
+        programProfile: {
+          include: {
+            person: true,
+            assignments: {
+              where: { isActive: true },
+              include: { subscription: true },
+            },
+          },
+        },
+      },
+      orderBy:
+        column === 'name'
+          ? { programProfile: { person: { name: order } } }
+          : { [column]: order },
+      take,
+      skip,
+    }),
+    client.enrollment.count({ where }),
+  ])
+
+  return { enrollments, totalCount }
+}

--- a/lib/db/queries/mahad-payments.ts
+++ b/lib/db/queries/mahad-payments.ts
@@ -136,8 +136,7 @@ export async function getMahadStudentsPage(
     params
   const skip = (page - 1) * take
 
-  const sortString = Array.isArray(sort) ? sort[0] : sort
-  const [column, order] = (sortString?.split('.') ?? ['name', 'asc']) as [
+  const [column, order] = (sort?.split('.') ?? ['name', 'asc']) as [
     string,
     'asc' | 'desc',
   ]
@@ -157,31 +156,19 @@ export async function getMahadStudentsPage(
     } as unknown as Prisma.EnrollmentWhereInput)
   } else {
     if (studentName) {
-      const nameFilter = Array.isArray(studentName)
-        ? studentName[0]
-        : studentName
-      if (nameFilter) {
-        whereConditions.push({
-          programProfile: {
-            person: { name: { contains: nameFilter, mode: 'insensitive' } },
-          },
-        })
-      }
+      whereConditions.push({
+        programProfile: {
+          person: { name: { contains: studentName, mode: 'insensitive' } },
+        },
+      })
     }
     if (batchId) {
-      const batchFilter = Array.isArray(batchId) ? batchId[0] : batchId
-      if (batchFilter) whereConditions.push({ batchId: batchFilter })
+      whereConditions.push({ batchId })
     }
     if (status) {
-      const statusValue = Array.isArray(status) ? status[0] : status
-      if (statusValue) {
-        whereConditions.push({
-          status: statusValue.toUpperCase() as
-            | 'REGISTERED'
-            | 'ENROLLED'
-            | 'WITHDRAWN',
-        })
-      }
+      whereConditions.push({
+        status: status.toUpperCase() as 'REGISTERED' | 'ENROLLED' | 'WITHDRAWN',
+      })
     } else {
       whereConditions.push({ status: { not: 'WITHDRAWN' } })
     }

--- a/lib/db/queries/siblings.ts
+++ b/lib/db/queries/siblings.ts
@@ -154,7 +154,7 @@ export async function getSiblingDetails(
  * @param client - Optional database client (for transaction support)
  */
 export async function getSiblingGroupsByProgram(
-  program?: string,
+  program?: Program,
   client: DatabaseClient = prisma
 ) {
   const relationships = await client.siblingRelationship.findMany({
@@ -166,9 +166,7 @@ export async function getSiblingGroupsByProgram(
       person1: {
         include: {
           programProfiles: {
-            ...(program
-              ? { where: { program: program as unknown as Program } }
-              : {}),
+            ...(program ? { where: { program } } : {}),
             include: {
               enrollments: {
                 where: {
@@ -184,9 +182,7 @@ export async function getSiblingGroupsByProgram(
       person2: {
         include: {
           programProfiles: {
-            ...(program
-              ? { where: { program: program as unknown as Program } }
-              : {}),
+            ...(program ? { where: { program } } : {}),
             include: {
               enrollments: {
                 where: {

--- a/lib/db/queries/student.ts
+++ b/lib/db/queries/student.ts
@@ -26,6 +26,7 @@ import {
 import { prisma } from '@/lib/db'
 import { ACTIVE_BILLING_ASSIGNMENT_WHERE } from '@/lib/db/query-builders'
 import { DatabaseClient } from '@/lib/db/types'
+import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
 import { normalizePhone } from '@/lib/types/person'
 import { StudentStatus } from '@/lib/types/student'
 import {
@@ -824,7 +825,10 @@ export async function resolveDuplicateStudents(
       (p) => p.program !== keepProfile.program
     )
     if (invalidPrograms.length > 0) {
-      throw new Error('Cannot merge profiles from different programs')
+      throw new ActionError(
+        'Cannot merge profiles from different programs',
+        ERROR_CODES.VALIDATION_ERROR
+      )
     }
 
     if (mergeData) {
@@ -965,7 +969,7 @@ export async function getStudentCompleteness(
   })
 
   if (!profile) {
-    throw new Error('Student not found')
+    throw new ActionError('Student not found', ERROR_CODES.NOT_FOUND)
   }
 
   const requiredFields = [

--- a/lib/db/queries/student.ts
+++ b/lib/db/queries/student.ts
@@ -1146,13 +1146,9 @@ export async function setProfileBillingDefaults(
   },
   client: DatabaseClient = prisma
 ) {
-  const exists = await client.programProfile.findUnique({
-    where: { id: profileId },
-    select: { id: true },
-  })
-  if (!exists) return null
-  return client.programProfile.update({
+  const { count } = await client.programProfile.updateMany({
     where: { id: profileId },
     data: defaults,
   })
+  return count > 0
 }

--- a/lib/db/queries/student.ts
+++ b/lib/db/queries/student.ts
@@ -1112,3 +1112,47 @@ export async function exportStudents(
     createdAt: student.createdAt.toISOString(),
   }))
 }
+
+export async function getProfileForPaymentLink(
+  profileId: string,
+  client: DatabaseClient = prisma
+) {
+  return client.programProfile.findUnique({
+    where: { id: profileId },
+    relationLoadStrategy: 'join',
+    select: {
+      id: true,
+      personId: true,
+      graduationStatus: true,
+      paymentFrequency: true,
+      billingType: true,
+      person: {
+        select: {
+          name: true,
+          email: true,
+          phone: true,
+        },
+      },
+    },
+  })
+}
+
+export async function setProfileBillingDefaults(
+  profileId: string,
+  defaults: {
+    graduationStatus: GraduationStatus
+    billingType: StudentBillingType
+    paymentFrequency: PaymentFrequency
+  },
+  client: DatabaseClient = prisma
+) {
+  const exists = await client.programProfile.findUnique({
+    where: { id: profileId },
+    select: { id: true },
+  })
+  if (!exists) return null
+  return client.programProfile.update({
+    where: { id: profileId },
+    data: defaults,
+  })
+}

--- a/lib/db/queries/teacher-management.ts
+++ b/lib/db/queries/teacher-management.ts
@@ -1,0 +1,74 @@
+import { prisma } from '@/lib/db'
+import { DatabaseClient } from '@/lib/db/types'
+import {
+  normalizePhone,
+  validateAndNormalizeEmail,
+} from '@/lib/utils/contact-normalization'
+
+export async function searchPeopleWithRoles(
+  query: string,
+  maxResults: number,
+  client: DatabaseClient = prisma
+) {
+  const searchTerm = query.trim().toLowerCase()
+  const normalizedPhone = normalizePhone(query.trim())
+
+  return client.person.findMany({
+    where: {
+      OR: [
+        { name: { contains: searchTerm, mode: 'insensitive' } },
+        {
+          email: {
+            contains: validateAndNormalizeEmail(query.trim()) ?? searchTerm,
+            mode: 'insensitive',
+          },
+        },
+        ...(normalizedPhone ? [{ phone: normalizedPhone }] : []),
+      ],
+    },
+    relationLoadStrategy: 'join',
+    include: {
+      teacher: {
+        include: {
+          programs: {
+            where: { isActive: true },
+          },
+        },
+      },
+      guardianRelationships: {
+        where: { isActive: true },
+        include: {
+          dependent: {
+            include: {
+              programProfiles: {
+                select: { program: true },
+              },
+            },
+          },
+        },
+      },
+      programProfiles: {
+        where: {
+          enrollments: {
+            some: {
+              status: { in: ['REGISTERED', 'ENROLLED'] },
+              endDate: null,
+            },
+          },
+        },
+        include: {
+          enrollments: {
+            where: {
+              status: { in: ['REGISTERED', 'ENROLLED'] },
+              endDate: null,
+            },
+            select: { status: true },
+            take: 1,
+          },
+        },
+      },
+    },
+    take: maxResults,
+    orderBy: { name: 'asc' },
+  })
+}

--- a/lib/services/mahad/student-mutation-service.ts
+++ b/lib/services/mahad/student-mutation-service.ts
@@ -7,9 +7,14 @@ import {
 } from '@prisma/client'
 
 import { prisma } from '@/lib/db'
+import { executeInTransaction } from '@/lib/db/prisma-helpers'
 import { ACTIVE_BILLING_ASSIGNMENT_WHERE } from '@/lib/db/query-builders'
+import { DatabaseClient } from '@/lib/db/types'
 import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
+import { createServiceLogger } from '@/lib/logger'
 import { isPrismaError } from '@/lib/utils/type-guards'
+
+const logger = createServiceLogger('student-mutation')
 
 export interface UpdateStudentData {
   name?: string
@@ -25,9 +30,12 @@ export interface UpdateStudentData {
   batchId?: string | null
 }
 
-export async function deleteStudentProfile(profileId: string): Promise<void> {
+export async function deleteStudentProfile(
+  profileId: string,
+  client: DatabaseClient = prisma
+): Promise<void> {
   try {
-    await prisma.$transaction(async (tx) => {
+    await executeInTransaction(client, async (tx) => {
       const liveAssignment = await tx.billingAssignment.findFirst({
         where: {
           programProfileId: profileId,
@@ -57,36 +65,42 @@ export async function deleteStudentProfile(profileId: string): Promise<void> {
     }
     throw error
   }
+
+  logger.info({ profileId }, 'Student profile deleted')
 }
 
 export async function bulkDeleteStudentProfiles(
-  studentIds: string[]
+  studentIds: string[],
+  client: DatabaseClient = prisma
 ): Promise<{ deletedCount: number; blockedIds: string[] }> {
-  const { deletedCount, blockedIds } = await prisma.$transaction(async (tx) => {
-    const activeAssignments = await tx.billingAssignment.findMany({
-      where: {
-        programProfileId: { in: studentIds },
-        ...ACTIVE_BILLING_ASSIGNMENT_WHERE,
-      },
-      select: { programProfileId: true },
-    })
-
-    const blockedIdSet = new Set(
-      activeAssignments.map((a) => a.programProfileId)
-    )
-    const safe = studentIds.filter((id) => !blockedIdSet.has(id))
-    const blocked = studentIds.filter((id) => blockedIdSet.has(id))
-
-    let deleted = 0
-    if (safe.length > 0) {
-      const result = await tx.programProfile.deleteMany({
-        where: { id: { in: safe } },
+  const { deletedCount, blockedIds } = await executeInTransaction(
+    client,
+    async (tx) => {
+      const activeAssignments = await tx.billingAssignment.findMany({
+        where: {
+          programProfileId: { in: studentIds },
+          ...ACTIVE_BILLING_ASSIGNMENT_WHERE,
+        },
+        select: { programProfileId: true },
       })
-      deleted = result.count
-    }
 
-    return { deletedCount: deleted, blockedIds: blocked }
-  })
+      const blockedIdSet = new Set(
+        activeAssignments.map((a) => a.programProfileId)
+      )
+      const safe = studentIds.filter((id) => !blockedIdSet.has(id))
+      const blocked = studentIds.filter((id) => blockedIdSet.has(id))
+
+      let deleted = 0
+      if (safe.length > 0) {
+        const result = await tx.programProfile.deleteMany({
+          where: { id: { in: safe } },
+        })
+        deleted = result.count
+      }
+
+      return { deletedCount: deleted, blockedIds: blocked }
+    }
+  )
 
   if (deletedCount === 0 && blockedIds.length > 0) {
     throw new ActionError(
@@ -95,15 +109,21 @@ export async function bulkDeleteStudentProfiles(
     )
   }
 
+  logger.info(
+    { deletedCount, blockedCount: blockedIds.length },
+    'Bulk student profiles deleted'
+  )
+
   return { deletedCount, blockedIds }
 }
 
 export async function updateStudentProfile(
   id: string,
-  data: UpdateStudentData
+  data: UpdateStudentData,
+  client: DatabaseClient = prisma
 ): Promise<void> {
   try {
-    await prisma.$transaction(async (tx) => {
+    await executeInTransaction(client, async (tx) => {
       const profile = await tx.programProfile.findUnique({
         where: { id },
         relationLoadStrategy: 'join',
@@ -188,4 +208,6 @@ export async function updateStudentProfile(
     }
     throw error
   }
+
+  logger.info({ profileId: id }, 'Student profile updated')
 }

--- a/lib/services/mahad/student-mutation-service.ts
+++ b/lib/services/mahad/student-mutation-service.ts
@@ -11,7 +11,7 @@ import { executeInTransaction } from '@/lib/db/prisma-helpers'
 import { ACTIVE_BILLING_ASSIGNMENT_WHERE } from '@/lib/db/query-builders'
 import { DatabaseClient } from '@/lib/db/types'
 import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
-import { createServiceLogger } from '@/lib/logger'
+import { createServiceLogger, logError } from '@/lib/logger'
 import { isPrismaError } from '@/lib/utils/type-guards'
 
 const logger = createServiceLogger('student-mutation')
@@ -63,6 +63,9 @@ export async function deleteStudentProfile(
           ERROR_CODES.VALIDATION_ERROR
         )
     }
+    await logError(logger, error, 'Unexpected error in deleteStudentProfile', {
+      profileId,
+    })
     throw error
   }
 
@@ -73,48 +76,61 @@ export async function bulkDeleteStudentProfiles(
   studentIds: string[],
   client: DatabaseClient = prisma
 ): Promise<{ deletedCount: number; blockedIds: string[] }> {
-  const { deletedCount, blockedIds } = await executeInTransaction(
-    client,
-    async (tx) => {
-      const activeAssignments = await tx.billingAssignment.findMany({
-        where: {
-          programProfileId: { in: studentIds },
-          ...ACTIVE_BILLING_ASSIGNMENT_WHERE,
-        },
-        select: { programProfileId: true },
-      })
-
-      const blockedIdSet = new Set(
-        activeAssignments.map((a) => a.programProfileId)
-      )
-      const safe = studentIds.filter((id) => !blockedIdSet.has(id))
-      const blocked = studentIds.filter((id) => blockedIdSet.has(id))
-
-      let deleted = 0
-      if (safe.length > 0) {
-        const result = await tx.programProfile.deleteMany({
-          where: { id: { in: safe } },
+  try {
+    const { deletedCount, blockedIds } = await executeInTransaction(
+      client,
+      async (tx) => {
+        const activeAssignments = await tx.billingAssignment.findMany({
+          where: {
+            programProfileId: { in: studentIds },
+            ...ACTIVE_BILLING_ASSIGNMENT_WHERE,
+          },
+          select: { programProfileId: true },
         })
-        deleted = result.count
+
+        const blockedIdSet = new Set(
+          activeAssignments.map((a) => a.programProfileId)
+        )
+        const safe = studentIds.filter((id) => !blockedIdSet.has(id))
+        const blocked = studentIds.filter((id) => blockedIdSet.has(id))
+
+        let deleted = 0
+        if (safe.length > 0) {
+          const result = await tx.programProfile.deleteMany({
+            where: { id: { in: safe } },
+          })
+          deleted = result.count
+        }
+
+        return { deletedCount: deleted, blockedIds: blocked }
       }
-
-      return { deletedCount: deleted, blockedIds: blocked }
-    }
-  )
-
-  if (deletedCount === 0 && blockedIds.length > 0) {
-    throw new ActionError(
-      `All ${blockedIds.length} student(s) have active subscriptions and cannot be deleted`,
-      ERROR_CODES.ACTIVE_SUBSCRIPTION
     )
+
+    if (deletedCount === 0 && blockedIds.length > 0) {
+      throw new ActionError(
+        `All ${blockedIds.length} student(s) have active subscriptions and cannot be deleted`,
+        ERROR_CODES.ACTIVE_SUBSCRIPTION
+      )
+    }
+
+    logger.info(
+      { deletedCount, blockedCount: blockedIds.length },
+      'Bulk student profiles deleted'
+    )
+
+    return { deletedCount, blockedIds }
+  } catch (error) {
+    if (error instanceof ActionError) throw error
+    await logError(
+      logger,
+      error,
+      'Unexpected error in bulkDeleteStudentProfiles',
+      {
+        studentIdCount: studentIds.length,
+      }
+    )
+    throw error
   }
-
-  logger.info(
-    { deletedCount, blockedCount: blockedIds.length },
-    'Bulk student profiles deleted'
-  )
-
-  return { deletedCount, blockedIds }
 }
 
 export async function updateStudentProfile(
@@ -206,6 +222,9 @@ export async function updateStudentProfile(
           ERROR_CODES.VALIDATION_ERROR
         )
     }
+    await logError(logger, error, 'Unexpected error in updateStudentProfile', {
+      profileId: id,
+    })
     throw error
   }
 

--- a/lib/services/mahad/student-mutation-service.ts
+++ b/lib/services/mahad/student-mutation-service.ts
@@ -113,7 +113,8 @@ export async function updateStudentProfile(
         },
       })
 
-      if (!profile) throw new Error('Profile not found')
+      if (!profile)
+        throw new ActionError('Student not found', ERROR_CODES.NOT_FOUND)
 
       const personUpdate: Prisma.PersonUpdateInput = {}
       if (data.name !== undefined) personUpdate.name = data.name

--- a/lib/services/mahad/student-mutation-service.ts
+++ b/lib/services/mahad/student-mutation-service.ts
@@ -1,0 +1,190 @@
+import {
+  GradeLevel,
+  GraduationStatus,
+  PaymentFrequency,
+  Prisma,
+  StudentBillingType,
+} from '@prisma/client'
+
+import { prisma } from '@/lib/db'
+import { ACTIVE_BILLING_ASSIGNMENT_WHERE } from '@/lib/db/query-builders'
+import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
+import { isPrismaError } from '@/lib/utils/type-guards'
+
+export interface UpdateStudentData {
+  name?: string
+  dateOfBirth?: Date | null
+  email?: string | null
+  phone?: string | null
+  gradeLevel?: GradeLevel | null
+  schoolName?: string | null
+  graduationStatus?: GraduationStatus | null
+  paymentFrequency?: PaymentFrequency | null
+  billingType?: StudentBillingType | null
+  paymentNotes?: string | null
+  batchId?: string | null
+}
+
+export async function deleteStudentProfile(profileId: string): Promise<void> {
+  try {
+    await prisma.$transaction(async (tx) => {
+      const liveAssignment = await tx.billingAssignment.findFirst({
+        where: {
+          programProfileId: profileId,
+          ...ACTIVE_BILLING_ASSIGNMENT_WHERE,
+        },
+      })
+      if (liveAssignment) {
+        throw new ActionError(
+          'Cannot delete student with active billing subscription. Cancel the subscription first.',
+          ERROR_CODES.ACTIVE_SUBSCRIPTION,
+          undefined,
+          403
+        )
+      }
+      await tx.programProfile.delete({ where: { id: profileId } })
+    })
+  } catch (error) {
+    if (error instanceof ActionError) throw error
+    if (isPrismaError(error)) {
+      if (error.code === 'P2025')
+        throw new ActionError('Student not found', ERROR_CODES.NOT_FOUND)
+      if (error.code === 'P2003')
+        throw new ActionError(
+          'Cannot delete student with related records',
+          ERROR_CODES.VALIDATION_ERROR
+        )
+    }
+    throw error
+  }
+}
+
+export async function bulkDeleteStudentProfiles(
+  studentIds: string[]
+): Promise<{ deletedCount: number; blockedIds: string[] }> {
+  const { deletedCount, blockedIds } = await prisma.$transaction(async (tx) => {
+    const activeAssignments = await tx.billingAssignment.findMany({
+      where: {
+        programProfileId: { in: studentIds },
+        ...ACTIVE_BILLING_ASSIGNMENT_WHERE,
+      },
+      select: { programProfileId: true },
+    })
+
+    const blockedIdSet = new Set(
+      activeAssignments.map((a) => a.programProfileId)
+    )
+    const safe = studentIds.filter((id) => !blockedIdSet.has(id))
+    const blocked = studentIds.filter((id) => blockedIdSet.has(id))
+
+    let deleted = 0
+    if (safe.length > 0) {
+      const result = await tx.programProfile.deleteMany({
+        where: { id: { in: safe } },
+      })
+      deleted = result.count
+    }
+
+    return { deletedCount: deleted, blockedIds: blocked }
+  })
+
+  if (deletedCount === 0 && blockedIds.length > 0) {
+    throw new ActionError(
+      `All ${blockedIds.length} student(s) have active subscriptions and cannot be deleted`,
+      ERROR_CODES.ACTIVE_SUBSCRIPTION
+    )
+  }
+
+  return { deletedCount, blockedIds }
+}
+
+export async function updateStudentProfile(
+  id: string,
+  data: UpdateStudentData
+): Promise<void> {
+  try {
+    await prisma.$transaction(async (tx) => {
+      const profile = await tx.programProfile.findUnique({
+        where: { id },
+        relationLoadStrategy: 'join',
+        include: {
+          person: true,
+          enrollments: { orderBy: { startDate: 'desc' }, take: 1 },
+        },
+      })
+
+      if (!profile) throw new Error('Profile not found')
+
+      const personUpdate: Prisma.PersonUpdateInput = {}
+      if (data.name !== undefined) personUpdate.name = data.name
+      if (data.dateOfBirth !== undefined)
+        personUpdate.dateOfBirth = data.dateOfBirth
+      if (data.email !== undefined) personUpdate.email = data.email
+      if (data.phone !== undefined) personUpdate.phone = data.phone
+
+      if (Object.keys(personUpdate).length > 0) {
+        await tx.person.update({
+          where: { id: profile.personId },
+          data: personUpdate,
+        })
+      }
+
+      const profileFields: Prisma.ProgramProfileUpdateInput = {
+        ...(data.gradeLevel !== undefined && { gradeLevel: data.gradeLevel }),
+        ...(data.schoolName !== undefined && { schoolName: data.schoolName }),
+        ...(data.graduationStatus !== undefined && {
+          graduationStatus: data.graduationStatus,
+        }),
+        ...(data.paymentFrequency !== undefined && {
+          paymentFrequency: data.paymentFrequency,
+        }),
+        ...(data.billingType !== undefined && {
+          billingType: data.billingType,
+        }),
+        ...(data.paymentNotes !== undefined && {
+          paymentNotes: data.paymentNotes,
+        }),
+      }
+
+      if (Object.keys(profileFields).length > 0) {
+        await tx.programProfile.update({ where: { id }, data: profileFields })
+      }
+
+      if (data.batchId !== undefined) {
+        const latestEnrollment = profile.enrollments[0]
+        if (latestEnrollment) {
+          await tx.enrollment.update({
+            where: { id: latestEnrollment.id },
+            data: { batchId: data.batchId },
+          })
+        } else if (data.batchId) {
+          await tx.enrollment.create({
+            data: {
+              programProfileId: id,
+              batchId: data.batchId,
+              status: 'REGISTERED',
+              startDate: new Date(),
+            },
+          })
+        }
+      }
+    })
+  } catch (error) {
+    if (error instanceof ActionError) throw error
+    if (isPrismaError(error)) {
+      if (error.code === 'P2002')
+        throw new ActionError(
+          'This email or phone is already associated with another student',
+          ERROR_CODES.VALIDATION_ERROR
+        )
+      if (error.code === 'P2025')
+        throw new ActionError('Student not found', ERROR_CODES.NOT_FOUND)
+      if (error.code === 'P2003')
+        throw new ActionError(
+          'Invalid batch or related record reference',
+          ERROR_CODES.VALIDATION_ERROR
+        )
+    }
+    throw error
+  }
+}

--- a/lib/services/shared/teacher-service.ts
+++ b/lib/services/shared/teacher-service.ts
@@ -18,7 +18,7 @@ import { prisma } from '@/lib/db'
 import { executeInTransaction } from '@/lib/db/prisma-helpers'
 import { DatabaseClient } from '@/lib/db/types'
 import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
-import { createServiceLogger, logError } from '@/lib/logger'
+import { createServiceLogger } from '@/lib/logger'
 import {
   ValidationError,
   validateTeacherCreation,
@@ -496,10 +496,10 @@ export async function createPersonTeacherAndAssignDugsi(
     })
   } catch (error) {
     if (isPrismaError(error) && error.code === 'P2002') {
-      logError(logger, error, 'Concurrent duplicate person on teacher create', {
-        hasEmail: !!data.email,
-        hasPhone: !!data.phone,
-      })
+      logger.warn(
+        { hasEmail: !!data.email, hasPhone: !!data.phone },
+        'Concurrent duplicate person on teacher create (race condition)'
+      )
       throw new ActionError(
         'A person with this email or phone already exists',
         ERROR_CODES.VALIDATION_ERROR

--- a/lib/services/shared/teacher-service.ts
+++ b/lib/services/shared/teacher-service.ts
@@ -23,6 +23,7 @@ import {
   ValidationError,
   validateTeacherCreation,
 } from '@/lib/services/validation-service'
+import { isPrismaError } from '@/lib/utils/type-guards'
 
 const logger = createServiceLogger('teacher')
 
@@ -481,16 +482,27 @@ export async function createPersonTeacherAndAssignDugsi(
     }
   }
 
-  const teacher = await executeInTransaction(client, async (tx) => {
-    const person = await tx.person.create({
-      data: { name: data.name, email: data.email, phone: data.phone },
+  let teacher
+  try {
+    teacher = await executeInTransaction(client, async (tx) => {
+      const person = await tx.person.create({
+        data: { name: data.name, email: data.email, phone: data.phone },
+      })
+      const newTeacher = await createTeacher(person.id, tx)
+      await tx.teacherProgram.create({
+        data: { teacherId: newTeacher.id, program: 'DUGSI_PROGRAM' },
+      })
+      return newTeacher
     })
-    const newTeacher = await createTeacher(person.id, tx)
-    await tx.teacherProgram.create({
-      data: { teacherId: newTeacher.id, program: 'DUGSI_PROGRAM' },
-    })
-    return newTeacher
-  })
+  } catch (error) {
+    if (isPrismaError(error) && error.code === 'P2002') {
+      throw new ActionError(
+        'A person with this email or phone already exists',
+        ERROR_CODES.VALIDATION_ERROR
+      )
+    }
+    throw error
+  }
 
   logger.info(
     { teacherId: teacher.id, program: 'DUGSI_PROGRAM' },

--- a/lib/services/shared/teacher-service.ts
+++ b/lib/services/shared/teacher-service.ts
@@ -18,7 +18,7 @@ import { prisma } from '@/lib/db'
 import { executeInTransaction } from '@/lib/db/prisma-helpers'
 import { DatabaseClient } from '@/lib/db/types'
 import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
-import { createServiceLogger } from '@/lib/logger'
+import { createServiceLogger, logError } from '@/lib/logger'
 import {
   ValidationError,
   validateTeacherCreation,
@@ -496,6 +496,9 @@ export async function createPersonTeacherAndAssignDugsi(
     })
   } catch (error) {
     if (isPrismaError(error) && error.code === 'P2002') {
+      logError(logger, error, 'Concurrent duplicate person on teacher create', {
+        email: data.email,
+      })
       throw new ActionError(
         'A person with this email or phone already exists',
         ERROR_CODES.VALIDATION_ERROR
@@ -516,11 +519,18 @@ export async function deactivateTeacherFromDugsi(
   teacherId: string,
   client: DatabaseClient = prisma
 ) {
-  await client.teacherProgram.updateMany({
+  const { count } = await client.teacherProgram.updateMany({
     where: { teacherId, program: 'DUGSI_PROGRAM', isActive: true },
     data: { shifts: [], isActive: false },
   })
-  logger.info({ teacherId }, 'Teacher deactivated from Dugsi')
+  if (count === 0) {
+    logger.warn(
+      { teacherId },
+      'deactivateTeacherFromDugsi matched 0 rows — already deactivated or not found'
+    )
+  } else {
+    logger.info({ teacherId }, 'Teacher deactivated from Dugsi')
+  }
 }
 
 /**

--- a/lib/services/shared/teacher-service.ts
+++ b/lib/services/shared/teacher-service.ts
@@ -18,7 +18,7 @@ import { prisma } from '@/lib/db'
 import { executeInTransaction } from '@/lib/db/prisma-helpers'
 import { DatabaseClient } from '@/lib/db/types'
 import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
-import { createServiceLogger } from '@/lib/logger'
+import { createServiceLogger, logError } from '@/lib/logger'
 import {
   ValidationError,
   validateTeacherCreation,
@@ -468,7 +468,7 @@ export async function createTeacherAndAssignDugsi(
   } catch (error) {
     if (isPrismaError(error) && error.code === 'P2002') {
       throw new ActionError(
-        'Teacher is already enrolled in this program',
+        'This person is already a teacher or is already enrolled in this program',
         ERROR_CODES.VALIDATION_ERROR
       )
     }
@@ -528,6 +528,15 @@ export async function createPersonTeacherAndAssignDugsi(
         ERROR_CODES.VALIDATION_ERROR
       )
     }
+    await logError(
+      logger,
+      error,
+      'Unexpected error in createPersonTeacherAndAssignDugsi',
+      {
+        hasEmail: !!data.email,
+        hasPhone: !!data.phone,
+      }
+    )
     throw error
   }
 

--- a/lib/services/shared/teacher-service.ts
+++ b/lib/services/shared/teacher-service.ts
@@ -456,13 +456,24 @@ export async function createTeacherAndAssignDugsi(
   personId: string,
   client: DatabaseClient = prisma
 ) {
-  const teacher = await executeInTransaction(client, async (tx) => {
-    const newTeacher = await createTeacher(personId, tx)
-    await tx.teacherProgram.create({
-      data: { teacherId: newTeacher.id, program: 'DUGSI_PROGRAM' },
+  let teacher
+  try {
+    teacher = await executeInTransaction(client, async (tx) => {
+      const newTeacher = await createTeacher(personId, tx)
+      await tx.teacherProgram.create({
+        data: { teacherId: newTeacher.id, program: 'DUGSI_PROGRAM' },
+      })
+      return newTeacher
     })
-    return newTeacher
-  })
+  } catch (error) {
+    if (isPrismaError(error) && error.code === 'P2002') {
+      throw new ActionError(
+        'Teacher is already enrolled in this program',
+        ERROR_CODES.VALIDATION_ERROR
+      )
+    }
+    throw error
+  }
 
   logger.info(
     { teacherId: teacher.id, personId, program: 'DUGSI_PROGRAM' },

--- a/lib/services/shared/teacher-service.ts
+++ b/lib/services/shared/teacher-service.ts
@@ -434,6 +434,45 @@ export async function getTeachersByProgram(
 // Program Authorization
 // ============================================================================
 
+// ============================================================================
+// Teacher + Program Creation Workflows
+// ============================================================================
+
+export async function createTeacherAndAssignDugsi(personId: string) {
+  return prisma.$transaction(async (tx) => {
+    const teacher = await createTeacher(personId, tx)
+    await tx.teacherProgram.create({
+      data: { teacherId: teacher.id, program: 'DUGSI_PROGRAM' },
+    })
+    return teacher
+  })
+}
+
+export async function createPersonTeacherAndAssignDugsi(data: {
+  name: string
+  email: string | null
+  phone: string | null
+}) {
+  return prisma.$transaction(async (tx) => {
+    const person = await tx.person.create({
+      data: { name: data.name, email: data.email, phone: data.phone },
+    })
+    const teacher = await createTeacher(person.id, tx)
+    await tx.teacherProgram.create({
+      data: { teacherId: teacher.id, program: 'DUGSI_PROGRAM' },
+    })
+    return teacher
+  })
+}
+
+export async function deactivateTeacherFromDugsi(teacherId: string) {
+  await prisma.teacherProgram.updateMany({
+    where: { teacherId, program: 'DUGSI_PROGRAM', isActive: true },
+    data: { shifts: [], isActive: false },
+  })
+  logger.info({ teacherId }, 'Teacher deactivated from Dugsi')
+}
+
 /**
  * Validate teacher is authorized for a program.
  *

--- a/lib/services/shared/teacher-service.ts
+++ b/lib/services/shared/teacher-service.ts
@@ -17,6 +17,7 @@ import { Prisma, Program } from '@prisma/client'
 import { prisma } from '@/lib/db'
 import { executeInTransaction } from '@/lib/db/prisma-helpers'
 import { DatabaseClient } from '@/lib/db/types'
+import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
 import { createServiceLogger } from '@/lib/logger'
 import {
   ValidationError,
@@ -453,6 +454,24 @@ export async function createPersonTeacherAndAssignDugsi(data: {
   email: string | null
   phone: string | null
 }) {
+  if (data.email || data.phone) {
+    const existing = await prisma.person.findFirst({
+      where: {
+        OR: [
+          ...(data.email ? [{ email: data.email }] : []),
+          ...(data.phone ? [{ phone: data.phone }] : []),
+        ],
+      },
+      select: { id: true },
+    })
+    if (existing) {
+      throw new ActionError(
+        'A person with this email or phone already exists',
+        ERROR_CODES.VALIDATION_ERROR
+      )
+    }
+  }
+
   return prisma.$transaction(async (tx) => {
     const person = await tx.person.create({
       data: { name: data.name, email: data.email, phone: data.phone },

--- a/lib/services/shared/teacher-service.ts
+++ b/lib/services/shared/teacher-service.ts
@@ -439,23 +439,32 @@ export async function getTeachersByProgram(
 // Teacher + Program Creation Workflows
 // ============================================================================
 
-export async function createTeacherAndAssignDugsi(personId: string) {
-  return prisma.$transaction(async (tx) => {
-    const teacher = await createTeacher(personId, tx)
+export async function createTeacherAndAssignDugsi(
+  personId: string,
+  client: DatabaseClient = prisma
+) {
+  const teacher = await executeInTransaction(client, async (tx) => {
+    const newTeacher = await createTeacher(personId, tx)
     await tx.teacherProgram.create({
-      data: { teacherId: teacher.id, program: 'DUGSI_PROGRAM' },
+      data: { teacherId: newTeacher.id, program: 'DUGSI_PROGRAM' },
     })
-    return teacher
+    return newTeacher
   })
+
+  logger.info(
+    { teacherId: teacher.id, personId, program: 'DUGSI_PROGRAM' },
+    'Teacher created and assigned to Dugsi'
+  )
+
+  return teacher
 }
 
-export async function createPersonTeacherAndAssignDugsi(data: {
-  name: string
-  email: string | null
-  phone: string | null
-}) {
+export async function createPersonTeacherAndAssignDugsi(
+  data: { name: string; email: string | null; phone: string | null },
+  client: DatabaseClient = prisma
+) {
   if (data.email || data.phone) {
-    const existing = await prisma.person.findFirst({
+    const existing = await client.person.findFirst({
       where: {
         OR: [
           ...(data.email ? [{ email: data.email }] : []),
@@ -472,20 +481,30 @@ export async function createPersonTeacherAndAssignDugsi(data: {
     }
   }
 
-  return prisma.$transaction(async (tx) => {
+  const teacher = await executeInTransaction(client, async (tx) => {
     const person = await tx.person.create({
       data: { name: data.name, email: data.email, phone: data.phone },
     })
-    const teacher = await createTeacher(person.id, tx)
+    const newTeacher = await createTeacher(person.id, tx)
     await tx.teacherProgram.create({
-      data: { teacherId: teacher.id, program: 'DUGSI_PROGRAM' },
+      data: { teacherId: newTeacher.id, program: 'DUGSI_PROGRAM' },
     })
-    return teacher
+    return newTeacher
   })
+
+  logger.info(
+    { teacherId: teacher.id, program: 'DUGSI_PROGRAM' },
+    'Person, teacher, and Dugsi assignment created'
+  )
+
+  return teacher
 }
 
-export async function deactivateTeacherFromDugsi(teacherId: string) {
-  await prisma.teacherProgram.updateMany({
+export async function deactivateTeacherFromDugsi(
+  teacherId: string,
+  client: DatabaseClient = prisma
+) {
+  await client.teacherProgram.updateMany({
     where: { teacherId, program: 'DUGSI_PROGRAM', isActive: true },
     data: { shifts: [], isActive: false },
   })

--- a/lib/services/shared/teacher-service.ts
+++ b/lib/services/shared/teacher-service.ts
@@ -497,7 +497,8 @@ export async function createPersonTeacherAndAssignDugsi(
   } catch (error) {
     if (isPrismaError(error) && error.code === 'P2002') {
       logError(logger, error, 'Concurrent duplicate person on teacher create', {
-        email: data.email,
+        hasEmail: !!data.email,
+        hasPhone: !!data.phone,
       })
       throw new ActionError(
         'A person with this email or phone already exists',

--- a/lib/services/shared/teacher-service.ts
+++ b/lib/services/shared/teacher-service.ts
@@ -91,12 +91,18 @@ export async function deleteTeacher(
   teacherId: string,
   client: DatabaseClient = prisma
 ) {
-  await client.teacherProgram.updateMany({
+  const { count } = await client.teacherProgram.updateMany({
     where: { teacherId },
     data: { isActive: false },
   })
-
-  logger.info({ teacherId }, 'Teacher soft deleted')
+  if (count === 0) {
+    logger.warn(
+      { teacherId },
+      'deleteTeacher matched 0 rows — already deleted or not found'
+    )
+  } else {
+    logger.info({ teacherId }, 'Teacher soft deleted')
+  }
 }
 
 // ============================================================================
@@ -194,7 +200,7 @@ export async function removeTeacherFromProgram(
 ) {
   const { teacherId, program } = input
 
-  await client.teacherProgram.updateMany({
+  const { count } = await client.teacherProgram.updateMany({
     where: {
       teacherId,
       program,
@@ -204,8 +210,14 @@ export async function removeTeacherFromProgram(
       isActive: false,
     },
   })
-
-  logger.info({ teacherId, program }, 'Teacher removed from program')
+  if (count === 0) {
+    logger.warn(
+      { teacherId, program },
+      'removeTeacherFromProgram matched 0 rows — not enrolled or already removed'
+    )
+  } else {
+    logger.info({ teacherId, program }, 'Teacher removed from program')
+  }
 }
 
 /**


### PR DESCRIPTION
### Why?

Server actions had Prisma calls mixed directly with business logic, and a PR review surfaced correctness issues: P2002 constraint violations were being caught as normal control flow (wrong mental model — database constraints are safety nets, not primary error reporters), a billing defaults update had a TOCTOU gap between two queries, and a plain `Error` inside a transaction was silently escaping all catch branches as a 500. A follow-up multi-agent review then identified additional error handling gaps: `ValidationError` from the service layer was passing through safe-action's `handleServerError` untranslated (user sees "Something went wrong" instead of the real message), unexpected errors were rethrown without `logError` (Sentry gets raw errors with no domain context), and `updateMany` soft-deletes were silently succeeding on zero rows.

### How?

Extracted direct Prisma callsites from server actions into a service/query layer, applied the correct uniqueness validation pattern throughout (explicit `findFirst` pre-checks before writes), and decoupled payment server components from Prisma by moving their queries to the query layer. Then fixed all identified error handling gaps: `ValidationError` → `ActionError` mapping in action catch blocks, `logError` before unexpected rethrows, `updateMany` count checks with structured warnings, `new Error()` → `ActionError` in query functions so messages reach users, and Stripe session creation wrapped in try/catch with `logError`. CLAUDE.md rule 6 updated to reflect the correct design principle.

### Decisions

Chose pre-validation (`findFirst` before transaction) over catch-outside-`$transaction` for this app because:
- Admin-only flows with negligible concurrency make TOCTOU risk operationally irrelevant
- Pre-validation expresses the business rule explicitly and readably — the constraint becomes a silent safety net, not a UI error path
- Consistent with how `validateTeacherCreation` already worked in the codebase
- P2002 in production now unambiguously signals a bug or genuine race, not a normal user flow

For the P2002 concurrent duplicate race in `createPersonTeacherAndAssignDugsi`: used `logger.warn` (not `logError`) because this is an expected operational race condition, not a bug — `logError` would generate false Sentry alerts.

<details>
<summary>Error Handling Fix Plan</summary>

# Plan: Fix All Error Handling Issues (PR #221 + Pre-existing)

## Context

PR #221 extracted Prisma callsites into a query/service layer. A multi-agent review identified error handling gaps in both new code (student-mutation-service.ts) and pre-existing code that the PR touched adjacent to (teacher-service.ts, actions files, query functions). All issues fall into 4 categories:

1. **Silent no-ops** — `updateMany` returns count 0 and logs success
2. **ValidationError not mapped to ActionError** — safe-action returns "Something went wrong" instead of the human-readable message
3. **Missing logError before rethrow** — Sentry gets raw error with no domain context
4. **Plain `new Error()` in query/service layer** — message never reaches user

## Files to Change (6 files)

### 1. `lib/services/mahad/student-mutation-service.ts`

**a. Add `logError` before final rethrow in `deleteStudentProfile`**
```typescript
} catch (error) {
  if (error instanceof ActionError) throw error
  if (isPrismaError(error)) {
    if (error.code === 'P2025')
      throw new ActionError('Student not found', ERROR_CODES.NOT_FOUND)
    if (error.code === 'P2003')
      throw new ActionError('Cannot delete student with related records', ERROR_CODES.VALIDATION_ERROR)
  }
  await logError(logger, error, 'Unexpected error in deleteStudentProfile', { profileId })
  throw error
}
```

**b. Add `logError` before final rethrow in `updateStudentProfile`**

**c. Wrap `bulkDeleteStudentProfiles` body in try/catch**

**Import to add:** `logError` from `@/lib/logger`

---

### 2. `lib/services/shared/teacher-service.ts`

**a. `deleteTeacher` — silent no-op on invalid teacherId** → check count, `logger.warn` on 0 rows

**b. `removeTeacherFromProgram` — silent no-op** → same count-check pattern

---

### 3. `app/admin/dugsi/teachers/actions.ts`

**a. `_assignTeacherToProgramAction` — add `TEACHER_NOT_FOUND` mapping**

**b. `_bulkAssignProgramsAction` — add catch block** mapping all `ValidationError` subtypes

---

### 4. `app/admin/mahad/_actions/index.ts`

**`validateBillingCycleAnchor` catch** — bind error, add logError, preserve message

**Stripe `checkout.sessions.create`** — wrap in try/catch with logError

---

### 5. `lib/db/queries/student.ts`

Replace `new Error()` with `ActionError` in `resolveDuplicateStudents` and `getStudentCompleteness`

---

### 6. `lib/db/queries/mahad-payments.ts`

Add `page < 1` guard throwing `ActionError`

---

## What We're NOT Changing

- Query functions without try/catch (`getMahadPaymentStats`, `getSubscriptionMembersBatch`) — thin query functions intentionally have no error handling
- `deleteTeacher` throwing on 0 rows — soft-delete is idempotent by design

</details>

<sub>Generated with Claude Code</sub>