### PR TITLE
fix(webhooks): Dugsi fallback for manually-created Stripe subscriptions

### DIFF
--- a/lib/db/queries/billing.ts
+++ b/lib/db/queries/billing.ts
@@ -504,6 +504,29 @@ export async function getBillingAssignmentsByProfile(
 }
 
 /**
+ * Find a person via any billing account already linked to this Stripe customer ID.
+ * Searches both Mahad and Dugsi customer ID columns — used for cross-program re-subscribers
+ * where the program-specific billing account has not been created yet.
+ */
+export async function findPersonByStripeCustomerId(
+  customerId: string,
+  client: DatabaseClient = prisma
+) {
+  return client.person.findFirst({
+    where: {
+      billingAccounts: {
+        some: {
+          OR: [
+            { stripeCustomerIdMahad: customerId },
+            { stripeCustomerIdDugsi: customerId },
+          ],
+        },
+      },
+    },
+  })
+}
+
+/**
  * Get billing assignments by subscription
  * @param client - Optional database client (for transaction support)
  */

--- a/lib/db/queries/dugsi-profiles.ts
+++ b/lib/db/queries/dugsi-profiles.ts
@@ -1,10 +1,3 @@
-/**
- * Dugsi Profile Query Functions
- *
- * Queries for resolving and verifying Dugsi billing profile assignments.
- * Used by the webhook service for authoritative profile ID derivation.
- */
-
 import { EnrollmentStatus, Program } from '@prisma/client'
 
 import { prisma } from '@/lib/db'
@@ -16,8 +9,9 @@ const BILLABLE_DUGSI_STATUSES = [
 ]
 
 /**
- * Find a guardian by normalized email with all their billable Dugsi children.
- * Used by the Path 4 email fallback when a subscription has no metadata.
+ * Find a guardian by normalized email. Includes only active guardian relationships
+ * and their billable Dugsi program profiles. The guardian may be returned with empty
+ * profile arrays if no billable children exist — callers must check.
  */
 export async function findGuardianWithBillableDugsiChildren(
   normalizedEmail: string,
@@ -47,9 +41,9 @@ export async function findGuardianWithBillableDugsiChildren(
 }
 
 /**
- * Verify that profile IDs from Stripe metadata are valid:
- * they must exist, be DUGSI_PROGRAM, have a billable status,
- * and belong to a dependent of the guardian.
+ * Verify that profile IDs from Stripe metadata are valid: they must exist,
+ * be DUGSI_PROGRAM, have a billable status, and be owned by someone who has
+ * guardianPersonId as their active guardian.
  *
  * Returns only the IDs that pass all checks.
  */
@@ -77,7 +71,8 @@ export async function verifyDugsiProfileIdsForGuardian(
 /**
  * Derive all billable Dugsi profile IDs for a guardian's active dependents.
  * Used as a fallback when metadata hints are absent or fail verification.
- * Deduplicates by profile ID (a child can appear via multiple guardian roles).
+ * Deduplicates by profile ID — the same child can appear twice in flatMap
+ * if they have multiple active guardian relationships (e.g. two parents).
  */
 export async function findBillableDugsiProfileIdsForGuardian(
   guardianPersonId: string,

--- a/lib/db/queries/dugsi-profiles.ts
+++ b/lib/db/queries/dugsi-profiles.ts
@@ -1,0 +1,114 @@
+/**
+ * Dugsi Profile Query Functions
+ *
+ * Queries for resolving and verifying Dugsi billing profile assignments.
+ * Used by the webhook service for authoritative profile ID derivation.
+ */
+
+import { EnrollmentStatus, Program } from '@prisma/client'
+
+import { prisma } from '@/lib/db'
+import { DatabaseClient } from '@/lib/db/types'
+
+const BILLABLE_DUGSI_STATUSES = [
+  EnrollmentStatus.REGISTERED,
+  EnrollmentStatus.ENROLLED,
+]
+
+/**
+ * Find a guardian by normalized email with all their billable Dugsi children.
+ * Used by the Path 4 email fallback when a subscription has no metadata.
+ */
+export async function findGuardianWithBillableDugsiChildren(
+  normalizedEmail: string,
+  client: DatabaseClient = prisma
+) {
+  return client.person.findFirst({
+    where: { email: normalizedEmail },
+    include: {
+      guardianRelationships: {
+        where: { isActive: true },
+        include: {
+          dependent: {
+            include: {
+              programProfiles: {
+                where: {
+                  program: Program.DUGSI_PROGRAM,
+                  status: { in: BILLABLE_DUGSI_STATUSES },
+                },
+                select: { id: true, familyReferenceId: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+}
+
+/**
+ * Verify that profile IDs from Stripe metadata are valid:
+ * they must exist, be DUGSI_PROGRAM, have a billable status,
+ * and belong to a dependent of the guardian.
+ *
+ * Returns only the IDs that pass all checks.
+ */
+export async function verifyDugsiProfileIdsForGuardian(
+  guardianPersonId: string,
+  profileIds: string[],
+  client: DatabaseClient = prisma
+) {
+  const valid = await client.programProfile.findMany({
+    where: {
+      id: { in: profileIds },
+      program: Program.DUGSI_PROGRAM,
+      status: { in: BILLABLE_DUGSI_STATUSES },
+      person: {
+        dependentRelationships: {
+          some: { guardianId: guardianPersonId, isActive: true },
+        },
+      },
+    },
+    select: { id: true },
+  })
+  return valid.map((p) => p.id)
+}
+
+/**
+ * Derive all billable Dugsi profile IDs for a guardian's active dependents.
+ * Used as a fallback when metadata hints are absent or fail verification.
+ * Deduplicates by profile ID (a child can appear via multiple guardian roles).
+ */
+export async function findBillableDugsiProfileIdsForGuardian(
+  guardianPersonId: string,
+  client: DatabaseClient = prisma
+) {
+  const guardian = await client.person.findFirst({
+    where: { id: guardianPersonId },
+    include: {
+      guardianRelationships: {
+        where: { isActive: true },
+        include: {
+          dependent: {
+            include: {
+              programProfiles: {
+                where: {
+                  program: Program.DUGSI_PROGRAM,
+                  status: { in: BILLABLE_DUGSI_STATUSES },
+                },
+                select: { id: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  if (!guardian) return []
+
+  const raw = guardian.guardianRelationships.flatMap(
+    (rel) => rel.dependent.programProfiles
+  )
+  return Array.from(new Set(raw.map((p) => p.id)))
+}

--- a/lib/db/queries/program-profile.ts
+++ b/lib/db/queries/program-profile.ts
@@ -628,6 +628,20 @@ export async function searchProgramProfilesByNameOrContact(
 }
 
 /**
+ * Verify that a person ID exists in the database.
+ * Used to validate person IDs sourced from Stripe metadata before creating billing records.
+ */
+export async function findPersonById(
+  personId: string,
+  client: DatabaseClient = prisma
+) {
+  return client.person.findUnique({
+    where: { id: personId },
+    select: { id: true },
+  })
+}
+
+/**
  * Update shift for all program profiles in a family
  * @param client - Optional database client (for transaction support)
  */

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -1,16 +1,43 @@
 import type Stripe from 'stripe'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 
-const { mockGetSubscriptionByStripeId, mockLoggerWarn } = vi.hoisted(() => ({
+const {
+  mockGetSubscriptionByStripeId,
+  mockGetBillingAccountByStripeCustomerId,
+  mockLoggerWarn,
+  mockFindPersonByActiveContact,
+  mockCustomersRetrieve,
+  mockSubscriptionsUpdate,
+  mockPrismaPersonFindFirst,
+  mockCreateOrUpdateBillingAccount,
+  mockCreateSubscriptionFromStripe,
+  mockSentrycaptureMessage,
+  mockCalculateDugsiRate,
+  mockExtractCustomerId,
+} = vi.hoisted(() => ({
   mockGetSubscriptionByStripeId: vi.fn(),
+  mockGetBillingAccountByStripeCustomerId: vi.fn(),
   mockLoggerWarn: vi.fn(),
+  mockFindPersonByActiveContact: vi.fn(),
+  mockCustomersRetrieve: vi.fn(),
+  mockSubscriptionsUpdate: vi.fn(),
+  mockPrismaPersonFindFirst: vi.fn(),
+  mockCreateOrUpdateBillingAccount: vi.fn(),
+  mockCreateSubscriptionFromStripe: vi.fn(),
+  mockSentrycaptureMessage: vi.fn(),
+  mockCalculateDugsiRate: vi.fn(),
+  mockExtractCustomerId: vi.fn(),
 }))
 
 vi.mock('@/lib/db/queries/billing', () => ({
-  getBillingAccountByStripeCustomerId: vi.fn(),
+  getBillingAccountByStripeCustomerId: mockGetBillingAccountByStripeCustomerId,
   getSubscriptionByStripeId: mockGetSubscriptionByStripeId,
   getBillingAssignmentsBySubscription: vi.fn(),
   updateSubscriptionStatus: vi.fn(),
+}))
+
+vi.mock('@/lib/db/queries/program-profile', () => ({
+  findPersonByActiveContact: mockFindPersonByActiveContact,
 }))
 
 vi.mock('@/lib/logger', () => ({
@@ -24,26 +51,35 @@ vi.mock('@/lib/logger', () => ({
 }))
 
 vi.mock('@/lib/db', () => ({
-  prisma: {},
+  prisma: {
+    person: { findFirst: mockPrismaPersonFindFirst },
+  },
 }))
 
 vi.mock('@sentry/nextjs', () => ({
   startSpan: vi.fn((_opts: unknown, cb: () => unknown) => cb()),
-  captureMessage: vi.fn(),
+  captureMessage: mockSentrycaptureMessage,
 }))
 
 vi.mock('@/lib/services/shared/billing-service', () => ({
-  createOrUpdateBillingAccount: vi.fn(),
+  createOrUpdateBillingAccount: mockCreateOrUpdateBillingAccount,
   linkSubscriptionToProfiles: vi.fn(),
   unlinkSubscription: vi.fn(),
 }))
 
 vi.mock('@/lib/services/shared/subscription-service', () => ({
-  createSubscriptionFromStripe: vi.fn(),
+  createSubscriptionFromStripe: mockCreateSubscriptionFromStripe,
+}))
+
+vi.mock('@/lib/stripe-dugsi', () => ({
+  getDugsiStripeClient: vi.fn(() => ({
+    customers: { retrieve: mockCustomersRetrieve },
+    subscriptions: { update: mockSubscriptionsUpdate },
+  })),
 }))
 
 vi.mock('@/lib/utils/dugsi-tuition', () => ({
-  calculateDugsiRate: vi.fn(),
+  calculateDugsiRate: mockCalculateDugsiRate,
 }))
 
 vi.mock('@/lib/utils/mahad-tuition', () => ({
@@ -51,7 +87,7 @@ vi.mock('@/lib/utils/mahad-tuition', () => ({
 }))
 
 vi.mock('@/lib/utils/type-guards', () => ({
-  extractCustomerId: vi.fn(),
+  extractCustomerId: mockExtractCustomerId,
   extractPeriodDates: vi.fn(() => ({
     periodStart: new Date(),
     periodEnd: new Date(),
@@ -59,7 +95,14 @@ vi.mock('@/lib/utils/type-guards', () => ({
   isValidSubscriptionStatus: vi.fn(() => true),
 }))
 
-import { handleSubscriptionUpdated } from '../webhook-service'
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+}))
+
+import {
+  handleSubscriptionUpdated,
+  handleSubscriptionCreated,
+} from '../webhook-service'
 
 function createMockSubscription(
   overrides: Partial<Stripe.Subscription> = {}
@@ -69,7 +112,17 @@ function createMockSubscription(
     object: 'subscription',
     status: 'active',
     customer: 'cus_test_123',
-    items: { object: 'list', data: [], has_more: false, url: '' },
+    metadata: {},
+    items: {
+      object: 'list',
+      data: [
+        {
+          price: { unit_amount: 5000 },
+        } as Stripe.SubscriptionItem,
+      ],
+      has_more: false,
+      url: '',
+    },
     ...overrides,
   } as Stripe.Subscription
 }
@@ -95,5 +148,219 @@ describe('handleSubscriptionUpdated', () => {
       { stripeSubscriptionId: 'sub_legacy_123' },
       'Subscription not found in database - student may need to re-register'
     )
+  })
+})
+
+describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)', () => {
+  const CUSTOMER_ID = 'cus_UHVIVIKqO7UuK6'
+  const GUARDIAN_ID = 'guardian-person-id'
+  const PROFILE_ID_1 = 'profile-id-1'
+  const PROFILE_ID_2 = 'profile-id-2'
+  const FAMILY_ID = 'family-ref-id'
+  const BILLING_ACCOUNT_ID = 'billing-account-id'
+  const DB_SUBSCRIPTION_ID = 'db-sub-id'
+  const STANDARD_RATE = 6000
+
+  const mockGuardianPerson = {
+    id: GUARDIAN_ID,
+    name: 'Kadar Warfa',
+    email: 'khadra.warfa@gmail.com',
+    phone: '6124420703',
+    programProfiles: [],
+  }
+
+  const mockFamilyProfiles = [
+    { id: PROFILE_ID_1, familyReferenceId: FAMILY_ID },
+    { id: PROFILE_ID_2, familyReferenceId: FAMILY_ID },
+  ]
+
+  const mockGuardianWithChildren = {
+    ...mockGuardianPerson,
+    guardianRelationships: [
+      { dependent: { programProfiles: [mockFamilyProfiles[0]] } },
+      { dependent: { programProfiles: [mockFamilyProfiles[1]] } },
+    ],
+  }
+
+  const mockBillingAccount = {
+    id: BILLING_ACCOUNT_ID,
+    personId: GUARDIAN_ID,
+  }
+
+  const mockDbSubscription = {
+    id: DB_SUBSCRIPTION_ID,
+    status: 'active',
+    stripeSubscriptionId: 'sub_test_123',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExtractCustomerId.mockReturnValue(CUSTOMER_ID)
+    mockGetBillingAccountByStripeCustomerId.mockResolvedValue(null)
+    mockPrismaPersonFindFirst
+      .mockResolvedValueOnce(null) // Path 3: no existing billing account person
+      .mockResolvedValueOnce(mockGuardianWithChildren) // Path 4: guardian with children
+    mockCustomersRetrieve.mockResolvedValue({
+      id: CUSTOMER_ID,
+      deleted: false,
+      email: 'khadra.warfa@gmail.com',
+    })
+    mockFindPersonByActiveContact.mockResolvedValue(mockGuardianPerson)
+    mockCreateOrUpdateBillingAccount.mockResolvedValue(mockBillingAccount)
+    mockCreateSubscriptionFromStripe.mockResolvedValue(mockDbSubscription)
+    mockCalculateDugsiRate.mockReturnValue(STANDARD_RATE)
+    mockSubscriptionsUpdate.mockResolvedValue({})
+  })
+
+  it('resolves billing account via Stripe customer email and derives profile IDs', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    const result = await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockCustomersRetrieve).toHaveBeenCalledWith(CUSTOMER_ID)
+    expect(mockFindPersonByActiveContact).toHaveBeenCalledWith(
+      'khadra.warfa@gmail.com'
+    )
+    expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        personId: GUARDIAN_ID,
+        accountType: 'DUGSI',
+        stripeCustomerId: CUSTOMER_ID,
+        paymentMethodCaptured: true,
+      })
+    )
+    expect(result.created).toBe(true)
+    expect(result.subscriptionId).toBe(DB_SUBSCRIPTION_ID)
+  })
+
+  it('patches Stripe subscription metadata with calculated rate and override flag', async () => {
+    const actualAmount = 4500 // custom/override rate
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+      items: {
+        object: 'list',
+        data: [
+          { price: { unit_amount: actualAmount } } as Stripe.SubscriptionItem,
+        ],
+        has_more: false,
+        url: '',
+      },
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledWith(
+      'sub_test_123',
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          guardianPersonId: GUARDIAN_ID,
+          familyId: FAMILY_ID,
+          childCount: '2',
+          profileIds: `${PROFILE_ID_1},${PROFILE_ID_2}`,
+          calculatedRate: String(STANDARD_RATE),
+          overrideUsed: 'true',
+          source: 'dugsi-webhook-fallback-recovery',
+        }),
+      })
+    )
+  })
+
+  it('sets overrideUsed to false when actual amount matches standard rate', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+      items: {
+        object: 'list',
+        data: [
+          { price: { unit_amount: STANDARD_RATE } } as Stripe.SubscriptionItem,
+        ],
+        has_more: false,
+        url: '',
+      },
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledWith(
+      'sub_test_123',
+      expect.objectContaining({
+        metadata: expect.objectContaining({ overrideUsed: 'false' }),
+      })
+    )
+  })
+
+  it('emits Sentry warning and logger.warn on successful fallback resolution', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockSentrycaptureMessage).toHaveBeenCalledWith(
+      'Dugsi subscription resolved via customer email fallback',
+      expect.objectContaining({ level: 'warning' })
+    )
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ guardianPersonId: GUARDIAN_ID, childCount: 2 }),
+      'Subscription created without metadata — resolved via Stripe customer email fallback'
+    )
+  })
+
+  it('still succeeds when Stripe metadata update fails', async () => {
+    mockSubscriptionsUpdate.mockRejectedValue(new Error('Stripe API timeout'))
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    const result = await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(result.created).toBe(true)
+    expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalled()
+  })
+
+  it('throws when Stripe customer is deleted', async () => {
+    mockCustomersRetrieve.mockResolvedValue({ id: CUSTOMER_ID, deleted: true })
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'DUGSI')
+    ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
+  })
+
+  it('throws when email lookup finds no person in DB', async () => {
+    mockFindPersonByActiveContact.mockResolvedValue(null)
+    mockPrismaPersonFindFirst.mockReset().mockResolvedValue(null)
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'DUGSI')
+    ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
+  })
+
+  it('throws without attempting fallback for non-DUGSI account type', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'MAHAD')
+    ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
+    expect(mockCustomersRetrieve).not.toHaveBeenCalled()
   })
 })

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -448,6 +448,129 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
     expect(mockCustomersRetrieve).not.toHaveBeenCalled()
   })
+
+  it('deduplicates profile IDs when guardian has multiple active roles for the same child', async () => {
+    const DUPLICATE_PROFILE_ID = 'profile-id-shared'
+    const guardianWithDuplicateRoles = {
+      ...mockGuardianPerson,
+      guardianRelationships: [
+        // Same child appears via PARENT role and SPONSOR role
+        {
+          dependent: {
+            programProfiles: [
+              { id: DUPLICATE_PROFILE_ID, familyReferenceId: FAMILY_ID },
+            ],
+          },
+        },
+        {
+          dependent: {
+            programProfiles: [
+              { id: DUPLICATE_PROFILE_ID, familyReferenceId: FAMILY_ID },
+            ],
+          },
+        },
+      ],
+    }
+    mockPrismaPersonFindFirst
+      .mockReset()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(guardianWithDuplicateRoles)
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    // childCount should be 1 (not 2) and metadata should have deduplicated profileIds
+    expect(mockCalculateDugsiRate).toHaveBeenCalledWith(1)
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledWith(
+      'sub_test_123',
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          childCount: '1',
+          profileIds: DUPLICATE_PROFILE_ID,
+        }),
+      })
+    )
+  })
+
+  it('omits familyId from Stripe metadata when familyReferenceId is null', async () => {
+    const guardianWithNullFamily = {
+      ...mockGuardianPerson,
+      guardianRelationships: [
+        {
+          dependent: {
+            programProfiles: [{ id: PROFILE_ID_1, familyReferenceId: null }],
+          },
+        },
+      ],
+    }
+    mockPrismaPersonFindFirst
+      .mockReset()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(guardianWithNullFamily)
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    const metadataArg = mockSubscriptionsUpdate.mock.calls[0][1].metadata
+    expect(metadataArg).not.toHaveProperty('familyId')
+  })
+
+  it('warns when guardian spans multiple families and uses first family ID', async () => {
+    const FAMILY_ID_2 = 'family-ref-id-2'
+    const guardianMultiFamily = {
+      ...mockGuardianPerson,
+      guardianRelationships: [
+        {
+          dependent: {
+            programProfiles: [
+              { id: PROFILE_ID_1, familyReferenceId: FAMILY_ID },
+            ],
+          },
+        },
+        {
+          dependent: {
+            programProfiles: [
+              { id: PROFILE_ID_2, familyReferenceId: FAMILY_ID_2 },
+            ],
+          },
+        },
+      ],
+    }
+    mockPrismaPersonFindFirst
+      .mockReset()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(guardianMultiFamily)
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guardianPersonId: GUARDIAN_ID,
+        familyIds: expect.arrayContaining([FAMILY_ID, FAMILY_ID_2]),
+      }),
+      'Path 4 fallback: guardian spans multiple families — using first family ID'
+    )
+    // First family ID wins
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledWith(
+      'sub_test_123',
+      expect.objectContaining({
+        metadata: expect.objectContaining({ familyId: FAMILY_ID }),
+      })
+    )
+  })
 })
 
 describe('handleSubscriptionCreated — Path 3 (existing billing account person)', () => {

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -335,7 +335,7 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     )
   })
 
-  it('includes Family name in Stripe metadata patch', async () => {
+  it('includes familyName in Stripe metadata patch', async () => {
     const subscription = createMockSubscription({
       customer: CUSTOMER_ID,
       metadata: {},
@@ -347,7 +347,7 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
       'sub_test_123',
       expect.objectContaining({
         metadata: expect.objectContaining({
-          Family: mockGuardianPerson.name,
+          familyName: mockGuardianPerson.name,
         }),
       })
     )
@@ -399,6 +399,23 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
       handleSubscriptionCreated(subscription, 'DUGSI')
     ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
     expect(mockFindPersonByActiveContact).not.toHaveBeenCalled()
+  })
+
+  it('throws immediately when second person lookup returns null (concurrent deletion)', async () => {
+    mockPrismaPersonFindFirst
+      .mockReset()
+      .mockResolvedValueOnce(null) // Path 3
+      .mockResolvedValueOnce(null) // Path 4: guardianWithChildren lookup
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'DUGSI')
+    ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
+    expect(mockCreateOrUpdateBillingAccount).not.toHaveBeenCalled()
   })
 
   it('throws when email lookup finds no person in DB', async () => {

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -10,10 +10,12 @@ const {
   mockSubscriptionsUpdate,
   mockPrismaPersonFindFirst,
   mockCreateOrUpdateBillingAccount,
+  mockLinkSubscriptionToProfiles,
   mockCreateSubscriptionFromStripe,
   mockSentrycaptureMessage,
   mockCalculateDugsiRate,
   mockExtractCustomerId,
+  mockLogError,
 } = vi.hoisted(() => ({
   mockGetSubscriptionByStripeId: vi.fn(),
   mockGetBillingAccountByStripeCustomerId: vi.fn(),
@@ -23,10 +25,12 @@ const {
   mockSubscriptionsUpdate: vi.fn(),
   mockPrismaPersonFindFirst: vi.fn(),
   mockCreateOrUpdateBillingAccount: vi.fn(),
+  mockLinkSubscriptionToProfiles: vi.fn(),
   mockCreateSubscriptionFromStripe: vi.fn(),
   mockSentrycaptureMessage: vi.fn(),
   mockCalculateDugsiRate: vi.fn(),
   mockExtractCustomerId: vi.fn(),
+  mockLogError: vi.fn(),
 }))
 
 vi.mock('@/lib/db/queries/billing', () => ({
@@ -47,7 +51,7 @@ vi.mock('@/lib/logger', () => ({
     error: vi.fn(),
     debug: vi.fn(),
   })),
-  logError: vi.fn(),
+  logError: mockLogError,
 }))
 
 vi.mock('@/lib/db', () => ({
@@ -63,7 +67,7 @@ vi.mock('@sentry/nextjs', () => ({
 
 vi.mock('@/lib/services/shared/billing-service', () => ({
   createOrUpdateBillingAccount: mockCreateOrUpdateBillingAccount,
-  linkSubscriptionToProfiles: vi.fn(),
+  linkSubscriptionToProfiles: mockLinkSubscriptionToProfiles,
   unlinkSubscription: vi.fn(),
 }))
 
@@ -195,6 +199,7 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
 
   beforeEach(() => {
     vi.clearAllMocks()
+    mockPrismaPersonFindFirst.mockReset()
     mockExtractCustomerId.mockReturnValue(CUSTOMER_ID)
     mockGetBillingAccountByStripeCustomerId.mockResolvedValue(null)
     mockPrismaPersonFindFirst
@@ -311,7 +316,7 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     )
   })
 
-  it('still succeeds when Stripe metadata update fails', async () => {
+  it('still succeeds when Stripe metadata update fails and emits Sentry error', async () => {
     mockSubscriptionsUpdate.mockRejectedValue(new Error('Stripe API timeout'))
 
     const subscription = createMockSubscription({
@@ -323,9 +328,48 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
 
     expect(result.created).toBe(true)
     expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalled()
+    expect(mockLogError).toHaveBeenCalled()
+    expect(mockSentrycaptureMessage).toHaveBeenCalledWith(
+      'Dugsi subscription metadata patch failed — manual intervention required',
+      expect.objectContaining({ level: 'error' })
+    )
   })
 
-  it('throws when Stripe customer is deleted', async () => {
+  it('includes Family name in Stripe metadata patch', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledWith(
+      'sub_test_123',
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          Family: mockGuardianPerson.name,
+        }),
+      })
+    )
+  })
+
+  it('links derived profile IDs to the created subscription', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockLinkSubscriptionToProfiles).toHaveBeenCalledWith(
+      DB_SUBSCRIPTION_ID,
+      [PROFILE_ID_1, PROFILE_ID_2],
+      5000,
+      'Linked automatically via webhook'
+    )
+  })
+
+  it('throws when Stripe customer is deleted and does not call email lookup', async () => {
     mockCustomersRetrieve.mockResolvedValue({ id: CUSTOMER_ID, deleted: true })
 
     const subscription = createMockSubscription({
@@ -336,6 +380,25 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     await expect(
       handleSubscriptionCreated(subscription, 'DUGSI')
     ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
+    expect(mockFindPersonByActiveContact).not.toHaveBeenCalled()
+  })
+
+  it('throws when Stripe customer has no email (not deleted)', async () => {
+    mockCustomersRetrieve.mockResolvedValue({
+      id: CUSTOMER_ID,
+      deleted: false,
+      email: null,
+    })
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'DUGSI')
+    ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
+    expect(mockFindPersonByActiveContact).not.toHaveBeenCalled()
   })
 
   it('throws when email lookup finds no person in DB', async () => {
@@ -352,6 +415,28 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
   })
 
+  it('throws when guardian has no active Dugsi children', async () => {
+    const guardianNoChildren = {
+      ...mockGuardianPerson,
+      guardianRelationships: [],
+    }
+    mockPrismaPersonFindFirst
+      .mockReset()
+      .mockResolvedValueOnce(null) // Path 3
+      .mockResolvedValueOnce(guardianNoChildren) // Path 4: guardian but no children
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'DUGSI')
+    ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
+    expect(mockCreateOrUpdateBillingAccount).not.toHaveBeenCalled()
+    expect(mockLogError).toHaveBeenCalled()
+  })
+
   it('throws without attempting fallback for non-DUGSI account type', async () => {
     const subscription = createMockSubscription({
       customer: CUSTOMER_ID,
@@ -361,6 +446,64 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     await expect(
       handleSubscriptionCreated(subscription, 'MAHAD')
     ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
+    expect(mockCustomersRetrieve).not.toHaveBeenCalled()
+  })
+})
+
+describe('handleSubscriptionCreated — Path 3 (existing billing account person)', () => {
+  const CUSTOMER_ID = 'cus_existing_123'
+  const EXISTING_PERSON_ID = 'existing-person-id'
+  const BILLING_ACCOUNT_ID = 'billing-account-id'
+  const DB_SUBSCRIPTION_ID = 'db-sub-id'
+
+  const mockExistingPerson = {
+    id: EXISTING_PERSON_ID,
+    name: 'Existing Person',
+    email: 'existing@example.com',
+    phone: '6125550000',
+  }
+
+  const mockBillingAccount = {
+    id: BILLING_ACCOUNT_ID,
+    personId: EXISTING_PERSON_ID,
+  }
+
+  const mockDbSubscription = {
+    id: DB_SUBSCRIPTION_ID,
+    status: 'active',
+    stripeSubscriptionId: 'sub_existing_123',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPrismaPersonFindFirst.mockReset()
+    mockExtractCustomerId.mockReturnValue(CUSTOMER_ID)
+    mockGetBillingAccountByStripeCustomerId.mockResolvedValue(null)
+    mockPrismaPersonFindFirst.mockResolvedValueOnce(mockExistingPerson)
+    mockCreateOrUpdateBillingAccount.mockResolvedValue(mockBillingAccount)
+    mockCreateSubscriptionFromStripe.mockResolvedValue(mockDbSubscription)
+    mockCalculateDugsiRate.mockReturnValue(5000)
+  })
+
+  it('creates billing account for person found via existing billing account link', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    const result = await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        personId: EXISTING_PERSON_ID,
+        accountType: 'DUGSI',
+        stripeCustomerId: CUSTOMER_ID,
+      })
+    )
+    expect(mockCreateOrUpdateBillingAccount).not.toHaveBeenCalledWith(
+      expect.objectContaining({ paymentMethodCaptured: true })
+    )
+    expect(result.created).toBe(true)
     expect(mockCustomersRetrieve).not.toHaveBeenCalled()
   })
 })

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -18,6 +18,8 @@ const {
   mockCalculateDugsiRate,
   mockExtractCustomerId,
   mockLogError,
+  mockFindPersonByStripeCustomerId,
+  mockFindPersonById,
 } = vi.hoisted(() => ({
   mockGetSubscriptionByStripeId: vi.fn(),
   mockGetBillingAccountByStripeCustomerId: vi.fn(),
@@ -35,6 +37,8 @@ const {
   mockCalculateDugsiRate: vi.fn(),
   mockExtractCustomerId: vi.fn(),
   mockLogError: vi.fn(),
+  mockFindPersonByStripeCustomerId: vi.fn(),
+  mockFindPersonById: vi.fn(),
 }))
 
 vi.mock('@/lib/db/queries/billing', () => ({
@@ -42,6 +46,11 @@ vi.mock('@/lib/db/queries/billing', () => ({
   getSubscriptionByStripeId: mockGetSubscriptionByStripeId,
   getBillingAssignmentsBySubscription: vi.fn(),
   updateSubscriptionStatus: vi.fn(),
+  findPersonByStripeCustomerId: mockFindPersonByStripeCustomerId,
+}))
+
+vi.mock('@/lib/db/queries/program-profile', () => ({
+  findPersonById: mockFindPersonById,
 }))
 
 vi.mock('@/lib/db/queries/dugsi-profiles', () => ({
@@ -208,11 +217,11 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
 
   beforeEach(() => {
     vi.clearAllMocks()
-    mockPrismaPersonFindFirst.mockReset()
     mockExtractCustomerId.mockReturnValue(CUSTOMER_ID)
     mockGetBillingAccountByStripeCustomerId.mockResolvedValue(null)
+    mockFindPersonById.mockResolvedValue(null)
     // Path 3: no existing person linked to this customer ID
-    mockPrismaPersonFindFirst.mockResolvedValueOnce(null)
+    mockFindPersonByStripeCustomerId.mockResolvedValue(null)
     // Path 4: guardian found by email with billable children
     mockFindGuardianWithBillableDugsiChildren.mockResolvedValue(
       mockGuardianWithChildren
@@ -487,20 +496,6 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     expect(mockCreateOrUpdateBillingAccount).not.toHaveBeenCalled()
   })
 
-  it('throws when email lookup finds no person in DB', async () => {
-    mockPrismaPersonFindFirst.mockReset().mockResolvedValueOnce(null)
-    mockFindGuardianWithBillableDugsiChildren.mockResolvedValue(null)
-
-    const subscription = createMockSubscription({
-      customer: CUSTOMER_ID,
-      metadata: {},
-    })
-
-    await expect(
-      handleSubscriptionCreated(subscription, 'DUGSI')
-    ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
-  })
-
   it('throws when guardian has no active Dugsi children', async () => {
     const guardianNoChildren = {
       ...mockGuardianPerson,
@@ -681,10 +676,10 @@ describe('handleSubscriptionCreated — Path 3 (existing billing account person)
 
   beforeEach(() => {
     vi.clearAllMocks()
-    mockPrismaPersonFindFirst.mockReset()
     mockExtractCustomerId.mockReturnValue(CUSTOMER_ID)
     mockGetBillingAccountByStripeCustomerId.mockResolvedValue(null)
-    mockPrismaPersonFindFirst.mockResolvedValueOnce(mockExistingPerson)
+    mockFindPersonById.mockResolvedValue(null)
+    mockFindPersonByStripeCustomerId.mockResolvedValue(mockExistingPerson)
     mockCreateOrUpdateBillingAccount.mockResolvedValue(mockBillingAccount)
     mockCreateSubscriptionFromStripe.mockResolvedValue(mockDbSubscription)
     mockCalculateDugsiRate.mockReturnValue(5000)
@@ -715,6 +710,88 @@ describe('handleSubscriptionCreated — Path 3 (existing billing account person)
   })
 })
 
+describe('handleSubscriptionCreated — Path 2 (subscription metadata personId)', () => {
+  const CUSTOMER_ID = 'cus_path2_123'
+  const PERSON_ID = 'person-id-from-metadata'
+  const BILLING_ACCOUNT_ID = 'billing-account-id'
+  const DB_SUBSCRIPTION_ID = 'db-sub-id'
+
+  const mockBillingAccount = { id: BILLING_ACCOUNT_ID, personId: PERSON_ID }
+  const mockDbSubscription = {
+    id: DB_SUBSCRIPTION_ID,
+    status: 'active',
+    stripeSubscriptionId: 'sub_path2_123',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExtractCustomerId.mockReturnValue(CUSTOMER_ID)
+    mockGetBillingAccountByStripeCustomerId.mockResolvedValue(null)
+    mockFindPersonById.mockResolvedValue({ id: PERSON_ID })
+    mockCreateOrUpdateBillingAccount.mockResolvedValue(mockBillingAccount)
+    mockCreateSubscriptionFromStripe.mockResolvedValue(mockDbSubscription)
+    mockFindBillableDugsiProfileIdsForGuardian.mockResolvedValue([])
+    mockVerifyDugsiProfileIdsForGuardian.mockResolvedValue([])
+    mockCalculateDugsiRate.mockReturnValue(5000)
+  })
+
+  it('creates billing account from metadata.guardianPersonId', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: { guardianPersonId: PERSON_ID },
+    })
+
+    const result = await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockFindPersonById).toHaveBeenCalledWith(PERSON_ID)
+    expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        personId: PERSON_ID,
+        accountType: 'DUGSI',
+        stripeCustomerId: CUSTOMER_ID,
+        paymentMethodCaptured: true,
+      })
+    )
+    expect(result.created).toBe(true)
+    expect(mockCustomersRetrieve).not.toHaveBeenCalled()
+  })
+
+  it('creates billing account from metadata.personId (Mahad-style key)', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: { personId: PERSON_ID },
+    })
+
+    const result = await handleSubscriptionCreated(subscription, 'MAHAD')
+
+    expect(mockFindPersonById).toHaveBeenCalledWith(PERSON_ID)
+    expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ personId: PERSON_ID, accountType: 'MAHAD' })
+    )
+    expect(result.created).toBe(true)
+  })
+
+  it('falls through to Path 3 and throws when metadata personId not found in DB', async () => {
+    mockFindPersonById.mockResolvedValue(null)
+    mockFindPersonByStripeCustomerId.mockResolvedValue(null)
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: { guardianPersonId: 'nonexistent-person-id' },
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'MAHAD')
+    ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ metadataPersonId: 'nonexistent-person-id' }),
+      'Path 2: metadataPersonId not found in DB — falling through to Path 3'
+    )
+    expect(mockCreateOrUpdateBillingAccount).not.toHaveBeenCalled()
+  })
+})
+
 describe('handleSubscriptionCreated — Dugsi profile ID verification (Paths 1/2/3)', () => {
   const CUSTOMER_ID = 'cus_common_123'
   const GUARDIAN_ID = 'guardian-person-id'
@@ -736,12 +813,13 @@ describe('handleSubscriptionCreated — Dugsi profile ID verification (Paths 1/2
 
   beforeEach(() => {
     vi.clearAllMocks()
-    mockPrismaPersonFindFirst.mockReset()
     mockExtractCustomerId.mockReturnValue(CUSTOMER_ID)
     // Path 1: billing account exists
     mockGetBillingAccountByStripeCustomerId.mockResolvedValue(
       mockBillingAccount
     )
+    mockFindPersonById.mockResolvedValue(null)
+    mockFindPersonByStripeCustomerId.mockResolvedValue(null)
     mockCreateOrUpdateBillingAccount.mockResolvedValue(mockBillingAccount)
     mockCreateSubscriptionFromStripe.mockResolvedValue(mockDbSubscription)
     mockCalculateDugsiRate.mockReturnValue(5000)
@@ -828,5 +906,45 @@ describe('handleSubscriptionCreated — Dugsi profile ID verification (Paths 1/2
 
     expect(mockSubscriptionsUpdate).not.toHaveBeenCalled()
     expect(mockSentrycaptureMessage).not.toHaveBeenCalled()
+  })
+
+  it('uses metadata profile ID hints without Dugsi DB lookup for Mahad subscriptions', async () => {
+    const MAHAD_PROFILE_ID = 'mahad-profile-id'
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: { profileId: MAHAD_PROFILE_ID },
+    })
+
+    await handleSubscriptionCreated(subscription, 'MAHAD')
+
+    expect(mockVerifyDugsiProfileIdsForGuardian).not.toHaveBeenCalled()
+    expect(mockFindBillableDugsiProfileIdsForGuardian).not.toHaveBeenCalled()
+    expect(mockLinkSubscriptionToProfiles).toHaveBeenCalledWith(
+      DB_SUBSCRIPTION_ID,
+      [MAHAD_PROFILE_ID],
+      5000,
+      'Linked automatically via webhook'
+    )
+  })
+
+  it('throws and logs when subscription amount is zero and profiles are present', async () => {
+    mockFindBillableDugsiProfileIdsForGuardian.mockResolvedValue([PROFILE_ID_1])
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+      items: {
+        object: 'list',
+        data: [{ price: { unit_amount: 0 } } as Stripe.SubscriptionItem],
+        has_more: false,
+        url: '',
+      },
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'DUGSI')
+    ).rejects.toThrow('Subscription has invalid amount')
+    expect(mockLogError).toHaveBeenCalled()
+    expect(mockLinkSubscriptionToProfiles).not.toHaveBeenCalled()
   })
 })

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -5,7 +5,9 @@ const {
   mockGetSubscriptionByStripeId,
   mockGetBillingAccountByStripeCustomerId,
   mockLoggerWarn,
-  mockFindPersonByActiveContact,
+  mockFindGuardianWithBillableDugsiChildren,
+  mockVerifyDugsiProfileIdsForGuardian,
+  mockFindBillableDugsiProfileIdsForGuardian,
   mockCustomersRetrieve,
   mockSubscriptionsUpdate,
   mockPrismaPersonFindFirst,
@@ -20,7 +22,9 @@ const {
   mockGetSubscriptionByStripeId: vi.fn(),
   mockGetBillingAccountByStripeCustomerId: vi.fn(),
   mockLoggerWarn: vi.fn(),
-  mockFindPersonByActiveContact: vi.fn(),
+  mockFindGuardianWithBillableDugsiChildren: vi.fn(),
+  mockVerifyDugsiProfileIdsForGuardian: vi.fn(),
+  mockFindBillableDugsiProfileIdsForGuardian: vi.fn(),
   mockCustomersRetrieve: vi.fn(),
   mockSubscriptionsUpdate: vi.fn(),
   mockPrismaPersonFindFirst: vi.fn(),
@@ -40,8 +44,12 @@ vi.mock('@/lib/db/queries/billing', () => ({
   updateSubscriptionStatus: vi.fn(),
 }))
 
-vi.mock('@/lib/db/queries/program-profile', () => ({
-  findPersonByActiveContact: mockFindPersonByActiveContact,
+vi.mock('@/lib/db/queries/dugsi-profiles', () => ({
+  findGuardianWithBillableDugsiChildren:
+    mockFindGuardianWithBillableDugsiChildren,
+  verifyDugsiProfileIdsForGuardian: mockVerifyDugsiProfileIdsForGuardian,
+  findBillableDugsiProfileIdsForGuardian:
+    mockFindBillableDugsiProfileIdsForGuardian,
 }))
 
 vi.mock('@/lib/logger', () => ({
@@ -117,6 +125,7 @@ function createMockSubscription(
     status: 'active',
     customer: 'cus_test_123',
     metadata: {},
+    created: 1700000000,
     items: {
       object: 'list',
       data: [
@@ -202,15 +211,17 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     mockPrismaPersonFindFirst.mockReset()
     mockExtractCustomerId.mockReturnValue(CUSTOMER_ID)
     mockGetBillingAccountByStripeCustomerId.mockResolvedValue(null)
-    mockPrismaPersonFindFirst
-      .mockResolvedValueOnce(null) // Path 3: no existing billing account person
-      .mockResolvedValueOnce(mockGuardianWithChildren) // Path 4: guardian with children
+    // Path 3: no existing person linked to this customer ID
+    mockPrismaPersonFindFirst.mockResolvedValueOnce(null)
+    // Path 4: guardian found by email with billable children
+    mockFindGuardianWithBillableDugsiChildren.mockResolvedValue(
+      mockGuardianWithChildren
+    )
     mockCustomersRetrieve.mockResolvedValue({
       id: CUSTOMER_ID,
       deleted: false,
       email: 'khadra.warfa@gmail.com',
     })
-    mockFindPersonByActiveContact.mockResolvedValue(mockGuardianPerson)
     mockCreateOrUpdateBillingAccount.mockResolvedValue(mockBillingAccount)
     mockCreateSubscriptionFromStripe.mockResolvedValue(mockDbSubscription)
     mockCalculateDugsiRate.mockReturnValue(STANDARD_RATE)
@@ -226,7 +237,7 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     const result = await handleSubscriptionCreated(subscription, 'DUGSI')
 
     expect(mockCustomersRetrieve).toHaveBeenCalledWith(CUSTOMER_ID)
-    expect(mockFindPersonByActiveContact).toHaveBeenCalledWith(
+    expect(mockFindGuardianWithBillableDugsiChildren).toHaveBeenCalledWith(
       'khadra.warfa@gmail.com'
     )
     expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalledWith(
@@ -241,8 +252,25 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     expect(result.subscriptionId).toBe(DB_SUBSCRIPTION_ID)
   })
 
+  it('uses subscription.created timestamp for paymentMethodCapturedAt in fallback', async () => {
+    const STRIPE_CREATED_TS = 1700000000
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+      created: STRIPE_CREATED_TS,
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentMethodCapturedAt: new Date(STRIPE_CREATED_TS * 1000),
+      })
+    )
+  })
+
   it('patches Stripe subscription metadata with calculated rate and override flag', async () => {
-    const actualAmount = 4500 // custom/override rate
+    const actualAmount = 4500
     const subscription = createMockSubscription({
       customer: CUSTOMER_ID,
       metadata: {},
@@ -272,6 +300,34 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
         }),
       })
     )
+  })
+
+  it('patches metadata after DB subscription is created and profiles are linked', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    const callOrder: string[] = []
+    mockCreateSubscriptionFromStripe.mockImplementation(async () => {
+      callOrder.push('createSubscription')
+      return mockDbSubscription
+    })
+    mockLinkSubscriptionToProfiles.mockImplementation(async () => {
+      callOrder.push('linkProfiles')
+    })
+    mockSubscriptionsUpdate.mockImplementation(async () => {
+      callOrder.push('patchMetadata')
+      return {}
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(callOrder).toEqual([
+      'createSubscription',
+      'linkProfiles',
+      'patchMetadata',
+    ])
   })
 
   it('sets overrideUsed to false when actual amount matches standard rate', async () => {
@@ -382,10 +438,10 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
       handleSubscriptionCreated(subscription, 'DUGSI')
     ).rejects.toThrow('Stripe network timeout')
     expect(mockLogError).toHaveBeenCalled()
-    expect(mockFindPersonByActiveContact).not.toHaveBeenCalled()
+    expect(mockFindGuardianWithBillableDugsiChildren).not.toHaveBeenCalled()
   })
 
-  it('throws when Stripe customer is deleted and does not call email lookup', async () => {
+  it('throws when Stripe customer is deleted and does not call guardian lookup', async () => {
     mockCustomersRetrieve.mockResolvedValue({ id: CUSTOMER_ID, deleted: true })
 
     const subscription = createMockSubscription({
@@ -396,7 +452,7 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     await expect(
       handleSubscriptionCreated(subscription, 'DUGSI')
     ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
-    expect(mockFindPersonByActiveContact).not.toHaveBeenCalled()
+    expect(mockFindGuardianWithBillableDugsiChildren).not.toHaveBeenCalled()
   })
 
   it('throws when Stripe customer has no email (not deleted)', async () => {
@@ -414,14 +470,11 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     await expect(
       handleSubscriptionCreated(subscription, 'DUGSI')
     ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
-    expect(mockFindPersonByActiveContact).not.toHaveBeenCalled()
+    expect(mockFindGuardianWithBillableDugsiChildren).not.toHaveBeenCalled()
   })
 
-  it('throws immediately when second person lookup returns null (concurrent deletion)', async () => {
-    mockPrismaPersonFindFirst
-      .mockReset()
-      .mockResolvedValueOnce(null) // Path 3
-      .mockResolvedValueOnce(null) // Path 4: guardianWithChildren lookup
+  it('throws when guardian lookup by email returns null', async () => {
+    mockFindGuardianWithBillableDugsiChildren.mockResolvedValue(null)
 
     const subscription = createMockSubscription({
       customer: CUSTOMER_ID,
@@ -435,8 +488,8 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
   })
 
   it('throws when email lookup finds no person in DB', async () => {
-    mockFindPersonByActiveContact.mockResolvedValue(null)
-    mockPrismaPersonFindFirst.mockReset().mockResolvedValue(null)
+    mockPrismaPersonFindFirst.mockReset().mockResolvedValueOnce(null)
+    mockFindGuardianWithBillableDugsiChildren.mockResolvedValue(null)
 
     const subscription = createMockSubscription({
       customer: CUSTOMER_ID,
@@ -453,10 +506,9 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
       ...mockGuardianPerson,
       guardianRelationships: [],
     }
-    mockPrismaPersonFindFirst
-      .mockReset()
-      .mockResolvedValueOnce(null) // Path 3
-      .mockResolvedValueOnce(guardianNoChildren) // Path 4: guardian but no children
+    mockFindGuardianWithBillableDugsiChildren.mockResolvedValue(
+      guardianNoChildren
+    )
 
     const subscription = createMockSubscription({
       customer: CUSTOMER_ID,
@@ -490,7 +542,6 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     const guardianWithDuplicateRoles = {
       ...mockGuardianPerson,
       guardianRelationships: [
-        // Same child appears via PARENT role and SPONSOR role
         {
           dependent: {
             programProfiles: [
@@ -507,10 +558,9 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
         },
       ],
     }
-    mockPrismaPersonFindFirst
-      .mockReset()
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(guardianWithDuplicateRoles)
+    mockFindGuardianWithBillableDugsiChildren.mockResolvedValue(
+      guardianWithDuplicateRoles
+    )
 
     const subscription = createMockSubscription({
       customer: CUSTOMER_ID,
@@ -519,7 +569,6 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
 
     await handleSubscriptionCreated(subscription, 'DUGSI')
 
-    // childCount should be 1 (not 2) and metadata should have deduplicated profileIds
     expect(mockCalculateDugsiRate).toHaveBeenCalledWith(1)
     expect(mockSubscriptionsUpdate).toHaveBeenCalledWith(
       'sub_test_123',
@@ -543,10 +592,9 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
         },
       ],
     }
-    mockPrismaPersonFindFirst
-      .mockReset()
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(guardianWithNullFamily)
+    mockFindGuardianWithBillableDugsiChildren.mockResolvedValue(
+      guardianWithNullFamily
+    )
 
     const subscription = createMockSubscription({
       customer: CUSTOMER_ID,
@@ -580,10 +628,9 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
         },
       ],
     }
-    mockPrismaPersonFindFirst
-      .mockReset()
-      .mockResolvedValueOnce(null)
-      .mockResolvedValueOnce(guardianMultiFamily)
+    mockFindGuardianWithBillableDugsiChildren.mockResolvedValue(
+      guardianMultiFamily
+    )
 
     const subscription = createMockSubscription({
       customer: CUSTOMER_ID,
@@ -599,7 +646,6 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
       }),
       'Path 4 fallback: guardian spans multiple families — using first family ID'
     )
-    // First family ID wins
     expect(mockSubscriptionsUpdate).toHaveBeenCalledWith(
       'sub_test_123',
       expect.objectContaining({
@@ -642,6 +688,8 @@ describe('handleSubscriptionCreated — Path 3 (existing billing account person)
     mockCreateOrUpdateBillingAccount.mockResolvedValue(mockBillingAccount)
     mockCreateSubscriptionFromStripe.mockResolvedValue(mockDbSubscription)
     mockCalculateDugsiRate.mockReturnValue(5000)
+    mockFindBillableDugsiProfileIdsForGuardian.mockResolvedValue([])
+    mockVerifyDugsiProfileIdsForGuardian.mockResolvedValue([])
   })
 
   it('creates billing account for person found via existing billing account link', async () => {
@@ -664,5 +712,121 @@ describe('handleSubscriptionCreated — Path 3 (existing billing account person)
     )
     expect(result.created).toBe(true)
     expect(mockCustomersRetrieve).not.toHaveBeenCalled()
+  })
+})
+
+describe('handleSubscriptionCreated — Dugsi profile ID verification (Paths 1/2/3)', () => {
+  const CUSTOMER_ID = 'cus_common_123'
+  const GUARDIAN_ID = 'guardian-person-id'
+  const PROFILE_ID_1 = 'profile-id-1'
+  const PROFILE_ID_2 = 'profile-id-2'
+  const BILLING_ACCOUNT_ID = 'billing-account-id'
+  const DB_SUBSCRIPTION_ID = 'db-sub-id'
+
+  const mockBillingAccount = {
+    id: BILLING_ACCOUNT_ID,
+    personId: GUARDIAN_ID,
+  }
+
+  const mockDbSubscription = {
+    id: DB_SUBSCRIPTION_ID,
+    status: 'active',
+    stripeSubscriptionId: 'sub_common_123',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockPrismaPersonFindFirst.mockReset()
+    mockExtractCustomerId.mockReturnValue(CUSTOMER_ID)
+    // Path 1: billing account exists
+    mockGetBillingAccountByStripeCustomerId.mockResolvedValue(
+      mockBillingAccount
+    )
+    mockCreateOrUpdateBillingAccount.mockResolvedValue(mockBillingAccount)
+    mockCreateSubscriptionFromStripe.mockResolvedValue(mockDbSubscription)
+    mockCalculateDugsiRate.mockReturnValue(5000)
+    mockVerifyDugsiProfileIdsForGuardian.mockResolvedValue([])
+    mockFindBillableDugsiProfileIdsForGuardian.mockResolvedValue([
+      PROFILE_ID_1,
+      PROFILE_ID_2,
+    ])
+  })
+
+  it('ignores unverified Dugsi profileIds from Stripe metadata and links DB-derived billable children', async () => {
+    const FAKE_PROFILE_ID = 'fake-unverified-profile-id'
+    // Verification rejects the fake ID
+    mockVerifyDugsiProfileIdsForGuardian.mockResolvedValue([])
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: { profileIds: FAKE_PROFILE_ID },
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadataProfileIds: [FAKE_PROFILE_ID],
+        verifiedProfileIds: [],
+      }),
+      'Ignoring unverified Dugsi profileIds from Stripe metadata'
+    )
+    expect(mockLinkSubscriptionToProfiles).toHaveBeenCalledWith(
+      DB_SUBSCRIPTION_ID,
+      [PROFILE_ID_1, PROFILE_ID_2],
+      5000,
+      'Linked automatically via webhook'
+    )
+  })
+
+  it('uses verified metadata profile IDs when they pass DB check', async () => {
+    mockVerifyDugsiProfileIdsForGuardian.mockResolvedValue([PROFILE_ID_1])
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: { profileIds: PROFILE_ID_1 },
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockLinkSubscriptionToProfiles).toHaveBeenCalledWith(
+      DB_SUBSCRIPTION_ID,
+      [PROFILE_ID_1],
+      5000,
+      'Linked automatically via webhook'
+    )
+    expect(mockFindBillableDugsiProfileIdsForGuardian).not.toHaveBeenCalled()
+  })
+
+  it('falls back to full DB derivation when no metadata profile hints are present', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockVerifyDugsiProfileIdsForGuardian).not.toHaveBeenCalled()
+    expect(mockFindBillableDugsiProfileIdsForGuardian).toHaveBeenCalledWith(
+      GUARDIAN_ID
+    )
+    expect(mockLinkSubscriptionToProfiles).toHaveBeenCalledWith(
+      DB_SUBSCRIPTION_ID,
+      [PROFILE_ID_1, PROFILE_ID_2],
+      5000,
+      'Linked automatically via webhook'
+    )
+  })
+
+  it('does not fire Dugsi metadata patch for common Dugsi paths', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockSubscriptionsUpdate).not.toHaveBeenCalled()
+    expect(mockSentrycaptureMessage).not.toHaveBeenCalled()
   })
 })

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -369,6 +369,22 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     )
   })
 
+  it('throws and logs when customers.retrieve rejects (Stripe API error)', async () => {
+    const apiError = new Error('Stripe network timeout')
+    mockCustomersRetrieve.mockRejectedValue(apiError)
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'DUGSI')
+    ).rejects.toThrow('Stripe network timeout')
+    expect(mockLogError).toHaveBeenCalled()
+    expect(mockFindPersonByActiveContact).not.toHaveBeenCalled()
+  })
+
   it('throws when Stripe customer is deleted and does not call email lookup', async () => {
     mockCustomersRetrieve.mockResolvedValue({ id: CUSTOMER_ID, deleted: true })
 
@@ -451,7 +467,10 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
       handleSubscriptionCreated(subscription, 'DUGSI')
     ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
     expect(mockCreateOrUpdateBillingAccount).not.toHaveBeenCalled()
-    expect(mockLogError).toHaveBeenCalled()
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ guardianPersonId: GUARDIAN_ID }),
+      'Path 4 fallback: Cannot create billing account — guardian has no enrolled Dugsi children'
+    )
   })
 
   it('throws without attempting fallback for non-DUGSI account type', async () => {

--- a/lib/services/webhooks/event-handlers.ts
+++ b/lib/services/webhooks/event-handlers.ts
@@ -139,14 +139,7 @@ async function handleSubscriptionCreatedEvent(
     'Processing customer.subscription.created'
   )
 
-  // Extract profile IDs from subscription metadata if available
-  const profileIds = subscription.metadata?.profileIds
-    ? subscription.metadata.profileIds.split(',').filter(Boolean)
-    : subscription.metadata?.profileId
-      ? [subscription.metadata.profileId]
-      : undefined
-
-  await handleSubscriptionCreated(subscription, accountType, profileIds)
+  await handleSubscriptionCreated(subscription, accountType)
 }
 
 /**

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -207,7 +207,7 @@ export async function handleSubscriptionCreated(
           accountType,
           stripeCustomerId: customerId,
         })
-      } else if (accountType === 'DUGSI') {
+      } else if (accountType === StripeAccountType.DUGSI) {
         // Fallback for subscriptions created manually in Stripe dashboard — no metadata was set.
         // Resolves the guardian via Stripe customer email and patches metadata for future events.
         const dugsiStripe = getDugsiStripeClient()
@@ -289,11 +289,14 @@ export async function handleSubscriptionCreated(
             { guardianPersonId: guardianPerson.id, customerId },
             'Path 4 fallback: Second person lookup returned null — possible concurrent deletion'
           )
+          throw new Error(
+            `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`
+          )
         }
 
-        const rawProfiles = (
-          guardianWithChildren?.guardianRelationships ?? []
-        ).flatMap((rel) => rel.dependent.programProfiles)
+        const rawProfiles = guardianWithChildren.guardianRelationships.flatMap(
+          (rel) => rel.dependent.programProfiles
+        )
 
         // Issue 2: deduplicate by profile ID — a guardian can have multiple active roles
         // per dependent (e.g., PARENT + SPONSOR), which would double-count the child
@@ -356,16 +359,39 @@ export async function handleSubscriptionCreated(
           await dugsiStripe.subscriptions.update(subscription.id, {
             metadata: {
               guardianPersonId: guardianPerson.id,
-              // Issue 3: omit familyId from metadata when null rather than writing ''
               ...(familyId ? { familyId } : {}),
               childCount: String(childCount),
-              profileIds: resolvedProfileIds.join(','),
+              profileIds: (profileIds ?? resolvedProfileIds).join(','),
               calculatedRate: String(standardRate),
               overrideUsed: String(actualAmount !== standardRate),
-              Family: guardianPerson.name,
+              familyName: guardianPerson.name,
               source: 'dugsi-webhook-fallback-recovery',
             },
           })
+
+          Sentry.captureMessage(
+            'Dugsi subscription resolved via customer email fallback',
+            {
+              level: 'warning',
+              extra: {
+                customerId,
+                subscriptionId: subscription.id,
+                guardianPersonId: guardianPerson.id,
+                childCount,
+                derivedProfileIds: profileIds,
+              },
+            }
+          )
+
+          logger.warn(
+            {
+              customerId,
+              subscriptionId: subscription.id,
+              guardianPersonId: guardianPerson.id,
+              childCount,
+            },
+            'Subscription created without metadata — resolved via Stripe customer email fallback'
+          )
         } catch (metadataErr) {
           await logError(
             logger,
@@ -389,30 +415,6 @@ export async function handleSubscriptionCreated(
             }
           )
         }
-
-        Sentry.captureMessage(
-          'Dugsi subscription resolved via customer email fallback',
-          {
-            level: 'warning',
-            extra: {
-              customerId,
-              subscriptionId: subscription.id,
-              guardianPersonId: guardianPerson.id,
-              childCount,
-              derivedProfileIds: profileIds,
-            },
-          }
-        )
-
-        logger.warn(
-          {
-            customerId,
-            subscriptionId: subscription.id,
-            guardianPersonId: guardianPerson.id,
-            childCount,
-          },
-          'Subscription created without metadata — resolved via Stripe customer email fallback'
-        )
       } else {
         throw new Error(
           `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -229,6 +229,7 @@ export async function handleSubscriptionCreated(
           ? null
           : stripeCustomer.email
 
+        // Issue 5: early return on each failure branch — intent is explicit at every fork
         if (!customerEmail) {
           logger.warn(
             {
@@ -238,146 +239,180 @@ export async function handleSubscriptionCreated(
             },
             'Path 4 fallback: Stripe customer has no email address, cannot resolve guardian'
           )
-        } else {
-          const guardianPerson = await findPersonByActiveContact(customerEmail)
-
-          if (!guardianPerson) {
-            logger.warn(
-              { customerId, customerEmail, subscriptionId: subscription.id },
-              'Path 4 fallback: Stripe customer email found but no matching Person record'
-            )
-          } else {
-            const guardianWithChildren = await prisma.person.findFirst({
-              where: { id: guardianPerson.id },
-              include: {
-                guardianRelationships: {
-                  where: { isActive: true },
-                  include: {
-                    dependent: {
-                      include: {
-                        programProfiles: {
-                          where: {
-                            program: Program.DUGSI_PROGRAM,
-                            status: { not: EnrollmentStatus.WITHDRAWN },
-                          },
-                          select: { id: true, familyReferenceId: true },
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            })
-
-            if (!guardianWithChildren) {
-              logger.warn(
-                { guardianPersonId: guardianPerson.id, customerId },
-                'Path 4 fallback: Second person lookup returned null — possible concurrent deletion'
-              )
-            }
-
-            const familyProfiles = (
-              guardianWithChildren?.guardianRelationships ?? []
-            ).flatMap((rel) => rel.dependent.programProfiles)
-
-            if (familyProfiles.length === 0) {
-              await logError(
-                logger,
-                new Error('Guardian has no active Dugsi program profiles'),
-                'Path 4 fallback: Cannot create billing account — guardian has no enrolled dependents',
-                {
-                  customerId,
-                  guardianPersonId: guardianPerson.id,
-                  subscriptionId: subscription.id,
-                }
-              )
-            } else {
-              billingAccount = await createOrUpdateBillingAccount({
-                personId: guardianPerson.id,
-                accountType,
-                stripeCustomerId: customerId,
-                paymentMethodCaptured: true,
-                paymentMethodCapturedAt: new Date(),
-              })
-
-              const resolvedProfileIds = familyProfiles.map((p) => p.id)
-              profileIds = resolvedProfileIds
-
-              const childCount = familyProfiles.length
-              const familyId = familyProfiles[0]?.familyReferenceId ?? null
-              const standardRate = calculateDugsiRate(childCount)
-              const actualAmount =
-                subscription.items.data[0]?.price?.unit_amount ?? standardRate
-
-              try {
-                await dugsiStripe.subscriptions.update(subscription.id, {
-                  metadata: {
-                    guardianPersonId: guardianPerson.id,
-                    familyId: familyId ?? '',
-                    childCount: String(childCount),
-                    profileIds: resolvedProfileIds.join(','),
-                    calculatedRate: String(standardRate),
-                    overrideUsed: String(actualAmount !== standardRate),
-                    Family: guardianPerson.name,
-                    source: 'dugsi-webhook-fallback-recovery',
-                  },
-                })
-              } catch (metadataErr) {
-                await logError(
-                  logger,
-                  metadataErr,
-                  'Path 4 fallback: Failed to patch Stripe subscription metadata — manual update required',
-                  {
-                    subscriptionId: subscription.id,
-                    customerId,
-                    guardianPersonId: guardianPerson.id,
-                  }
-                )
-                Sentry.captureMessage(
-                  'Dugsi subscription metadata patch failed — manual intervention required',
-                  {
-                    level: 'error',
-                    extra: {
-                      subscriptionId: subscription.id,
-                      customerId,
-                      guardianPersonId: guardianPerson.id,
-                    },
-                  }
-                )
-              }
-
-              Sentry.captureMessage(
-                'Dugsi subscription resolved via customer email fallback',
-                {
-                  level: 'warning',
-                  extra: {
-                    customerId,
-                    subscriptionId: subscription.id,
-                    guardianPersonId: guardianPerson.id,
-                    childCount,
-                    derivedProfileIds: profileIds,
-                  },
-                }
-              )
-
-              logger.warn(
-                {
-                  customerId,
-                  subscriptionId: subscription.id,
-                  guardianPersonId: guardianPerson.id,
-                  childCount,
-                },
-                'Subscription created without metadata — resolved via Stripe customer email fallback'
-              )
-            }
-          }
-        }
-
-        if (!billingAccount) {
           throw new Error(
             `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`
           )
         }
+
+        const guardianPerson = await findPersonByActiveContact(customerEmail)
+
+        if (!guardianPerson) {
+          logger.warn(
+            { customerId, customerEmail, subscriptionId: subscription.id },
+            'Path 4 fallback: Stripe customer email found but no matching Person record'
+          )
+          throw new Error(
+            `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`
+          )
+        }
+
+        const guardianWithChildren = await prisma.person.findFirst({
+          where: { id: guardianPerson.id },
+          include: {
+            guardianRelationships: {
+              where: { isActive: true },
+              include: {
+                dependent: {
+                  include: {
+                    programProfiles: {
+                      where: {
+                        program: Program.DUGSI_PROGRAM,
+                        // Issue 1: restrict to billable statuses only (matches checkout-service)
+                        status: {
+                          in: [
+                            EnrollmentStatus.REGISTERED,
+                            EnrollmentStatus.ENROLLED,
+                          ],
+                        },
+                      },
+                      select: { id: true, familyReferenceId: true },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        })
+
+        if (!guardianWithChildren) {
+          logger.warn(
+            { guardianPersonId: guardianPerson.id, customerId },
+            'Path 4 fallback: Second person lookup returned null — possible concurrent deletion'
+          )
+        }
+
+        const rawProfiles = (
+          guardianWithChildren?.guardianRelationships ?? []
+        ).flatMap((rel) => rel.dependent.programProfiles)
+
+        // Issue 2: deduplicate by profile ID — a guardian can have multiple active roles
+        // per dependent (e.g., PARENT + SPONSOR), which would double-count the child
+        const familyProfiles = Array.from(
+          new Map(rawProfiles.map((p) => [p.id, p])).values()
+        )
+
+        if (familyProfiles.length === 0) {
+          await logError(
+            logger,
+            new Error('Guardian has no active Dugsi program profiles'),
+            'Path 4 fallback: Cannot create billing account — guardian has no enrolled dependents',
+            {
+              customerId,
+              guardianPersonId: guardianPerson.id,
+              subscriptionId: subscription.id,
+            }
+          )
+          throw new Error(
+            `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`
+          )
+        }
+
+        billingAccount = await createOrUpdateBillingAccount({
+          personId: guardianPerson.id,
+          accountType,
+          stripeCustomerId: customerId,
+          paymentMethodCaptured: true,
+          paymentMethodCapturedAt: new Date(),
+        })
+
+        const resolvedProfileIds = familyProfiles.map((p) => p.id)
+        // Issue 4: only set profileIds if the caller didn't supply them
+        if (!profileIds?.length) {
+          profileIds = resolvedProfileIds
+        }
+
+        const childCount = familyProfiles.length
+        const familyId = familyProfiles[0]?.familyReferenceId ?? null
+
+        // Issue 6: warn when a guardian spans multiple families — first family wins
+        const uniqueFamilyIds = new Set(
+          familyProfiles.map((p) => p.familyReferenceId).filter(Boolean)
+        )
+        if (uniqueFamilyIds.size > 1) {
+          logger.warn(
+            {
+              guardianPersonId: guardianPerson.id,
+              familyIds: [...uniqueFamilyIds],
+            },
+            'Path 4 fallback: guardian spans multiple families — using first family ID'
+          )
+        }
+
+        const standardRate = calculateDugsiRate(childCount)
+        const actualAmount =
+          subscription.items.data[0]?.price?.unit_amount ?? standardRate
+
+        try {
+          await dugsiStripe.subscriptions.update(subscription.id, {
+            metadata: {
+              guardianPersonId: guardianPerson.id,
+              // Issue 3: omit familyId from metadata when null rather than writing ''
+              ...(familyId ? { familyId } : {}),
+              childCount: String(childCount),
+              profileIds: resolvedProfileIds.join(','),
+              calculatedRate: String(standardRate),
+              overrideUsed: String(actualAmount !== standardRate),
+              Family: guardianPerson.name,
+              source: 'dugsi-webhook-fallback-recovery',
+            },
+          })
+        } catch (metadataErr) {
+          await logError(
+            logger,
+            metadataErr,
+            'Path 4 fallback: Failed to patch Stripe subscription metadata — manual update required',
+            {
+              subscriptionId: subscription.id,
+              customerId,
+              guardianPersonId: guardianPerson.id,
+            }
+          )
+          Sentry.captureMessage(
+            'Dugsi subscription metadata patch failed — manual intervention required',
+            {
+              level: 'error',
+              extra: {
+                subscriptionId: subscription.id,
+                customerId,
+                guardianPersonId: guardianPerson.id,
+              },
+            }
+          )
+        }
+
+        Sentry.captureMessage(
+          'Dugsi subscription resolved via customer email fallback',
+          {
+            level: 'warning',
+            extra: {
+              customerId,
+              subscriptionId: subscription.id,
+              guardianPersonId: guardianPerson.id,
+              childCount,
+              derivedProfileIds: profileIds,
+            },
+          }
+        )
+
+        logger.warn(
+          {
+            customerId,
+            subscriptionId: subscription.id,
+            guardianPersonId: guardianPerson.id,
+            childCount,
+          },
+          'Subscription created without metadata — resolved via Stripe customer email fallback'
+        )
       } else {
         throw new Error(
           `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -30,12 +30,14 @@ import {
   getSubscriptionByStripeId,
   getBillingAssignmentsBySubscription,
   updateSubscriptionStatus as updateSubscriptionStatusQuery,
+  findPersonByStripeCustomerId,
 } from '@/lib/db/queries/billing'
 import {
   findGuardianWithBillableDugsiChildren,
   verifyDugsiProfileIdsForGuardian,
   findBillableDugsiProfileIdsForGuardian,
 } from '@/lib/db/queries/dugsi-profiles'
+import { findPersonById } from '@/lib/db/queries/program-profile'
 import type { DatabaseClient } from '@/lib/db/types'
 import { createServiceLogger, logError } from '@/lib/logger'
 import {
@@ -147,18 +149,23 @@ interface DugsiRecoveryMetadata {
   guardianPersonId: string
   familyName: string
   familyId: string | null
-  childCount: number
   effectiveProfileIds: string[]
   standardRate: number
   actualAmount: number
 }
 
-interface ResolvedSubscriptionContext {
-  billingAccount: { id: string; personId: string | null }
-  effectiveProfileIds: string[]
-  recoverySource: RecoverySource
-  dugsiRecoveryMetadata?: DugsiRecoveryMetadata
-}
+type ResolvedSubscriptionContext =
+  | {
+      billingAccount: { id: string; personId: string | null }
+      effectiveProfileIds: string[]
+      recoverySource: Exclude<RecoverySource, 'dugsi_email_fallback'>
+    }
+  | {
+      billingAccount: { id: string; personId: string | null }
+      effectiveProfileIds: string[]
+      recoverySource: 'dugsi_email_fallback'
+      dugsiRecoveryMetadata: DugsiRecoveryMetadata
+    }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -189,7 +196,13 @@ async function resolveDugsiProfileIds(
   subscription: Stripe.Subscription
 ): Promise<string[]> {
   const personId = billingAccount.personId
-  if (!personId) return []
+  if (!personId) {
+    logger.warn(
+      { subscriptionId: subscription.id },
+      'resolveDugsiProfileIds: billing account has no personId — cannot resolve profile IDs'
+    )
+    return []
+  }
 
   const hints = extractMetadataProfileIdHints(subscription)
 
@@ -211,7 +224,16 @@ async function resolveDugsiProfileIds(
     if (verified.length > 0) return verified
   }
 
-  return findBillableDugsiProfileIdsForGuardian(personId)
+  const fallbackIds = await findBillableDugsiProfileIdsForGuardian(personId)
+
+  if (fallbackIds.length === 0) {
+    logger.warn(
+      { personId, subscriptionId: subscription.id },
+      'resolveDugsiProfileIds: no billable Dugsi profiles found via metadata or DB fallback — subscription will be created without profile links'
+    )
+  }
+
+  return fallbackIds
 }
 
 async function resolveDugsiFallbackFromCustomerEmail(
@@ -318,7 +340,6 @@ async function resolveDugsiFallbackFromCustomerEmail(
       guardianPersonId: guardian.id,
       familyName: guardian.name,
       familyId,
-      childCount,
       effectiveProfileIds,
       standardRate,
       actualAmount,
@@ -355,48 +376,47 @@ async function resolveSubscriptionContext(
     subscription.metadata?.personId || subscription.metadata?.guardianPersonId
 
   if (metadataPersonId) {
-    logger.info(
-      {
-        customerId,
+    const verifiedPerson = await findPersonById(metadataPersonId)
+
+    if (!verifiedPerson) {
+      logger.warn(
+        { customerId, metadataPersonId, subscriptionId: subscription.id },
+        'Path 2: metadataPersonId not found in DB — falling through to Path 3'
+      )
+    } else {
+      logger.info(
+        {
+          customerId,
+          personId: metadataPersonId,
+          subscriptionId: subscription.id,
+        },
+        'Creating billing account from subscription metadata'
+      )
+
+      const billingAccount = await createOrUpdateBillingAccount({
         personId: metadataPersonId,
-        subscriptionId: subscription.id,
-      },
-      'Creating billing account from subscription metadata'
-    )
+        accountType,
+        stripeCustomerId: customerId,
+        paymentMethodCaptured: true,
+        paymentMethodCapturedAt: new Date(),
+      })
 
-    const billingAccount = await createOrUpdateBillingAccount({
-      personId: metadataPersonId,
-      accountType,
-      stripeCustomerId: customerId,
-      paymentMethodCaptured: true,
-      paymentMethodCapturedAt: new Date(),
-    })
+      const effectiveProfileIds =
+        accountType === StripeAccountType.DUGSI
+          ? await resolveDugsiProfileIds(billingAccount, subscription)
+          : extractMetadataProfileIdHints(subscription)
 
-    const effectiveProfileIds =
-      accountType === StripeAccountType.DUGSI
-        ? await resolveDugsiProfileIds(billingAccount, subscription)
-        : extractMetadataProfileIdHints(subscription)
-
-    return {
-      billingAccount,
-      effectiveProfileIds,
-      recoverySource: 'metadata_person_id',
+      return {
+        billingAccount,
+        effectiveProfileIds,
+        recoverySource: 'metadata_person_id',
+      }
     }
   }
 
-  // Path 3: person already linked to this Stripe customer ID via an existing billing account
-  const existingPerson = await prisma.person.findFirst({
-    where: {
-      billingAccounts: {
-        some: {
-          OR: [
-            { stripeCustomerIdMahad: customerId },
-            { stripeCustomerIdDugsi: customerId },
-          ],
-        },
-      },
-    },
-  })
+  // Path 3: cross-program person lookup — finds a person via any billing account already
+  // linked to this Stripe customer ID (searches both Mahad and Dugsi customer ID columns)
+  const existingPerson = await findPersonByStripeCustomerId(customerId)
 
   if (existingPerson) {
     const billingAccount = await createOrUpdateBillingAccount({
@@ -432,12 +452,14 @@ async function patchRecoveredDugsiMetadata(
 ): Promise<void> {
   const dugsiStripe = getDugsiStripeClient()
 
+  const childCount = recovery.effectiveProfileIds.length
+
   try {
     await dugsiStripe.subscriptions.update(subscriptionId, {
       metadata: {
         guardianPersonId: recovery.guardianPersonId,
         ...(recovery.familyId ? { familyId: recovery.familyId } : {}),
-        childCount: String(recovery.childCount),
+        childCount: String(childCount),
         profileIds: recovery.effectiveProfileIds.join(','),
         calculatedRate: String(recovery.standardRate),
         overrideUsed: String(recovery.actualAmount !== recovery.standardRate),
@@ -454,7 +476,7 @@ async function patchRecoveredDugsiMetadata(
           customerId,
           subscriptionId,
           guardianPersonId: recovery.guardianPersonId,
-          childCount: recovery.childCount,
+          childCount,
           derivedProfileIds: recovery.effectiveProfileIds,
         },
       }
@@ -465,11 +487,27 @@ async function patchRecoveredDugsiMetadata(
         customerId,
         subscriptionId,
         guardianPersonId: recovery.guardianPersonId,
-        childCount: recovery.childCount,
+        childCount,
       },
       'Subscription created without metadata — resolved via Stripe customer email fallback'
     )
   } catch (metadataErr) {
+    const isAuthError =
+      metadataErr !== null &&
+      typeof metadataErr === 'object' &&
+      'type' in metadataErr &&
+      (metadataErr as { type: unknown }).type === 'StripeAuthenticationError'
+
+    if (isAuthError) {
+      await logError(
+        logger,
+        metadataErr,
+        'Path 4 fallback: Stripe API key invalid — metadata patch cannot proceed',
+        { subscriptionId, customerId }
+      )
+      throw metadataErr
+    }
+
     await logError(
       logger,
       metadataErr,
@@ -542,20 +580,21 @@ function validateMahadRateIfPresent(subscription: Stripe.Subscription): void {
     )
   }
 
-  logger.info(
-    {
-      subscriptionId: subscription.id,
-      profileId: metadata.profileId,
-      studentName: metadata.studentName,
-      stripeAmount: priceAmount,
-      expectedRate,
-      graduationStatus: metadata.graduationStatus,
-      paymentFrequency: metadata.paymentFrequency,
-      billingType: metadata.billingType,
-      rateValid: priceAmount === expectedRate,
-    },
-    'Mahad subscription rate validation completed'
-  )
+  if (priceAmount === expectedRate && actualCalculatedRate === expectedRate) {
+    logger.info(
+      {
+        subscriptionId: subscription.id,
+        profileId: metadata.profileId,
+        studentName: metadata.studentName,
+        stripeAmount: priceAmount,
+        expectedRate,
+        graduationStatus: metadata.graduationStatus,
+        paymentFrequency: metadata.paymentFrequency,
+        billingType: metadata.billingType,
+      },
+      'Mahad subscription rate validation completed'
+    )
+  }
 }
 
 function validateDugsiRateIfPresent(subscription: Stripe.Subscription): void {
@@ -592,16 +631,17 @@ function validateDugsiRateIfPresent(subscription: Stripe.Subscription): void {
     )
   }
 
-  logger.info(
-    {
-      subscriptionId: subscription.id,
-      stripeAmount: priceAmount,
-      expectedRate,
-      childCount,
-      rateValid: priceAmount === expectedRate,
-    },
-    'Dugsi subscription rate validation completed'
-  )
+  if (priceAmount === expectedRate && actualCalculatedRate === expectedRate) {
+    logger.info(
+      {
+        subscriptionId: subscription.id,
+        stripeAmount: priceAmount,
+        expectedRate,
+        childCount,
+      },
+      'Dugsi subscription rate validation completed'
+    )
+  }
 }
 
 async function linkProfilesIfPresent(
@@ -714,10 +754,7 @@ export async function handleSubscriptionCreated(
     subscription
   )
 
-  if (
-    accountType === StripeAccountType.DUGSI &&
-    resolved.dugsiRecoveryMetadata
-  ) {
+  if (resolved.recoverySource === 'dugsi_email_fallback') {
     await patchRecoveredDugsiMetadata(
       subscription.id,
       customerId,
@@ -753,7 +790,6 @@ export async function handleSubscriptionUpdated(
 ): Promise<SubscriptionEventResult> {
   const stripeSubscriptionId = subscription.id
 
-  // Get subscription from database
   const dbSubscription = await getSubscriptionByStripeId(stripeSubscriptionId)
 
   if (!dbSubscription) {
@@ -768,25 +804,22 @@ export async function handleSubscriptionUpdated(
     }
   }
 
-  // Validate status
   const status = subscription.status as SubscriptionStatus
   if (!isValidSubscriptionStatus(status)) {
     throw new Error(`Invalid subscription status: ${status}`)
   }
 
-  // Extract period dates
   const periodDates = extractPeriodDates(subscription)
 
-  // Update subscription
   await updateSubscriptionStatusQuery(dbSubscription.id, status, {
     currentPeriodStart: periodDates.periodStart,
     currentPeriodEnd: periodDates.periodEnd,
     paidUntil: periodDates.periodEnd,
   })
 
-  if (accountType === 'MAHAD') {
+  if (accountType === StripeAccountType.MAHAD) {
     revalidateTag('mahad-students')
-  } else if (accountType === 'DUGSI') {
+  } else if (accountType === StripeAccountType.DUGSI) {
     revalidateTag('dugsi-registrations')
   }
 
@@ -812,7 +845,6 @@ export async function handleSubscriptionDeleted(
 ): Promise<SubscriptionEventResult> {
   const stripeSubscriptionId = subscription.id
 
-  // Get subscription from database
   const dbSubscription = await getSubscriptionByStripeId(stripeSubscriptionId)
 
   if (!dbSubscription) {
@@ -827,7 +859,6 @@ export async function handleSubscriptionDeleted(
     }
   }
 
-  // Update subscription to canceled and unlink from all profiles atomically
   await prisma.$transaction(async (tx) => {
     await updateSubscriptionStatusQuery(
       dbSubscription.id,
@@ -838,9 +869,9 @@ export async function handleSubscriptionDeleted(
     await unlinkSubscription(dbSubscription.id, tx)
   })
 
-  if (accountType === 'MAHAD') {
+  if (accountType === StripeAccountType.MAHAD) {
     revalidateTag('mahad-students')
-  } else if (accountType === 'DUGSI') {
+  } else if (accountType === StripeAccountType.DUGSI) {
     revalidateTag('dugsi-registrations')
   }
 
@@ -879,7 +910,6 @@ export async function handleInvoiceFinalized(
     return null
   }
 
-  // Get subscription from database
   const dbSubscription = await getSubscriptionByStripeId(subscriptionId)
 
   if (!dbSubscription) {
@@ -890,7 +920,6 @@ export async function handleInvoiceFinalized(
     return null
   }
 
-  // Update paid_until to the period_end of the invoice
   const paidUntil = invoice.period_end
     ? new Date(invoice.period_end * 1000)
     : null
@@ -903,9 +932,9 @@ export async function handleInvoiceFinalized(
     }
   )
 
-  if (accountType === 'MAHAD') {
+  if (accountType === StripeAccountType.MAHAD) {
     revalidateTag('mahad-students')
-  } else if (accountType === 'DUGSI') {
+  } else if (accountType === StripeAccountType.DUGSI) {
     revalidateTag('dugsi-registrations')
   }
 

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -15,7 +15,12 @@
 
 import { revalidateTag } from 'next/cache'
 
-import { StripeAccountType, SubscriptionStatus, Program } from '@prisma/client'
+import {
+  EnrollmentStatus,
+  Program,
+  StripeAccountType,
+  SubscriptionStatus,
+} from '@prisma/client'
 import type {
   GraduationStatus,
   PaymentFrequency,
@@ -206,15 +211,42 @@ export async function handleSubscriptionCreated(
         // Fallback for subscriptions created manually in Stripe dashboard — no metadata was set.
         // Resolves the guardian via Stripe customer email and patches metadata for future events.
         const dugsiStripe = getDugsiStripeClient()
-        const stripeCustomer = await dugsiStripe.customers.retrieve(customerId)
+
+        let stripeCustomer: Stripe.Customer | Stripe.DeletedCustomer
+        try {
+          stripeCustomer = await dugsiStripe.customers.retrieve(customerId)
+        } catch (stripeErr) {
+          await logError(
+            logger,
+            stripeErr,
+            'Path 4 fallback: Failed to retrieve Stripe customer',
+            { customerId, subscriptionId: subscription.id }
+          )
+          throw stripeErr
+        }
+
         const customerEmail = stripeCustomer.deleted
           ? null
           : stripeCustomer.email
 
-        if (customerEmail) {
+        if (!customerEmail) {
+          logger.warn(
+            {
+              customerId,
+              subscriptionId: subscription.id,
+              isDeleted: stripeCustomer.deleted ?? false,
+            },
+            'Path 4 fallback: Stripe customer has no email address, cannot resolve guardian'
+          )
+        } else {
           const guardianPerson = await findPersonByActiveContact(customerEmail)
 
-          if (guardianPerson) {
+          if (!guardianPerson) {
+            logger.warn(
+              { customerId, customerEmail, subscriptionId: subscription.id },
+              'Path 4 fallback: Stripe customer email found but no matching Person record'
+            )
+          } else {
             const guardianWithChildren = await prisma.person.findFirst({
               where: { id: guardianPerson.id },
               include: {
@@ -226,7 +258,7 @@ export async function handleSubscriptionCreated(
                         programProfiles: {
                           where: {
                             program: Program.DUGSI_PROGRAM,
-                            status: { not: 'WITHDRAWN' },
+                            status: { not: EnrollmentStatus.WITHDRAWN },
                           },
                           select: { id: true, familyReferenceId: true },
                         },
@@ -237,77 +269,107 @@ export async function handleSubscriptionCreated(
               },
             })
 
+            if (!guardianWithChildren) {
+              logger.warn(
+                { guardianPersonId: guardianPerson.id, customerId },
+                'Path 4 fallback: Second person lookup returned null — possible concurrent deletion'
+              )
+            }
+
             const familyProfiles = (
               guardianWithChildren?.guardianRelationships ?? []
             ).flatMap((rel) => rel.dependent.programProfiles)
 
-            billingAccount = await createOrUpdateBillingAccount({
-              personId: guardianPerson.id,
-              accountType,
-              stripeCustomerId: customerId,
-              paymentMethodCaptured: true,
-              paymentMethodCapturedAt: new Date(),
-            })
-
-            const resolvedProfileIds =
-              familyProfiles.length > 0 ? familyProfiles.map((p) => p.id) : null
-            if (resolvedProfileIds) {
-              profileIds = resolvedProfileIds
-            }
-
-            const childCount = familyProfiles.length
-            const familyId = familyProfiles[0]?.familyReferenceId ?? null
-            const standardRate = calculateDugsiRate(childCount)
-            const actualAmount =
-              subscription.items.data[0]?.price?.unit_amount ?? standardRate
-
-            try {
-              await dugsiStripe.subscriptions.update(subscription.id, {
-                metadata: {
-                  guardianPersonId: guardianPerson.id,
-                  familyId: familyId ?? '',
-                  childCount: String(childCount),
-                  ...(resolvedProfileIds && {
-                    profileIds: resolvedProfileIds.join(','),
-                  }),
-                  calculatedRate: String(standardRate),
-                  overrideUsed: String(actualAmount !== standardRate),
-                  Family: guardianPerson.name,
-                  source: 'dugsi-webhook-fallback-recovery',
-                },
-              })
-            } catch (metadataErr) {
+            if (familyProfiles.length === 0) {
               await logError(
                 logger,
-                metadataErr,
-                'Failed to patch Stripe subscription metadata in fallback',
-                { subscriptionId: subscription.id, customerId }
+                new Error('Guardian has no active Dugsi program profiles'),
+                'Path 4 fallback: Cannot create billing account — guardian has no enrolled dependents',
+                {
+                  customerId,
+                  guardianPersonId: guardianPerson.id,
+                  subscriptionId: subscription.id,
+                }
               )
-            }
+            } else {
+              billingAccount = await createOrUpdateBillingAccount({
+                personId: guardianPerson.id,
+                accountType,
+                stripeCustomerId: customerId,
+                paymentMethodCaptured: true,
+                paymentMethodCapturedAt: new Date(),
+              })
 
-            Sentry.captureMessage(
-              'Dugsi subscription resolved via customer email fallback',
-              {
-                level: 'warning',
-                extra: {
+              const resolvedProfileIds = familyProfiles.map((p) => p.id)
+              profileIds = resolvedProfileIds
+
+              const childCount = familyProfiles.length
+              const familyId = familyProfiles[0]?.familyReferenceId ?? null
+              const standardRate = calculateDugsiRate(childCount)
+              const actualAmount =
+                subscription.items.data[0]?.price?.unit_amount ?? standardRate
+
+              try {
+                await dugsiStripe.subscriptions.update(subscription.id, {
+                  metadata: {
+                    guardianPersonId: guardianPerson.id,
+                    familyId: familyId ?? '',
+                    childCount: String(childCount),
+                    profileIds: resolvedProfileIds.join(','),
+                    calculatedRate: String(standardRate),
+                    overrideUsed: String(actualAmount !== standardRate),
+                    Family: guardianPerson.name,
+                    source: 'dugsi-webhook-fallback-recovery',
+                  },
+                })
+              } catch (metadataErr) {
+                await logError(
+                  logger,
+                  metadataErr,
+                  'Path 4 fallback: Failed to patch Stripe subscription metadata — manual update required',
+                  {
+                    subscriptionId: subscription.id,
+                    customerId,
+                    guardianPersonId: guardianPerson.id,
+                  }
+                )
+                Sentry.captureMessage(
+                  'Dugsi subscription metadata patch failed — manual intervention required',
+                  {
+                    level: 'error',
+                    extra: {
+                      subscriptionId: subscription.id,
+                      customerId,
+                      guardianPersonId: guardianPerson.id,
+                    },
+                  }
+                )
+              }
+
+              Sentry.captureMessage(
+                'Dugsi subscription resolved via customer email fallback',
+                {
+                  level: 'warning',
+                  extra: {
+                    customerId,
+                    subscriptionId: subscription.id,
+                    guardianPersonId: guardianPerson.id,
+                    childCount,
+                    derivedProfileIds: profileIds,
+                  },
+                }
+              )
+
+              logger.warn(
+                {
                   customerId,
                   subscriptionId: subscription.id,
                   guardianPersonId: guardianPerson.id,
                   childCount,
-                  derivedProfileIds: profileIds,
                 },
-              }
-            )
-
-            logger.warn(
-              {
-                customerId,
-                subscriptionId: subscription.id,
-                guardianPersonId: guardianPerson.id,
-                childCount,
-              },
-              'Subscription created without metadata — resolved via Stripe customer email fallback'
-            )
+                'Subscription created without metadata — resolved via Stripe customer email fallback'
+              )
+            }
           }
         }
 

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -229,7 +229,7 @@ export async function handleSubscriptionCreated(
           ? null
           : stripeCustomer.email
 
-        // Issue 5: early return on each failure branch — intent is explicit at every fork
+        // Early return on each failure branch — intent is explicit at every fork
         if (!customerEmail) {
           logger.warn(
             {
@@ -267,7 +267,7 @@ export async function handleSubscriptionCreated(
                     programProfiles: {
                       where: {
                         program: Program.DUGSI_PROGRAM,
-                        // Issue 1: restrict to billable statuses only (matches checkout-service)
+                        // Restrict to billable statuses only (matches checkout-service)
                         status: {
                           in: [
                             EnrollmentStatus.REGISTERED,
@@ -298,22 +298,20 @@ export async function handleSubscriptionCreated(
           (rel) => rel.dependent.programProfiles
         )
 
-        // Issue 2: deduplicate by profile ID — a guardian can have multiple active roles
+        // Deduplicate by profile ID — a guardian can have multiple active roles
         // per dependent (e.g., PARENT + SPONSOR), which would double-count the child
         const familyProfiles = Array.from(
           new Map(rawProfiles.map((p) => [p.id, p])).values()
         )
 
         if (familyProfiles.length === 0) {
-          await logError(
-            logger,
-            new Error('Guardian has no active Dugsi program profiles'),
-            'Path 4 fallback: Cannot create billing account — guardian has no enrolled dependents',
+          logger.warn(
             {
               customerId,
               guardianPersonId: guardianPerson.id,
               subscriptionId: subscription.id,
-            }
+            },
+            'Path 4 fallback: Cannot create billing account — guardian has no enrolled Dugsi children'
           )
           throw new Error(
             `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`
@@ -329,15 +327,16 @@ export async function handleSubscriptionCreated(
         })
 
         const resolvedProfileIds = familyProfiles.map((p) => p.id)
-        // Issue 4: only set profileIds if the caller didn't supply them
-        if (!profileIds?.length) {
-          profileIds = resolvedProfileIds
-        }
+        // Prefer caller-supplied profile IDs; fall back to DB-derived ones
+        const effectiveProfileIds = profileIds?.length
+          ? profileIds
+          : resolvedProfileIds
+        profileIds = effectiveProfileIds
 
         const childCount = familyProfiles.length
         const familyId = familyProfiles[0]?.familyReferenceId ?? null
 
-        // Issue 6: warn when a guardian spans multiple families — first family wins
+        // Warn when a guardian spans multiple families — first family wins
         const uniqueFamilyIds = new Set(
           familyProfiles.map((p) => p.familyReferenceId).filter(Boolean)
         )
@@ -361,7 +360,7 @@ export async function handleSubscriptionCreated(
               guardianPersonId: guardianPerson.id,
               ...(familyId ? { familyId } : {}),
               childCount: String(childCount),
-              profileIds: (profileIds ?? resolvedProfileIds).join(','),
+              profileIds: effectiveProfileIds.join(','),
               calculatedRate: String(standardRate),
               overrideUsed: String(actualAmount !== standardRate),
               familyName: guardianPerson.name,
@@ -378,7 +377,7 @@ export async function handleSubscriptionCreated(
                 subscriptionId: subscription.id,
                 guardianPersonId: guardianPerson.id,
                 childCount,
-                derivedProfileIds: profileIds,
+                derivedProfileIds: effectiveProfileIds,
               },
             }
           )

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -15,12 +15,7 @@
 
 import { revalidateTag } from 'next/cache'
 
-import {
-  EnrollmentStatus,
-  Program,
-  StripeAccountType,
-  SubscriptionStatus,
-} from '@prisma/client'
+import { StripeAccountType, SubscriptionStatus } from '@prisma/client'
 import type {
   GraduationStatus,
   PaymentFrequency,
@@ -36,7 +31,11 @@ import {
   getBillingAssignmentsBySubscription,
   updateSubscriptionStatus as updateSubscriptionStatusQuery,
 } from '@/lib/db/queries/billing'
-import { findPersonByActiveContact } from '@/lib/db/queries/program-profile'
+import {
+  findGuardianWithBillableDugsiChildren,
+  verifyDugsiProfileIdsForGuardian,
+  findBillableDugsiProfileIdsForGuardian,
+} from '@/lib/db/queries/dugsi-profiles'
 import type { DatabaseClient } from '@/lib/db/types'
 import { createServiceLogger, logError } from '@/lib/logger'
 import {
@@ -46,6 +45,7 @@ import {
 } from '@/lib/services/shared/billing-service'
 import { createSubscriptionFromStripe } from '@/lib/services/shared/subscription-service'
 import { getDugsiStripeClient } from '@/lib/stripe-dugsi'
+import { normalizeEmail } from '@/lib/utils/contact-normalization'
 import { calculateDugsiRate } from '@/lib/utils/dugsi-tuition'
 import { calculateMahadRate } from '@/lib/utils/mahad-tuition'
 import {
@@ -135,6 +135,527 @@ export async function handlePaymentMethodCapture(
   }
 }
 
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+type RecoverySource =
+  | 'existing_billing_account'
+  | 'metadata_person_id'
+  | 'existing_person_by_customer'
+  | 'dugsi_email_fallback'
+
+interface DugsiRecoveryMetadata {
+  guardianPersonId: string
+  familyName: string
+  familyId: string | null
+  childCount: number
+  effectiveProfileIds: string[]
+  standardRate: number
+  actualAmount: number
+}
+
+interface ResolvedSubscriptionContext {
+  billingAccount: { id: string; personId: string | null }
+  effectiveProfileIds: string[]
+  recoverySource: RecoverySource
+  dugsiRecoveryMetadata?: DugsiRecoveryMetadata
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function buildNoPersonFoundError(customerId: string): Error {
+  return new Error(
+    `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`
+  )
+}
+
+function extractMetadataProfileIdHints(
+  subscription: Stripe.Subscription
+): string[] {
+  const metadata = subscription.metadata ?? {}
+  if (metadata.profileIds) {
+    return metadata.profileIds
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean)
+  }
+  if (metadata.profileId) {
+    return [metadata.profileId]
+  }
+  return []
+}
+
+async function resolveDugsiProfileIds(
+  billingAccount: { personId: string | null },
+  subscription: Stripe.Subscription
+): Promise<string[]> {
+  const personId = billingAccount.personId
+  if (!personId) return []
+
+  const hints = extractMetadataProfileIdHints(subscription)
+
+  if (hints.length > 0) {
+    const verified = await verifyDugsiProfileIdsForGuardian(personId, hints)
+
+    if (verified.length !== hints.length) {
+      logger.warn(
+        {
+          personId,
+          subscriptionId: subscription.id,
+          metadataProfileIds: hints,
+          verifiedProfileIds: verified,
+        },
+        'Ignoring unverified Dugsi profileIds from Stripe metadata'
+      )
+    }
+
+    if (verified.length > 0) return verified
+  }
+
+  return findBillableDugsiProfileIdsForGuardian(personId)
+}
+
+async function resolveDugsiFallbackFromCustomerEmail(
+  subscription: Stripe.Subscription,
+  customerId: string
+): Promise<ResolvedSubscriptionContext> {
+  const dugsiStripe = getDugsiStripeClient()
+
+  let stripeCustomer: Stripe.Customer | Stripe.DeletedCustomer
+  try {
+    stripeCustomer = await dugsiStripe.customers.retrieve(customerId)
+  } catch (stripeErr) {
+    await logError(
+      logger,
+      stripeErr,
+      'Path 4 fallback: Failed to retrieve Stripe customer',
+      { customerId, subscriptionId: subscription.id }
+    )
+    throw stripeErr
+  }
+
+  const customerEmail = stripeCustomer.deleted ? null : stripeCustomer.email
+  const normalizedEmail = normalizeEmail(customerEmail)
+
+  if (!normalizedEmail) {
+    logger.warn(
+      {
+        customerId,
+        subscriptionId: subscription.id,
+        isDeleted: stripeCustomer.deleted ?? false,
+      },
+      'Path 4 fallback: Stripe customer has no email address, cannot resolve guardian'
+    )
+    throw buildNoPersonFoundError(customerId)
+  }
+
+  const guardian = await findGuardianWithBillableDugsiChildren(normalizedEmail)
+
+  if (!guardian) {
+    logger.warn(
+      {
+        customerId,
+        customerEmail: normalizedEmail,
+        subscriptionId: subscription.id,
+      },
+      'Path 4 fallback: Stripe customer email found but no matching Person record'
+    )
+    throw buildNoPersonFoundError(customerId)
+  }
+
+  const rawProfiles = guardian.guardianRelationships.flatMap(
+    (rel) => rel.dependent.programProfiles
+  )
+  const familyProfiles = Array.from(
+    new Map(rawProfiles.map((p) => [p.id, p])).values()
+  )
+
+  if (familyProfiles.length === 0) {
+    logger.warn(
+      {
+        customerId,
+        guardianPersonId: guardian.id,
+        subscriptionId: subscription.id,
+      },
+      'Path 4 fallback: Cannot create billing account — guardian has no enrolled Dugsi children'
+    )
+    throw buildNoPersonFoundError(customerId)
+  }
+
+  const billingAccount = await createOrUpdateBillingAccount({
+    personId: guardian.id,
+    accountType: StripeAccountType.DUGSI,
+    stripeCustomerId: customerId,
+    paymentMethodCaptured: true,
+    paymentMethodCapturedAt: new Date(subscription.created * 1000),
+  })
+
+  const effectiveProfileIds = familyProfiles.map((p) => p.id)
+  const childCount = familyProfiles.length
+  const familyId = familyProfiles[0]?.familyReferenceId ?? null
+
+  const uniqueFamilyIds = new Set(
+    familyProfiles.map((p) => p.familyReferenceId).filter(Boolean)
+  )
+  if (uniqueFamilyIds.size > 1) {
+    logger.warn(
+      {
+        guardianPersonId: guardian.id,
+        familyIds: [...uniqueFamilyIds],
+      },
+      'Path 4 fallback: guardian spans multiple families — using first family ID'
+    )
+  }
+
+  const standardRate = calculateDugsiRate(childCount)
+  const actualAmount =
+    subscription.items.data[0]?.price?.unit_amount ?? standardRate
+
+  return {
+    billingAccount,
+    effectiveProfileIds,
+    recoverySource: 'dugsi_email_fallback',
+    dugsiRecoveryMetadata: {
+      guardianPersonId: guardian.id,
+      familyName: guardian.name,
+      familyId,
+      childCount,
+      effectiveProfileIds,
+      standardRate,
+      actualAmount,
+    },
+  }
+}
+
+async function resolveSubscriptionContext(
+  subscription: Stripe.Subscription,
+  accountType: StripeAccountType,
+  customerId: string
+): Promise<ResolvedSubscriptionContext> {
+  // Path 1: billing account already exists for this Stripe customer
+  const existingBillingAccount = await getBillingAccountByStripeCustomerId(
+    customerId,
+    accountType
+  )
+
+  if (existingBillingAccount) {
+    const effectiveProfileIds =
+      accountType === StripeAccountType.DUGSI
+        ? await resolveDugsiProfileIds(existingBillingAccount, subscription)
+        : extractMetadataProfileIdHints(subscription)
+
+    return {
+      billingAccount: existingBillingAccount,
+      effectiveProfileIds,
+      recoverySource: 'existing_billing_account',
+    }
+  }
+
+  // Path 2: personId or guardianPersonId present in Stripe subscription metadata
+  const metadataPersonId =
+    subscription.metadata?.personId || subscription.metadata?.guardianPersonId
+
+  if (metadataPersonId) {
+    logger.info(
+      {
+        customerId,
+        personId: metadataPersonId,
+        subscriptionId: subscription.id,
+      },
+      'Creating billing account from subscription metadata'
+    )
+
+    const billingAccount = await createOrUpdateBillingAccount({
+      personId: metadataPersonId,
+      accountType,
+      stripeCustomerId: customerId,
+      paymentMethodCaptured: true,
+      paymentMethodCapturedAt: new Date(),
+    })
+
+    const effectiveProfileIds =
+      accountType === StripeAccountType.DUGSI
+        ? await resolveDugsiProfileIds(billingAccount, subscription)
+        : extractMetadataProfileIdHints(subscription)
+
+    return {
+      billingAccount,
+      effectiveProfileIds,
+      recoverySource: 'metadata_person_id',
+    }
+  }
+
+  // Path 3: person already linked to this Stripe customer ID via an existing billing account
+  const existingPerson = await prisma.person.findFirst({
+    where: {
+      billingAccounts: {
+        some: {
+          OR: [
+            { stripeCustomerIdMahad: customerId },
+            { stripeCustomerIdDugsi: customerId },
+          ],
+        },
+      },
+    },
+  })
+
+  if (existingPerson) {
+    const billingAccount = await createOrUpdateBillingAccount({
+      personId: existingPerson.id,
+      accountType,
+      stripeCustomerId: customerId,
+    })
+
+    const effectiveProfileIds =
+      accountType === StripeAccountType.DUGSI
+        ? await resolveDugsiProfileIds(billingAccount, subscription)
+        : extractMetadataProfileIdHints(subscription)
+
+    return {
+      billingAccount,
+      effectiveProfileIds,
+      recoverySource: 'existing_person_by_customer',
+    }
+  }
+
+  // Path 4: Dugsi-only email fallback for subscriptions manually created in the Stripe dashboard
+  if (accountType === StripeAccountType.DUGSI) {
+    return resolveDugsiFallbackFromCustomerEmail(subscription, customerId)
+  }
+
+  throw buildNoPersonFoundError(customerId)
+}
+
+async function patchRecoveredDugsiMetadata(
+  subscriptionId: string,
+  customerId: string,
+  recovery: DugsiRecoveryMetadata
+): Promise<void> {
+  const dugsiStripe = getDugsiStripeClient()
+
+  try {
+    await dugsiStripe.subscriptions.update(subscriptionId, {
+      metadata: {
+        guardianPersonId: recovery.guardianPersonId,
+        ...(recovery.familyId ? { familyId: recovery.familyId } : {}),
+        childCount: String(recovery.childCount),
+        profileIds: recovery.effectiveProfileIds.join(','),
+        calculatedRate: String(recovery.standardRate),
+        overrideUsed: String(recovery.actualAmount !== recovery.standardRate),
+        familyName: recovery.familyName,
+        source: 'dugsi-webhook-fallback-recovery',
+      },
+    })
+
+    Sentry.captureMessage(
+      'Dugsi subscription resolved via customer email fallback',
+      {
+        level: 'warning',
+        extra: {
+          customerId,
+          subscriptionId,
+          guardianPersonId: recovery.guardianPersonId,
+          childCount: recovery.childCount,
+          derivedProfileIds: recovery.effectiveProfileIds,
+        },
+      }
+    )
+
+    logger.warn(
+      {
+        customerId,
+        subscriptionId,
+        guardianPersonId: recovery.guardianPersonId,
+        childCount: recovery.childCount,
+      },
+      'Subscription created without metadata — resolved via Stripe customer email fallback'
+    )
+  } catch (metadataErr) {
+    await logError(
+      logger,
+      metadataErr,
+      'Path 4 fallback: Failed to patch Stripe subscription metadata — manual update required',
+      {
+        subscriptionId,
+        customerId,
+        guardianPersonId: recovery.guardianPersonId,
+      }
+    )
+    Sentry.captureMessage(
+      'Dugsi subscription metadata patch failed — manual intervention required',
+      {
+        level: 'error',
+        extra: {
+          subscriptionId,
+          customerId,
+          guardianPersonId: recovery.guardianPersonId,
+        },
+      }
+    )
+  }
+}
+
+function validateMahadRateIfPresent(subscription: Stripe.Subscription): void {
+  const metadata = subscription.metadata || {}
+  if (
+    !metadata.calculatedRate ||
+    !metadata.graduationStatus ||
+    !metadata.paymentFrequency ||
+    !metadata.billingType
+  ) {
+    return
+  }
+
+  const priceAmount = subscription.items?.data?.[0]?.price?.unit_amount
+  const expectedRate = parseInt(metadata.calculatedRate, 10)
+
+  const actualCalculatedRate = calculateMahadRate(
+    metadata.graduationStatus as GraduationStatus,
+    metadata.paymentFrequency as PaymentFrequency,
+    metadata.billingType as StudentBillingType
+  )
+
+  if (priceAmount !== expectedRate) {
+    logger.warn(
+      {
+        subscriptionId: subscription.id,
+        stripeAmount: priceAmount,
+        expectedRate,
+        graduationStatus: metadata.graduationStatus,
+        paymentFrequency: metadata.paymentFrequency,
+        billingType: metadata.billingType,
+      },
+      'Rate mismatch: Stripe amount differs from expected calculated rate'
+    )
+  }
+
+  if (actualCalculatedRate !== expectedRate) {
+    logger.warn(
+      {
+        subscriptionId: subscription.id,
+        metadataRate: expectedRate,
+        recalculatedRate: actualCalculatedRate,
+        graduationStatus: metadata.graduationStatus,
+        paymentFrequency: metadata.paymentFrequency,
+        billingType: metadata.billingType,
+      },
+      'Rate calculation mismatch: Stored metadata rate differs from recalculated rate'
+    )
+  }
+
+  logger.info(
+    {
+      subscriptionId: subscription.id,
+      profileId: metadata.profileId,
+      studentName: metadata.studentName,
+      stripeAmount: priceAmount,
+      expectedRate,
+      graduationStatus: metadata.graduationStatus,
+      paymentFrequency: metadata.paymentFrequency,
+      billingType: metadata.billingType,
+      rateValid: priceAmount === expectedRate,
+    },
+    'Mahad subscription rate validation completed'
+  )
+}
+
+function validateDugsiRateIfPresent(subscription: Stripe.Subscription): void {
+  const metadata = subscription.metadata || {}
+  if (!metadata.calculatedRate || !metadata.childCount) return
+
+  const priceAmount = subscription.items?.data?.[0]?.price?.unit_amount
+  const expectedRate = parseInt(metadata.calculatedRate, 10)
+  const childCount = parseInt(metadata.childCount, 10)
+
+  const actualCalculatedRate = calculateDugsiRate(childCount)
+
+  if (priceAmount !== expectedRate) {
+    logger.warn(
+      {
+        subscriptionId: subscription.id,
+        stripeAmount: priceAmount,
+        expectedRate,
+        childCount,
+      },
+      'Rate mismatch: Stripe amount differs from expected calculated rate'
+    )
+  }
+
+  if (actualCalculatedRate !== expectedRate) {
+    logger.warn(
+      {
+        subscriptionId: subscription.id,
+        metadataRate: expectedRate,
+        recalculatedRate: actualCalculatedRate,
+        childCount,
+      },
+      'Rate calculation mismatch: Stored metadata rate differs from recalculated rate'
+    )
+  }
+
+  logger.info(
+    {
+      subscriptionId: subscription.id,
+      stripeAmount: priceAmount,
+      expectedRate,
+      childCount,
+      rateValid: priceAmount === expectedRate,
+    },
+    'Dugsi subscription rate validation completed'
+  )
+}
+
+async function linkProfilesIfPresent(
+  dbSubscriptionId: string,
+  profileIds: string[],
+  subscription: Stripe.Subscription
+): Promise<void> {
+  if (profileIds.length === 0) return
+
+  if (!subscription.items?.data?.length) {
+    const error = new Error('Subscription has no items')
+    await logError(
+      logger,
+      error,
+      'Subscription has no items - cannot link to profiles',
+      { subscriptionId: subscription.id }
+    )
+    throw error
+  }
+
+  const priceAmount = subscription.items.data[0]?.price?.unit_amount
+  if (priceAmount === null || priceAmount === undefined || priceAmount <= 0) {
+    const error = new Error('Subscription has invalid amount')
+    await logError(
+      logger,
+      error,
+      'Subscription has invalid amount - cannot link to profiles',
+      { subscriptionId: subscription.id, priceAmount }
+    )
+    throw error
+  }
+
+  await Sentry.startSpan(
+    {
+      name: 'subscription.link_profiles',
+      op: 'db.transaction',
+      attributes: {
+        subscription_id: dbSubscriptionId,
+        num_profiles: profileIds.length,
+        amount: priceAmount,
+      },
+    },
+    async () =>
+      await linkSubscriptionToProfiles(
+        dbSubscriptionId,
+        profileIds,
+        priceAmount,
+        'Linked automatically via webhook'
+      )
+  )
+}
+
+// ─── Orchestrator ────────────────────────────────────────────────────────────
+
 /**
  * Handle subscription creation event.
  *
@@ -143,13 +664,11 @@ export async function handlePaymentMethodCapture(
  *
  * @param subscription - Stripe subscription object
  * @param accountType - Stripe account type
- * @param profileIds - Program profile IDs to link (optional)
  * @returns Subscription event result
  */
 export async function handleSubscriptionCreated(
   subscription: Stripe.Subscription,
-  accountType: StripeAccountType,
-  profileIds?: string[]
+  accountType: StripeAccountType
 ): Promise<SubscriptionEventResult> {
   const customerId = extractCustomerId(subscription.customer)
 
@@ -157,272 +676,12 @@ export async function handleSubscriptionCreated(
     throw new Error('Invalid customer ID in subscription')
   }
 
-  // Get or create billing account
-  let billingAccount = await getBillingAccountByStripeCustomerId(
-    customerId,
-    accountType
+  const resolved = await resolveSubscriptionContext(
+    subscription,
+    accountType,
+    customerId
   )
 
-  if (!billingAccount) {
-    // Check for personId (Mahad) or guardianPersonId (Dugsi) in subscription metadata
-    const metadataPersonId =
-      subscription.metadata?.personId || subscription.metadata?.guardianPersonId // Mahad // Dugsi
-
-    if (metadataPersonId) {
-      // Use person ID from metadata to create billing account
-      // Handles race condition where subscription.created arrives before checkout.completed
-      logger.info(
-        {
-          customerId,
-          personId: metadataPersonId,
-          subscriptionId: subscription.id,
-        },
-        'Creating billing account from subscription metadata'
-      )
-
-      billingAccount = await createOrUpdateBillingAccount({
-        personId: metadataPersonId,
-        accountType,
-        stripeCustomerId: customerId,
-        paymentMethodCaptured: true,
-        paymentMethodCapturedAt: new Date(),
-      })
-    } else {
-      const existingPerson = await prisma.person.findFirst({
-        where: {
-          billingAccounts: {
-            some: {
-              OR: [
-                { stripeCustomerIdMahad: customerId },
-                { stripeCustomerIdDugsi: customerId },
-              ],
-            },
-          },
-        },
-      })
-
-      if (existingPerson) {
-        billingAccount = await createOrUpdateBillingAccount({
-          personId: existingPerson.id,
-          accountType,
-          stripeCustomerId: customerId,
-        })
-      } else if (accountType === StripeAccountType.DUGSI) {
-        // Fallback for subscriptions created manually in Stripe dashboard — no metadata was set.
-        // Resolves the guardian via Stripe customer email and patches metadata for future events.
-        const dugsiStripe = getDugsiStripeClient()
-
-        let stripeCustomer: Stripe.Customer | Stripe.DeletedCustomer
-        try {
-          stripeCustomer = await dugsiStripe.customers.retrieve(customerId)
-        } catch (stripeErr) {
-          await logError(
-            logger,
-            stripeErr,
-            'Path 4 fallback: Failed to retrieve Stripe customer',
-            { customerId, subscriptionId: subscription.id }
-          )
-          throw stripeErr
-        }
-
-        const customerEmail = stripeCustomer.deleted
-          ? null
-          : stripeCustomer.email
-
-        // Early return on each failure branch — intent is explicit at every fork
-        if (!customerEmail) {
-          logger.warn(
-            {
-              customerId,
-              subscriptionId: subscription.id,
-              isDeleted: stripeCustomer.deleted ?? false,
-            },
-            'Path 4 fallback: Stripe customer has no email address, cannot resolve guardian'
-          )
-          throw new Error(
-            `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`
-          )
-        }
-
-        const guardianPerson = await findPersonByActiveContact(customerEmail)
-
-        if (!guardianPerson) {
-          logger.warn(
-            { customerId, customerEmail, subscriptionId: subscription.id },
-            'Path 4 fallback: Stripe customer email found but no matching Person record'
-          )
-          throw new Error(
-            `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`
-          )
-        }
-
-        const guardianWithChildren = await prisma.person.findFirst({
-          where: { id: guardianPerson.id },
-          include: {
-            guardianRelationships: {
-              where: { isActive: true },
-              include: {
-                dependent: {
-                  include: {
-                    programProfiles: {
-                      where: {
-                        program: Program.DUGSI_PROGRAM,
-                        // Restrict to billable statuses only (matches checkout-service)
-                        status: {
-                          in: [
-                            EnrollmentStatus.REGISTERED,
-                            EnrollmentStatus.ENROLLED,
-                          ],
-                        },
-                      },
-                      select: { id: true, familyReferenceId: true },
-                    },
-                  },
-                },
-              },
-            },
-          },
-        })
-
-        if (!guardianWithChildren) {
-          logger.warn(
-            { guardianPersonId: guardianPerson.id, customerId },
-            'Path 4 fallback: Second person lookup returned null — possible concurrent deletion'
-          )
-          throw new Error(
-            `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`
-          )
-        }
-
-        const rawProfiles = guardianWithChildren.guardianRelationships.flatMap(
-          (rel) => rel.dependent.programProfiles
-        )
-
-        // Deduplicate by profile ID — a guardian can have multiple active roles
-        // per dependent (e.g., PARENT + SPONSOR), which would double-count the child
-        const familyProfiles = Array.from(
-          new Map(rawProfiles.map((p) => [p.id, p])).values()
-        )
-
-        if (familyProfiles.length === 0) {
-          logger.warn(
-            {
-              customerId,
-              guardianPersonId: guardianPerson.id,
-              subscriptionId: subscription.id,
-            },
-            'Path 4 fallback: Cannot create billing account — guardian has no enrolled Dugsi children'
-          )
-          throw new Error(
-            `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`
-          )
-        }
-
-        billingAccount = await createOrUpdateBillingAccount({
-          personId: guardianPerson.id,
-          accountType,
-          stripeCustomerId: customerId,
-          paymentMethodCaptured: true,
-          paymentMethodCapturedAt: new Date(),
-        })
-
-        const resolvedProfileIds = familyProfiles.map((p) => p.id)
-        // Prefer caller-supplied profile IDs; fall back to DB-derived ones
-        const effectiveProfileIds = profileIds?.length
-          ? profileIds
-          : resolvedProfileIds
-        profileIds = effectiveProfileIds
-
-        const childCount = familyProfiles.length
-        const familyId = familyProfiles[0]?.familyReferenceId ?? null
-
-        // Warn when a guardian spans multiple families — first family wins
-        const uniqueFamilyIds = new Set(
-          familyProfiles.map((p) => p.familyReferenceId).filter(Boolean)
-        )
-        if (uniqueFamilyIds.size > 1) {
-          logger.warn(
-            {
-              guardianPersonId: guardianPerson.id,
-              familyIds: [...uniqueFamilyIds],
-            },
-            'Path 4 fallback: guardian spans multiple families — using first family ID'
-          )
-        }
-
-        const standardRate = calculateDugsiRate(childCount)
-        const actualAmount =
-          subscription.items.data[0]?.price?.unit_amount ?? standardRate
-
-        try {
-          await dugsiStripe.subscriptions.update(subscription.id, {
-            metadata: {
-              guardianPersonId: guardianPerson.id,
-              ...(familyId ? { familyId } : {}),
-              childCount: String(childCount),
-              profileIds: effectiveProfileIds.join(','),
-              calculatedRate: String(standardRate),
-              overrideUsed: String(actualAmount !== standardRate),
-              familyName: guardianPerson.name,
-              source: 'dugsi-webhook-fallback-recovery',
-            },
-          })
-
-          Sentry.captureMessage(
-            'Dugsi subscription resolved via customer email fallback',
-            {
-              level: 'warning',
-              extra: {
-                customerId,
-                subscriptionId: subscription.id,
-                guardianPersonId: guardianPerson.id,
-                childCount,
-                derivedProfileIds: effectiveProfileIds,
-              },
-            }
-          )
-
-          logger.warn(
-            {
-              customerId,
-              subscriptionId: subscription.id,
-              guardianPersonId: guardianPerson.id,
-              childCount,
-            },
-            'Subscription created without metadata — resolved via Stripe customer email fallback'
-          )
-        } catch (metadataErr) {
-          await logError(
-            logger,
-            metadataErr,
-            'Path 4 fallback: Failed to patch Stripe subscription metadata — manual update required',
-            {
-              subscriptionId: subscription.id,
-              customerId,
-              guardianPersonId: guardianPerson.id,
-            }
-          )
-          Sentry.captureMessage(
-            'Dugsi subscription metadata patch failed — manual intervention required',
-            {
-              level: 'error',
-              extra: {
-                subscriptionId: subscription.id,
-                customerId,
-                guardianPersonId: guardianPerson.id,
-              },
-            }
-          )
-        }
-      } else {
-        throw new Error(
-          `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`
-        )
-      }
-    }
-  }
-
-  // Create subscription in database
   const dbSubscription = await Sentry.startSpan(
     {
       name: 'subscription.create_from_stripe',
@@ -430,183 +689,45 @@ export async function handleSubscriptionCreated(
       attributes: {
         account_type: accountType,
         stripe_subscription_id: subscription.id,
-        billing_account_id: billingAccount.id,
+        billing_account_id: resolved.billingAccount.id,
       },
     },
     async () =>
       await createSubscriptionFromStripe(
         subscription,
-        billingAccount.id,
+        resolved.billingAccount.id,
         accountType
       )
   )
 
-  // Validate rate against calculated rate if metadata is present (Mahad checkout)
-  const subscriptionMetadata = subscription.metadata || {}
+  if (accountType === StripeAccountType.MAHAD) {
+    validateMahadRateIfPresent(subscription)
+  }
+
+  if (accountType === StripeAccountType.DUGSI) {
+    validateDugsiRateIfPresent(subscription)
+  }
+
+  await linkProfilesIfPresent(
+    dbSubscription.id,
+    resolved.effectiveProfileIds,
+    subscription
+  )
+
   if (
-    accountType === 'MAHAD' &&
-    subscriptionMetadata.calculatedRate &&
-    subscriptionMetadata.graduationStatus &&
-    subscriptionMetadata.paymentFrequency &&
-    subscriptionMetadata.billingType
+    accountType === StripeAccountType.DUGSI &&
+    resolved.dugsiRecoveryMetadata
   ) {
-    const priceAmount = subscription.items?.data?.[0]?.price?.unit_amount
-    const expectedRate = parseInt(subscriptionMetadata.calculatedRate, 10)
-
-    // Validate that the checkout session calculated rate matches the actual rate
-    const actualCalculatedRate = calculateMahadRate(
-      subscriptionMetadata.graduationStatus as GraduationStatus,
-      subscriptionMetadata.paymentFrequency as PaymentFrequency,
-      subscriptionMetadata.billingType as StudentBillingType
-    )
-
-    if (priceAmount !== expectedRate) {
-      logger.warn(
-        {
-          subscriptionId: subscription.id,
-          stripeAmount: priceAmount,
-          expectedRate,
-          graduationStatus: subscriptionMetadata.graduationStatus,
-          paymentFrequency: subscriptionMetadata.paymentFrequency,
-          billingType: subscriptionMetadata.billingType,
-        },
-        'Rate mismatch: Stripe amount differs from expected calculated rate'
-      )
-    }
-
-    if (actualCalculatedRate !== expectedRate) {
-      logger.warn(
-        {
-          subscriptionId: subscription.id,
-          metadataRate: expectedRate,
-          recalculatedRate: actualCalculatedRate,
-          graduationStatus: subscriptionMetadata.graduationStatus,
-          paymentFrequency: subscriptionMetadata.paymentFrequency,
-          billingType: subscriptionMetadata.billingType,
-        },
-        'Rate calculation mismatch: Stored metadata rate differs from recalculated rate'
-      )
-    }
-
-    logger.info(
-      {
-        subscriptionId: subscription.id,
-        profileId: subscriptionMetadata.profileId,
-        studentName: subscriptionMetadata.studentName,
-        stripeAmount: priceAmount,
-        expectedRate,
-        graduationStatus: subscriptionMetadata.graduationStatus,
-        paymentFrequency: subscriptionMetadata.paymentFrequency,
-        billingType: subscriptionMetadata.billingType,
-        rateValid: priceAmount === expectedRate,
-      },
-      'Mahad subscription rate validation completed'
+    await patchRecoveredDugsiMetadata(
+      subscription.id,
+      customerId,
+      resolved.dugsiRecoveryMetadata
     )
   }
 
-  // Validate rate for Dugsi subscriptions
-  if (
-    accountType === 'DUGSI' &&
-    subscriptionMetadata.calculatedRate &&
-    subscriptionMetadata.childCount
-  ) {
-    const priceAmount = subscription.items?.data?.[0]?.price?.unit_amount
-    const expectedRate = parseInt(subscriptionMetadata.calculatedRate, 10)
-    const childCount = parseInt(subscriptionMetadata.childCount, 10)
-
-    const actualCalculatedRate = calculateDugsiRate(childCount)
-
-    if (priceAmount !== expectedRate) {
-      logger.warn(
-        {
-          subscriptionId: subscription.id,
-          stripeAmount: priceAmount,
-          expectedRate,
-          childCount,
-        },
-        'Rate mismatch: Stripe amount differs from expected calculated rate'
-      )
-    }
-
-    if (actualCalculatedRate !== expectedRate) {
-      logger.warn(
-        {
-          subscriptionId: subscription.id,
-          metadataRate: expectedRate,
-          recalculatedRate: actualCalculatedRate,
-          childCount,
-        },
-        'Rate calculation mismatch: Stored metadata rate differs from recalculated rate'
-      )
-    }
-
-    logger.info(
-      {
-        subscriptionId: subscription.id,
-        stripeAmount: priceAmount,
-        expectedRate,
-        childCount,
-        rateValid: priceAmount === expectedRate,
-      },
-      'Dugsi subscription rate validation completed'
-    )
-  }
-
-  // Link to profiles if provided
-  if (profileIds && profileIds.length > 0) {
-    // Validate subscription has items with valid pricing
-    if (!subscription.items?.data?.length) {
-      const error = new Error('Subscription has no items')
-      await logError(
-        logger,
-        error,
-        'Subscription has no items - cannot link to profiles',
-        {
-          subscriptionId: subscription.id,
-        }
-      )
-      throw error
-    }
-
-    const priceAmount = subscription.items.data[0]?.price?.unit_amount
-    if (priceAmount === null || priceAmount === undefined || priceAmount <= 0) {
-      const error = new Error('Subscription has invalid amount')
-      await logError(
-        logger,
-        error,
-        'Subscription has invalid amount - cannot link to profiles',
-        {
-          subscriptionId: subscription.id,
-          priceAmount,
-        }
-      )
-      throw error
-    }
-
-    const amount = priceAmount
-    await Sentry.startSpan(
-      {
-        name: 'subscription.link_profiles',
-        op: 'db.transaction',
-        attributes: {
-          subscription_id: dbSubscription.id,
-          num_profiles: profileIds.length,
-          amount,
-        },
-      },
-      async () =>
-        await linkSubscriptionToProfiles(
-          dbSubscription.id,
-          profileIds,
-          amount,
-          'Linked automatically via webhook'
-        )
-    )
-  }
-
-  if (accountType === 'MAHAD') {
+  if (accountType === StripeAccountType.MAHAD) {
     revalidateTag('mahad-students')
-  } else if (accountType === 'DUGSI') {
+  } else if (accountType === StripeAccountType.DUGSI) {
     revalidateTag('dugsi-registrations')
   }
 

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -15,7 +15,7 @@
 
 import { revalidateTag } from 'next/cache'
 
-import { StripeAccountType, SubscriptionStatus } from '@prisma/client'
+import { StripeAccountType, SubscriptionStatus, Program } from '@prisma/client'
 import type {
   GraduationStatus,
   PaymentFrequency,
@@ -31,6 +31,7 @@ import {
   getBillingAssignmentsBySubscription,
   updateSubscriptionStatus as updateSubscriptionStatusQuery,
 } from '@/lib/db/queries/billing'
+import { findPersonByActiveContact } from '@/lib/db/queries/program-profile'
 import type { DatabaseClient } from '@/lib/db/types'
 import { createServiceLogger, logError } from '@/lib/logger'
 import {
@@ -39,6 +40,7 @@ import {
   unlinkSubscription,
 } from '@/lib/services/shared/billing-service'
 import { createSubscriptionFromStripe } from '@/lib/services/shared/subscription-service'
+import { getDugsiStripeClient } from '@/lib/stripe-dugsi'
 import { calculateDugsiRate } from '@/lib/utils/dugsi-tuition'
 import { calculateMahadRate } from '@/lib/utils/mahad-tuition'
 import {
@@ -181,8 +183,8 @@ export async function handleSubscriptionCreated(
         paymentMethodCapturedAt: new Date(),
       })
     } else {
-      // Fall back to finding person by existing billing account (for non-Mahad subscriptions)
-      const person = await prisma.person.findFirst({
+      // Path 3: find by customer ID already linked to a billing account
+      const existingPerson = await prisma.person.findFirst({
         where: {
           billingAccounts: {
             some: {
@@ -195,17 +197,131 @@ export async function handleSubscriptionCreated(
         },
       })
 
-      if (!person) {
+      if (existingPerson) {
+        billingAccount = await createOrUpdateBillingAccount({
+          personId: existingPerson.id,
+          accountType,
+          stripeCustomerId: customerId,
+        })
+      } else if (accountType === 'DUGSI') {
+        // Path 4: Dugsi-only fallback for subscriptions created manually in the Stripe dashboard.
+        // Resolves the person via Stripe customer email, derives family profiles from DB,
+        // then patches the subscription metadata so future webhook events work normally.
+        const stripeCustomer =
+          await getDugsiStripeClient().customers.retrieve(customerId)
+        const customerEmail = stripeCustomer.deleted
+          ? null
+          : stripeCustomer.email
+
+        if (customerEmail) {
+          const guardianPerson = await findPersonByActiveContact(customerEmail)
+
+          if (guardianPerson) {
+            const guardianWithChildren = await prisma.person.findFirst({
+              where: { id: guardianPerson.id },
+              include: {
+                guardianRelationships: {
+                  where: { isActive: true },
+                  include: {
+                    dependent: {
+                      include: {
+                        programProfiles: {
+                          where: {
+                            program: Program.DUGSI_PROGRAM,
+                            status: { not: 'WITHDRAWN' },
+                          },
+                          select: { id: true, familyReferenceId: true },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            })
+
+            const familyProfiles = (
+              guardianWithChildren?.guardianRelationships ?? []
+            ).flatMap((rel) => rel.dependent.programProfiles)
+
+            billingAccount = await createOrUpdateBillingAccount({
+              personId: guardianPerson.id,
+              accountType,
+              stripeCustomerId: customerId,
+              paymentMethodCaptured: true,
+              paymentMethodCapturedAt: new Date(),
+            })
+
+            if (familyProfiles.length > 0) {
+              profileIds = familyProfiles.map((p) => p.id)
+            }
+
+            const childCount = familyProfiles.length
+            const familyId = familyProfiles[0]?.familyReferenceId ?? null
+            const standardRate = calculateDugsiRate(childCount)
+            const actualAmount =
+              subscription.items.data[0]?.price?.unit_amount ?? standardRate
+
+            try {
+              await getDugsiStripeClient().subscriptions.update(
+                subscription.id,
+                {
+                  metadata: {
+                    guardianPersonId: guardianPerson.id,
+                    familyId: familyId ?? '',
+                    childCount: String(childCount),
+                    profileIds: (profileIds ?? []).join(','),
+                    calculatedRate: String(standardRate),
+                    overrideUsed: String(actualAmount !== standardRate),
+                    Family: guardianPerson.name,
+                    source: 'dugsi-webhook-fallback-recovery',
+                  },
+                }
+              )
+            } catch (metadataErr) {
+              await logError(
+                logger,
+                metadataErr,
+                'Failed to patch Stripe subscription metadata in fallback',
+                { subscriptionId: subscription.id, customerId }
+              )
+            }
+
+            Sentry.captureMessage(
+              'Dugsi subscription resolved via customer email fallback',
+              {
+                level: 'warning',
+                extra: {
+                  customerId,
+                  subscriptionId: subscription.id,
+                  guardianPersonId: guardianPerson.id,
+                  childCount,
+                  derivedProfileIds: profileIds,
+                },
+              }
+            )
+
+            logger.warn(
+              {
+                customerId,
+                subscriptionId: subscription.id,
+                guardianPersonId: guardianPerson.id,
+                childCount,
+              },
+              'Subscription created without metadata — resolved via Stripe customer email fallback'
+            )
+          }
+        }
+
+        if (!billingAccount) {
+          throw new Error(
+            `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`
+          )
+        }
+      } else {
         throw new Error(
           `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`
         )
       }
-
-      billingAccount = await createOrUpdateBillingAccount({
-        personId: person.id,
-        accountType,
-        stripeCustomerId: customerId,
-      })
     }
   }
 

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -183,7 +183,6 @@ export async function handleSubscriptionCreated(
         paymentMethodCapturedAt: new Date(),
       })
     } else {
-      // Path 3: find by customer ID already linked to a billing account
       const existingPerson = await prisma.person.findFirst({
         where: {
           billingAccounts: {
@@ -204,11 +203,10 @@ export async function handleSubscriptionCreated(
           stripeCustomerId: customerId,
         })
       } else if (accountType === 'DUGSI') {
-        // Path 4: Dugsi-only fallback for subscriptions created manually in the Stripe dashboard.
-        // Resolves the person via Stripe customer email, derives family profiles from DB,
-        // then patches the subscription metadata so future webhook events work normally.
-        const stripeCustomer =
-          await getDugsiStripeClient().customers.retrieve(customerId)
+        // Fallback for subscriptions created manually in Stripe dashboard — no metadata was set.
+        // Resolves the guardian via Stripe customer email and patches metadata for future events.
+        const dugsiStripe = getDugsiStripeClient()
+        const stripeCustomer = await dugsiStripe.customers.retrieve(customerId)
         const customerEmail = stripeCustomer.deleted
           ? null
           : stripeCustomer.email
@@ -251,8 +249,10 @@ export async function handleSubscriptionCreated(
               paymentMethodCapturedAt: new Date(),
             })
 
-            if (familyProfiles.length > 0) {
-              profileIds = familyProfiles.map((p) => p.id)
+            const resolvedProfileIds =
+              familyProfiles.length > 0 ? familyProfiles.map((p) => p.id) : null
+            if (resolvedProfileIds) {
+              profileIds = resolvedProfileIds
             }
 
             const childCount = familyProfiles.length
@@ -262,21 +262,20 @@ export async function handleSubscriptionCreated(
               subscription.items.data[0]?.price?.unit_amount ?? standardRate
 
             try {
-              await getDugsiStripeClient().subscriptions.update(
-                subscription.id,
-                {
-                  metadata: {
-                    guardianPersonId: guardianPerson.id,
-                    familyId: familyId ?? '',
-                    childCount: String(childCount),
-                    profileIds: (profileIds ?? []).join(','),
-                    calculatedRate: String(standardRate),
-                    overrideUsed: String(actualAmount !== standardRate),
-                    Family: guardianPerson.name,
-                    source: 'dugsi-webhook-fallback-recovery',
-                  },
-                }
-              )
+              await dugsiStripe.subscriptions.update(subscription.id, {
+                metadata: {
+                  guardianPersonId: guardianPerson.id,
+                  familyId: familyId ?? '',
+                  childCount: String(childCount),
+                  ...(resolvedProfileIds && {
+                    profileIds: resolvedProfileIds.join(','),
+                  }),
+                  calculatedRate: String(standardRate),
+                  overrideUsed: String(actualAmount !== standardRate),
+                  Family: guardianPerson.name,
+                  source: 'dugsi-webhook-fallback-recovery',
+                },
+              })
             } catch (metadataErr) {
               await logError(
                 logger,


### PR DESCRIPTION
### Why?

When a Dugsi subscription is created manually in the Stripe dashboard (instead of through the checkout flow), the webhook arrives with no metadata — no `guardianPersonId`, `familyId`, or `profileIds`. The existing handler had no recovery path for this case and threw `No person found for customer`, causing Stripe to retry the webhook for 72 hours until exhaustion.

This happened with a real family whose payment link could not be sent, requiring a manual subscription to be created directly in Stripe.

During review, three additional structural issues were identified in the handler: it mutated a caller-supplied `profileIds` parameter as a side-channel for profile resolution, it made two DB round-trips where one sufficed, and it used `new Date()` (webhook arrival time) instead of the Stripe subscription's actual creation timestamp. These are also fixed here.

### How?

Adds a Path 4 Dugsi-only fallback that activates when all existing resolution paths fail: resolves the guardian by looking up the Stripe customer email in the Person table (single query), derives the family's active program profiles from guardian relationships, creates the billing account, then patches the Stripe subscription metadata so all future webhook events work normally.

The broader handler was refactored around a single design principle: **Stripe metadata is a hint, not authority — the DB is authority for profile assignment.** `handleSubscriptionCreated` is now a thin orchestrator that delegates to `resolveSubscriptionContext` (Paths 1-4), then calls `createSubscriptionFromStripe`, `linkProfilesIfPresent`, and `patchRecoveredDugsiMetadata` in sequence. Profile IDs for common paths (1/2/3) are now DB-verified rather than passed through unvalidated from Stripe metadata.

### Decisions

**Metadata patch runs after all DB work:** `patchRecoveredDugsiMetadata` is called at the end of the orchestrator, after the subscription record and billing assignments are created. Billing correctness never depends on the Stripe enrichment succeeding.

**Lightweight verification for Paths 1/2/3, full derivation for Path 4 only:** Common paths use a targeted `programProfile.findMany` to verify any metadata hints against the DB. Path 4 uses the full `findGuardianWithBillableDugsiChildren` query (guardian + relationships + profiles in one round-trip) only when metadata is absent entirely.

**Zero-profile guardian is a hard stop:** A guardian with no active Dugsi children is treated as unrecoverable — no billing account is created and no `calculatedRate: "0"` is written to Stripe.

**Metadata patch failure is non-fatal:** The subscription and billing account are still created if the Stripe metadata patch fails (DB state is valid regardless). A Sentry `warning` is emitted on successful recovery; a Sentry `error` is emitted if the patch itself fails.

<details>
<summary>Implementation Plan</summary>

# Refactor Plan: handleSubscriptionCreated

Source: GPT-4o deep review of PR #222 + full file bundle.

## Core thesis

Stripe metadata is a hint, not authority. DB is the authority for profile assignment.
`handleSubscriptionCreated` becomes an orchestrator. Metadata patching is enrichment
that runs after all DB work is done — correctness must not depend on it.

---

## Changes

### 1. event-handlers.ts

Remove profileIds extraction from Stripe metadata. Stop passing it to the service.

```ts
// REMOVE:
const profileIds = subscription.metadata?.profileIds
  ? subscription.metadata.profileIds.split(',').filter(Boolean)
  : subscription.metadata?.profileId
    ? [subscription.metadata.profileId]
    : undefined

await handleSubscriptionCreated(subscription, accountType, profileIds)

// REPLACE WITH:
await handleSubscriptionCreated(subscription, accountType)
```

### 2. New types

```ts
type RecoverySource =
  | 'existing_billing_account'
  | 'metadata_person_id'
  | 'existing_person_by_customer'
  | 'dugsi_email_fallback'

interface DugsiRecoveryMetadata {
  guardianPersonId: string
  familyName: string
  familyId: string | null
  childCount: number
  effectiveProfileIds: string[]
  standardRate: number
  actualAmount: number
}

interface ResolvedSubscriptionContext {
  billingAccount: BillingAccountRecord
  effectiveProfileIds: string[]
  recoverySource: RecoverySource
  dugsiRecoveryMetadata?: DugsiRecoveryMetadata
}
```

### 3. handleSubscriptionCreated becomes an orchestrator

```ts
export async function handleSubscriptionCreated(
  subscription: Stripe.Subscription,
  accountType: StripeAccountType
): Promise<SubscriptionEventResult> {
  const resolved = await resolveSubscriptionContext(subscription, accountType)
  const dbSubscription = await createSubscriptionFromStripe(...)
  if (accountType === MAHAD) validateMahadRateIfPresent(...)
  if (accountType === DUGSI) validateDugsiRateIfPresent(...)
  await linkProfilesIfPresent(dbSubscription.id, resolved.effectiveProfileIds, subscription)
  if (accountType === DUGSI && resolved.dugsiRecoveryMetadata) {
    await patchRecoveredDugsiMetadata(...)  // best-effort, at end
  }
  revalidateTag(...)
  return { subscriptionId, status, created: true }
}
```

### 4. What this fixes

| Issue | Before | After |
|-------|---------|-------|
| Parameter mutation (`profileIds = effectiveProfileIds`) | Present | Eliminated via context struct |
| Double DB query in Path 4 | Two queries | One query by normalized email |
| `paymentMethodCapturedAt` accuracy | `new Date()` (webhook time) | `new Date(subscription.created * 1000)` |
| Metadata patch ordering | Inside Path 4, before DB subscription created | After all DB work, best-effort |
| Stripe metadata as authority | event-handlers.ts extracts + passes profileIds | Removed; DB derives authoritatively |
| Giant function | 150-line branching monolith | Orchestrator + focused helpers |

</details>

<sub>Generated with Claude Code</sub>