### PR TITLE
fix(webhooks): handle Dugsi subscriptions created without metadata

### DIFF
--- a/lib/db/queries/billing.ts
+++ b/lib/db/queries/billing.ts
@@ -504,30 +504,6 @@ export async function getBillingAssignmentsByProfile(
 }
 
 /**
- * Find a person via any billing account already linked to this Stripe customer ID.
- * Searches both Mahad and Dugsi customer ID columns — used for cross-program re-subscribers
- * where the program-specific billing account has not been created yet.
- */
-export async function findPersonByStripeCustomerId(
-  customerId: string,
-  client: DatabaseClient = prisma
-) {
-  return client.person.findFirst({
-    where: {
-      billingAccounts: {
-        some: {
-          OR: [
-            { stripeCustomerIdMahad: customerId },
-            { stripeCustomerIdDugsi: customerId },
-          ],
-        },
-      },
-    },
-    select: { id: true },
-  })
-}
-
-/**
  * Get billing assignments by subscription
  * @param client - Optional database client (for transaction support)
  */

--- a/lib/db/queries/billing.ts
+++ b/lib/db/queries/billing.ts
@@ -280,22 +280,30 @@ export async function createSubscription(
   },
   client: DatabaseClient = prisma
 ) {
-  return client.subscription.create({
-    data: {
-      billingAccountId: data.billingAccountId,
-      stripeAccountType: data.stripeAccountType,
-      stripeSubscriptionId: data.stripeSubscriptionId,
-      stripeCustomerId: data.stripeCustomerId,
-      status: data.status || 'incomplete',
-      amount: data.amount,
-      currency: data.currency || 'usd',
-      interval: data.interval || 'month',
-      currentPeriodStart: data.currentPeriodStart,
-      currentPeriodEnd: data.currentPeriodEnd,
-      paidUntil: data.paidUntil,
-      lastPaymentDate: data.lastPaymentDate,
-      previousSubscriptionIds: data.previousSubscriptionIds || [],
-    },
+  const subscriptionData = {
+    billingAccountId: data.billingAccountId,
+    stripeAccountType: data.stripeAccountType,
+    stripeSubscriptionId: data.stripeSubscriptionId,
+    stripeCustomerId: data.stripeCustomerId,
+    status: data.status || 'incomplete',
+    amount: data.amount,
+    currency: data.currency || 'usd',
+    interval: data.interval || 'month',
+    currentPeriodStart: data.currentPeriodStart,
+    currentPeriodEnd: data.currentPeriodEnd,
+    paidUntil: data.paidUntil,
+    lastPaymentDate: data.lastPaymentDate,
+    previousSubscriptionIds: data.previousSubscriptionIds || [],
+  }
+
+  // upsert is used instead of create to be safe against concurrent Stripe webhook
+  // deliveries — two simultaneous calls with the same stripeSubscriptionId would
+  // both pass the idempotency check in createSubscriptionFromStripe and race to
+  // insert, causing P2002. The empty update: {} is a no-op on conflict.
+  return client.subscription.upsert({
+    where: { stripeSubscriptionId: data.stripeSubscriptionId },
+    create: subscriptionData,
+    update: {},
     include: {
       billingAccount: {
         include: {

--- a/lib/db/queries/billing.ts
+++ b/lib/db/queries/billing.ts
@@ -504,6 +504,29 @@ export async function getBillingAssignmentsByProfile(
 }
 
 /**
+ * Find a person via any billing account already linked to this Stripe customer ID.
+ * Searches both Mahad and Dugsi customer ID columns — used for cross-program re-subscribers
+ * where the program-specific billing account has not been created yet.
+ */
+export async function findPersonByStripeCustomerId(
+  customerId: string,
+  client: DatabaseClient = prisma
+) {
+  return client.person.findFirst({
+    where: {
+      billingAccounts: {
+        some: {
+          OR: [
+            { stripeCustomerIdMahad: customerId },
+            { stripeCustomerIdDugsi: customerId },
+          ],
+        },
+      },
+    },
+  })
+}
+
+/**
  * Get billing assignments by subscription
  * @param client - Optional database client (for transaction support)
  */

--- a/lib/db/queries/billing.ts
+++ b/lib/db/queries/billing.ts
@@ -523,6 +523,7 @@ export async function findPersonByStripeCustomerId(
         },
       },
     },
+    select: { id: true },
   })
 }
 

--- a/lib/db/queries/dugsi-profiles.ts
+++ b/lib/db/queries/dugsi-profiles.ts
@@ -1,7 +1,7 @@
 import { EnrollmentStatus, Program } from '@prisma/client'
 
 import { prisma } from '@/lib/db'
-import { DatabaseClient } from '@/lib/db/types'
+import type { DatabaseClient } from '@/lib/db/types'
 
 export const BILLABLE_DUGSI_STATUSES = [
   EnrollmentStatus.REGISTERED,

--- a/lib/db/queries/dugsi-profiles.ts
+++ b/lib/db/queries/dugsi-profiles.ts
@@ -85,7 +85,7 @@ export async function findBillableDugsiProfileIdsForGuardian(
     select: {
       guardianRelationships: {
         where: { isActive: true },
-        include: {
+        select: {
           dependent: {
             select: {
               programProfiles: {

--- a/lib/db/queries/dugsi-profiles.ts
+++ b/lib/db/queries/dugsi-profiles.ts
@@ -24,7 +24,7 @@ export async function findGuardianWithBillableDugsiChildren(
         where: { isActive: true },
         include: {
           dependent: {
-            include: {
+            select: {
               programProfiles: {
                 where: {
                   program: Program.DUGSI_PROGRAM,
@@ -85,7 +85,7 @@ export async function findBillableDugsiProfileIdsForGuardian(
         where: { isActive: true },
         include: {
           dependent: {
-            include: {
+            select: {
               programProfiles: {
                 where: {
                   program: Program.DUGSI_PROGRAM,

--- a/lib/db/queries/dugsi-profiles.ts
+++ b/lib/db/queries/dugsi-profiles.ts
@@ -80,7 +80,7 @@ export async function findBillableDugsiProfileIdsForGuardian(
 ) {
   const guardian = await client.person.findFirst({
     where: { id: guardianPersonId },
-    include: {
+    select: {
       guardianRelationships: {
         where: { isActive: true },
         include: {

--- a/lib/db/queries/dugsi-profiles.ts
+++ b/lib/db/queries/dugsi-profiles.ts
@@ -1,0 +1,109 @@
+import { EnrollmentStatus, Program } from '@prisma/client'
+
+import { prisma } from '@/lib/db'
+import { DatabaseClient } from '@/lib/db/types'
+
+const BILLABLE_DUGSI_STATUSES = [
+  EnrollmentStatus.REGISTERED,
+  EnrollmentStatus.ENROLLED,
+]
+
+/**
+ * Find a guardian by normalized email. Includes only active guardian relationships
+ * and their billable Dugsi program profiles. The guardian may be returned with empty
+ * profile arrays if no billable children exist — callers must check.
+ */
+export async function findGuardianWithBillableDugsiChildren(
+  normalizedEmail: string,
+  client: DatabaseClient = prisma
+) {
+  return client.person.findFirst({
+    where: { email: normalizedEmail },
+    include: {
+      guardianRelationships: {
+        where: { isActive: true },
+        include: {
+          dependent: {
+            include: {
+              programProfiles: {
+                where: {
+                  program: Program.DUGSI_PROGRAM,
+                  status: { in: BILLABLE_DUGSI_STATUSES },
+                },
+                select: { id: true, familyReferenceId: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+}
+
+/**
+ * Verify that profile IDs from Stripe metadata are valid: they must exist,
+ * be DUGSI_PROGRAM, have a billable status, and be owned by someone who has
+ * guardianPersonId as their active guardian.
+ *
+ * Returns only the IDs that pass all checks.
+ */
+export async function verifyDugsiProfileIdsForGuardian(
+  guardianPersonId: string,
+  profileIds: string[],
+  client: DatabaseClient = prisma
+) {
+  const valid = await client.programProfile.findMany({
+    where: {
+      id: { in: profileIds },
+      program: Program.DUGSI_PROGRAM,
+      status: { in: BILLABLE_DUGSI_STATUSES },
+      person: {
+        dependentRelationships: {
+          some: { guardianId: guardianPersonId, isActive: true },
+        },
+      },
+    },
+    select: { id: true },
+  })
+  return valid.map((p) => p.id)
+}
+
+/**
+ * Derive all billable Dugsi profile IDs for a guardian's active dependents.
+ * Used as a fallback when metadata hints are absent or fail verification.
+ * Deduplicates by profile ID — the same child can appear twice in flatMap
+ * if they have multiple active guardian relationships (e.g. two parents).
+ */
+export async function findBillableDugsiProfileIdsForGuardian(
+  guardianPersonId: string,
+  client: DatabaseClient = prisma
+) {
+  const guardian = await client.person.findFirst({
+    where: { id: guardianPersonId },
+    include: {
+      guardianRelationships: {
+        where: { isActive: true },
+        include: {
+          dependent: {
+            include: {
+              programProfiles: {
+                where: {
+                  program: Program.DUGSI_PROGRAM,
+                  status: { in: BILLABLE_DUGSI_STATUSES },
+                },
+                select: { id: true },
+              },
+            },
+          },
+        },
+      },
+    },
+  })
+
+  if (!guardian) return []
+
+  const raw = guardian.guardianRelationships.flatMap(
+    (rel) => rel.dependent.programProfiles
+  )
+  return Array.from(new Set(raw.map((p) => p.id)))
+}

--- a/lib/db/queries/dugsi-profiles.ts
+++ b/lib/db/queries/dugsi-profiles.ts
@@ -3,7 +3,7 @@ import { EnrollmentStatus, Program } from '@prisma/client'
 import { prisma } from '@/lib/db'
 import { DatabaseClient } from '@/lib/db/types'
 
-const BILLABLE_DUGSI_STATUSES = [
+export const BILLABLE_DUGSI_STATUSES = [
   EnrollmentStatus.REGISTERED,
   EnrollmentStatus.ENROLLED,
 ]
@@ -17,7 +17,7 @@ export async function findGuardianWithBillableDugsiChildren(
   normalizedEmail: string,
   client: DatabaseClient = prisma
 ) {
-  return client.person.findFirst({
+  return client.person.findUnique({
     where: { email: normalizedEmail },
     select: {
       id: true,
@@ -80,7 +80,7 @@ export async function findBillableDugsiProfileIdsForGuardian(
   guardianPersonId: string,
   client: DatabaseClient = prisma
 ) {
-  const guardian = await client.person.findFirst({
+  const guardian = await client.person.findUnique({
     where: { id: guardianPersonId },
     select: {
       guardianRelationships: {

--- a/lib/db/queries/dugsi-profiles.ts
+++ b/lib/db/queries/dugsi-profiles.ts
@@ -19,10 +19,12 @@ export async function findGuardianWithBillableDugsiChildren(
 ) {
   return client.person.findFirst({
     where: { email: normalizedEmail },
-    include: {
+    select: {
+      id: true,
+      name: true,
       guardianRelationships: {
         where: { isActive: true },
-        include: {
+        select: {
           dependent: {
             select: {
               programProfiles: {

--- a/lib/db/queries/person.ts
+++ b/lib/db/queries/person.ts
@@ -182,6 +182,44 @@ export async function getPersonWithAllRelations(
   })
 }
 
+/**
+ * Verify that a person ID exists in the database.
+ * Used to validate person IDs sourced from Stripe metadata before creating billing records.
+ */
+export async function findPersonById(
+  personId: string,
+  client: DatabaseClient = prisma
+) {
+  return client.person.findUnique({
+    where: { id: personId },
+    select: { id: true },
+  })
+}
+
+/**
+ * Find a person via any billing account already linked to this Stripe customer ID.
+ * Searches both Mahad and Dugsi customer ID columns — used for cross-program re-subscribers
+ * where the program-specific billing account has not been created yet.
+ */
+export async function findPersonByStripeCustomerId(
+  customerId: string,
+  client: DatabaseClient = prisma
+) {
+  return client.person.findFirst({
+    where: {
+      billingAccounts: {
+        some: {
+          OR: [
+            { stripeCustomerIdMahad: customerId },
+            { stripeCustomerIdDugsi: customerId },
+          ],
+        },
+      },
+    },
+    select: { id: true },
+  })
+}
+
 export async function updatePersonContact(
   personId: string,
   data: PersonContactFields,

--- a/lib/db/queries/program-profile.ts
+++ b/lib/db/queries/program-profile.ts
@@ -628,6 +628,20 @@ export async function searchProgramProfilesByNameOrContact(
 }
 
 /**
+ * Verify that a person ID exists in the database.
+ * Used to validate person IDs sourced from Stripe metadata before creating billing records.
+ */
+export async function findPersonById(
+  personId: string,
+  client: DatabaseClient = prisma
+) {
+  return client.person.findUnique({
+    where: { id: personId },
+    select: { id: true },
+  })
+}
+
+/**
  * Update shift for all program profiles in a family
  * @param client - Optional database client (for transaction support)
  */

--- a/lib/db/queries/program-profile.ts
+++ b/lib/db/queries/program-profile.ts
@@ -628,20 +628,6 @@ export async function searchProgramProfilesByNameOrContact(
 }
 
 /**
- * Verify that a person ID exists in the database.
- * Used to validate person IDs sourced from Stripe metadata before creating billing records.
- */
-export async function findPersonById(
-  personId: string,
-  client: DatabaseClient = prisma
-) {
-  return client.person.findUnique({
-    where: { id: personId },
-    select: { id: true },
-  })
-}
-
-/**
  * Update shift for all program profiles in a family
  * @param client - Optional database client (for transaction support)
  */

--- a/lib/services/shared/__tests__/subscription-service.test.ts
+++ b/lib/services/shared/__tests__/subscription-service.test.ts
@@ -1,0 +1,170 @@
+import { StripeAccountType } from '@prisma/client'
+import type Stripe from 'stripe'
+import { vi, describe, it, expect, beforeEach } from 'vitest'
+
+const {
+  mockGetSubscriptionByStripeId,
+  mockCreateSubscription,
+  mockExtractPeriodDates,
+  mockLoggerWarn,
+} = vi.hoisted(() => ({
+  mockGetSubscriptionByStripeId: vi.fn(),
+  mockCreateSubscription: vi.fn(),
+  mockExtractPeriodDates: vi.fn(),
+  mockLoggerWarn: vi.fn(),
+}))
+
+vi.mock('@/lib/db/queries/billing', () => ({
+  getSubscriptionByStripeId: mockGetSubscriptionByStripeId,
+  createSubscription: mockCreateSubscription,
+  updateSubscriptionStatus: vi.fn(),
+}))
+
+vi.mock('@/lib/db/query-builders', () => ({
+  LIVE_SUBSCRIPTION_STATUSES: ['active', 'trialing'],
+}))
+
+vi.mock('@/lib/logger', () => ({
+  createServiceLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: mockLoggerWarn,
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  logError: vi.fn(),
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  startSpan: vi.fn((_opts: unknown, cb: () => unknown) => cb()),
+  captureMessage: vi.fn(),
+}))
+
+vi.mock('@/lib/utils/stripe-client', () => ({
+  getStripeClient: vi.fn(),
+}))
+
+vi.mock('@/lib/utils/type-guards', () => ({
+  extractPeriodDates: mockExtractPeriodDates,
+}))
+
+vi.mock('@/lib/errors/action-error', () => ({
+  ActionError: class ActionError extends Error {},
+  ERROR_CODES: {},
+}))
+
+import { createSubscriptionFromStripe } from '../subscription-service'
+
+function createMockStripeSubscription(
+  overrides: Partial<Stripe.Subscription> = {}
+): Stripe.Subscription {
+  return {
+    id: 'sub_test_123',
+    object: 'subscription',
+    status: 'active',
+    customer: 'cus_test_123',
+    currency: 'usd',
+    metadata: {},
+    created: 1700000000,
+    items: {
+      object: 'list',
+      data: [
+        {
+          price: {
+            unit_amount: 5000,
+            recurring: { interval: 'month' },
+          },
+        } as Stripe.SubscriptionItem,
+      ],
+      has_more: false,
+      url: '',
+    },
+    ...overrides,
+  } as Stripe.Subscription
+}
+
+describe('createSubscriptionFromStripe — idempotency', () => {
+  const BILLING_ACCOUNT_ID = 'billing-account-id'
+  const EXISTING_SUB = {
+    id: 'db-sub-id',
+    status: 'active',
+    stripeSubscriptionId: 'sub_test_123',
+    billingAccountId: BILLING_ACCOUNT_ID,
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExtractPeriodDates.mockReturnValue({
+      periodStart: new Date(),
+      periodEnd: new Date(),
+    })
+  })
+
+  it('returns the existing row without creating a new one on retry', async () => {
+    mockGetSubscriptionByStripeId.mockResolvedValue(EXISTING_SUB)
+
+    const subscription = createMockStripeSubscription()
+    const result = await createSubscriptionFromStripe(
+      subscription,
+      BILLING_ACCOUNT_ID,
+      StripeAccountType.DUGSI
+    )
+
+    expect(result).toBe(EXISTING_SUB)
+    expect(mockCreateSubscription).not.toHaveBeenCalled()
+  })
+
+  it('calls createSubscription when no existing row is found', async () => {
+    mockGetSubscriptionByStripeId.mockResolvedValue(null)
+    const newRow = {
+      id: 'new-db-sub',
+      status: 'active',
+      billingAccountId: BILLING_ACCOUNT_ID,
+    }
+    mockCreateSubscription.mockResolvedValue(newRow)
+
+    const subscription = createMockStripeSubscription()
+    const result = await createSubscriptionFromStripe(
+      subscription,
+      BILLING_ACCOUNT_ID,
+      StripeAccountType.DUGSI
+    )
+
+    expect(mockCreateSubscription).toHaveBeenCalledOnce()
+    expect(result).toBe(newRow)
+  })
+
+  it('warns when idempotency return has a different billing account than requested', async () => {
+    const DIFFERENT_BILLING_ACCOUNT_ID = 'billing-account-from-path-3'
+    mockGetSubscriptionByStripeId.mockResolvedValue(EXISTING_SUB)
+
+    const subscription = createMockStripeSubscription()
+    await createSubscriptionFromStripe(
+      subscription,
+      DIFFERENT_BILLING_ACCOUNT_ID,
+      StripeAccountType.DUGSI
+    )
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        stripeSubscriptionId: 'sub_test_123',
+        storedBillingAccountId: BILLING_ACCOUNT_ID,
+        requestedBillingAccountId: DIFFERENT_BILLING_ACCOUNT_ID,
+      }),
+      'createSubscriptionFromStripe: idempotency return — billing account mismatch between retry invocations'
+    )
+    expect(mockCreateSubscription).not.toHaveBeenCalled()
+  })
+
+  it('does not warn when idempotency return has the same billing account', async () => {
+    mockGetSubscriptionByStripeId.mockResolvedValue(EXISTING_SUB)
+
+    const subscription = createMockStripeSubscription()
+    await createSubscriptionFromStripe(
+      subscription,
+      BILLING_ACCOUNT_ID,
+      StripeAccountType.DUGSI
+    )
+
+    expect(mockLoggerWarn).not.toHaveBeenCalled()
+  })
+})

--- a/lib/services/shared/subscription-service.ts
+++ b/lib/services/shared/subscription-service.ts
@@ -240,6 +240,16 @@ export async function createSubscriptionFromStripe(
   // return it rather than throwing P2002 on stripeSubscriptionId unique constraint.
   const existing = await getSubscriptionByStripeId(stripeSubscription.id)
   if (existing) {
+    if (existing.billingAccountId !== billingAccountId) {
+      logger.warn(
+        {
+          stripeSubscriptionId: stripeSubscription.id,
+          storedBillingAccountId: existing.billingAccountId,
+          requestedBillingAccountId: billingAccountId,
+        },
+        'createSubscriptionFromStripe: idempotency return — billing account mismatch between retry invocations'
+      )
+    }
     return existing
   }
 

--- a/lib/services/shared/subscription-service.ts
+++ b/lib/services/shared/subscription-service.ts
@@ -227,15 +227,6 @@ export async function createSubscriptionFromStripe(
     throw new Error('Invalid customer ID in subscription')
   }
 
-  // Extract price data
-  const priceData = stripeSubscription.items.data[0]?.price
-  const amount = priceData?.unit_amount || 0
-  const currency = stripeSubscription.currency || 'usd'
-  const interval = priceData?.recurring?.interval || 'month'
-
-  // Extract period dates
-  const periodDates = extractPeriodDates(stripeSubscription)
-
   // Idempotent: if the row already exists (webhook retry after partial failure),
   // return it rather than throwing P2002 on stripeSubscriptionId unique constraint.
   const existing = await getSubscriptionByStripeId(stripeSubscription.id)
@@ -252,6 +243,12 @@ export async function createSubscriptionFromStripe(
     }
     return existing
   }
+
+  const priceData = stripeSubscription.items.data[0]?.price
+  const amount = priceData?.unit_amount || 0
+  const currency = stripeSubscription.currency || 'usd'
+  const interval = priceData?.recurring?.interval || 'month'
+  const periodDates = extractPeriodDates(stripeSubscription)
 
   return await createSubscription({
     billingAccountId,

--- a/lib/services/shared/subscription-service.ts
+++ b/lib/services/shared/subscription-service.ts
@@ -21,8 +21,8 @@ import {
   updateSubscriptionStatus as updateSubscriptionStatusQuery,
 } from '@/lib/db/queries/billing'
 import { LIVE_SUBSCRIPTION_STATUSES } from '@/lib/db/query-builders'
-import { createServiceLogger, logError } from '@/lib/logger'
 import { ActionError, ERROR_CODES } from '@/lib/errors/action-error'
+import { createServiceLogger, logError } from '@/lib/logger'
 import { getStripeClient } from '@/lib/utils/stripe-client'
 import { extractPeriodDates } from '@/lib/utils/type-guards'
 
@@ -236,7 +236,13 @@ export async function createSubscriptionFromStripe(
   // Extract period dates
   const periodDates = extractPeriodDates(stripeSubscription)
 
-  // Create subscription
+  // Idempotent: if the row already exists (webhook retry after partial failure),
+  // return it rather than throwing P2002 on stripeSubscriptionId unique constraint.
+  const existing = await getSubscriptionByStripeId(stripeSubscription.id)
+  if (existing) {
+    return existing
+  }
+
   return await createSubscription({
     billingAccountId,
     stripeAccountType: accountType,

--- a/lib/services/shared/subscription-service.ts
+++ b/lib/services/shared/subscription-service.ts
@@ -215,7 +215,8 @@ export async function syncSubscriptionFromStripe(
 export async function createSubscriptionFromStripe(
   stripeSubscription: Stripe.Subscription,
   billingAccountId: string,
-  accountType: StripeAccountType
+  accountType: StripeAccountType,
+  overrideAmount?: number
 ) {
   // Extract customer ID
   const customerId =
@@ -245,7 +246,7 @@ export async function createSubscriptionFromStripe(
   }
 
   const priceData = stripeSubscription.items.data[0]?.price
-  const amount = priceData?.unit_amount || 0
+  const amount = overrideAmount ?? priceData?.unit_amount ?? 0
   const currency = stripeSubscription.currency || 'usd'
   const interval = priceData?.recurring?.interval || 'month'
   const periodDates = extractPeriodDates(stripeSubscription)

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -370,7 +370,7 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
 
     expect(mockSentrycaptureMessage).toHaveBeenCalledWith(
       'Path 4: billing account and subscription record created via email fallback — linking profiles',
-      expect.objectContaining({ level: 'info' })
+      expect.objectContaining({ level: 'warning' })
     )
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       expect.objectContaining({ guardianPersonId: GUARDIAN_ID, childCount: 2 }),
@@ -400,6 +400,26 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
       type: 'api_error',
     })
     mockSubscriptionsUpdate.mockRejectedValue(connectionError)
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    const result = await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(result.created).toBe(true)
+    expect(mockLogError).toHaveBeenCalled()
+    expect(mockSentrycaptureException).not.toHaveBeenCalled()
+  })
+
+  it('still succeeds and skips captureException when Stripe 5xx error occurs during metadata patch', async () => {
+    const serverError = new Stripe.errors.StripeAPIError({
+      message: 'Service unavailable',
+      type: 'api_error',
+      statusCode: 503,
+    })
+    mockSubscriptionsUpdate.mockRejectedValue(serverError)
 
     const subscription = createMockSubscription({
       customer: CUSTOMER_ID,

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -373,7 +373,7 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
 
     expect(mockSentrycaptureMessage).toHaveBeenCalledWith(
       'Dugsi subscription resolved via customer email fallback',
-      expect.objectContaining({ level: 'warning' })
+      expect.objectContaining({ level: 'info' })
     )
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       expect.objectContaining({ guardianPersonId: GUARDIAN_ID, childCount: 2 }),

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -10,7 +10,6 @@ const {
   mockFindBillableDugsiProfileIdsForGuardian,
   mockCustomersRetrieve,
   mockSubscriptionsUpdate,
-  mockPrismaPersonFindFirst,
   mockCreateOrUpdateBillingAccount,
   mockLinkSubscriptionToProfiles,
   mockCreateSubscriptionFromStripe,
@@ -30,7 +29,6 @@ const {
   mockFindBillableDugsiProfileIdsForGuardian: vi.fn(),
   mockCustomersRetrieve: vi.fn(),
   mockSubscriptionsUpdate: vi.fn(),
-  mockPrismaPersonFindFirst: vi.fn(),
   mockCreateOrUpdateBillingAccount: vi.fn(),
   mockLinkSubscriptionToProfiles: vi.fn(),
   mockCreateSubscriptionFromStripe: vi.fn(),
@@ -73,12 +71,6 @@ vi.mock('@/lib/logger', () => ({
     debug: vi.fn(),
   })),
   logError: mockLogError,
-}))
-
-vi.mock('@/lib/db', () => ({
-  prisma: {
-    person: { findFirst: mockPrismaPersonFindFirst },
-  },
 }))
 
 vi.mock('@sentry/nextjs', () => ({

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -313,7 +313,7 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     )
   })
 
-  it('patches metadata after DB subscription is created and profiles are linked', async () => {
+  it('patches metadata before linking profiles so Stripe is updated even if link step throws', async () => {
     const subscription = createMockSubscription({
       customer: CUSTOMER_ID,
       metadata: {},
@@ -336,8 +336,8 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
 
     expect(callOrder).toEqual([
       'createSubscription',
-      'linkProfiles',
       'patchMetadata',
+      'linkProfiles',
     ])
   })
 
@@ -625,6 +625,57 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
 
     const metadataArg = mockSubscriptionsUpdate.mock.calls[0][1].metadata
     expect(metadataArg).not.toHaveProperty('familyId')
+  })
+
+  it('on retry via Path 1 does not re-patch Stripe metadata or look up guardian again', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    // First delivery: Path 4 runs (no billing account yet)
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledOnce()
+    expect(mockFindGuardianWithBillableDugsiChildren).toHaveBeenCalledOnce()
+
+    vi.clearAllMocks()
+    mockExtractCustomerId.mockReturnValue(CUSTOMER_ID)
+    mockCreateSubscriptionFromStripe.mockResolvedValue(mockDbSubscription)
+    mockCalculateDugsiRate.mockReturnValue(STANDARD_RATE)
+    mockFindBillableDugsiProfileIdsForGuardian.mockResolvedValue([
+      PROFILE_ID_1,
+      PROFILE_ID_2,
+    ])
+    mockVerifyDugsiProfileIdsForGuardian.mockResolvedValue([])
+    // Retry: billing account now exists → Path 1
+    mockGetBillingAccountByStripeCustomerId.mockResolvedValue(
+      mockBillingAccount
+    )
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockCustomersRetrieve).not.toHaveBeenCalled()
+    expect(mockFindGuardianWithBillableDugsiChildren).not.toHaveBeenCalled()
+    expect(mockSubscriptionsUpdate).not.toHaveBeenCalled()
+  })
+
+  it('Stripe metadata is patched before linkProfilesIfPresent when link step throws', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+      items: {
+        object: 'list',
+        data: [{ price: { unit_amount: 0 } } as Stripe.SubscriptionItem],
+        has_more: false,
+        url: '',
+      },
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'DUGSI')
+    ).rejects.toThrow('Subscription has invalid amount')
+
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledOnce()
   })
 
   it('warns when guardian spans multiple families and uses first family ID', async () => {

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -15,6 +15,7 @@ const {
   mockLinkSubscriptionToProfiles,
   mockCreateSubscriptionFromStripe,
   mockSentrycaptureMessage,
+  mockSentrycaptureException,
   mockCalculateDugsiRate,
   mockExtractCustomerId,
   mockLogError,
@@ -34,6 +35,7 @@ const {
   mockLinkSubscriptionToProfiles: vi.fn(),
   mockCreateSubscriptionFromStripe: vi.fn(),
   mockSentrycaptureMessage: vi.fn(),
+  mockSentrycaptureException: vi.fn(),
   mockCalculateDugsiRate: vi.fn(),
   mockExtractCustomerId: vi.fn(),
   mockLogError: vi.fn(),
@@ -82,6 +84,7 @@ vi.mock('@/lib/db', () => ({
 vi.mock('@sentry/nextjs', () => ({
   startSpan: vi.fn((_opts: unknown, cb: () => unknown) => cb()),
   captureMessage: mockSentrycaptureMessage,
+  captureException: mockSentrycaptureException,
 }))
 
 vi.mock('@/lib/services/shared/billing-service', () => ({
@@ -396,6 +399,7 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     expect(result.created).toBe(true)
     expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalled()
     expect(mockLogError).toHaveBeenCalled()
+    expect(mockSentrycaptureException).toHaveBeenCalledOnce()
   })
 
   it('still succeeds when Stripe auth error occurs during metadata patch', async () => {
@@ -423,6 +427,7 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
       expect.anything(),
       expect.objectContaining({ level: 'error' })
     )
+    expect(mockSentrycaptureException).not.toHaveBeenCalled()
   })
 
   it('includes familyName in Stripe metadata patch', async () => {

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -369,7 +369,7 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     await handleSubscriptionCreated(subscription, 'DUGSI')
 
     expect(mockSentrycaptureMessage).toHaveBeenCalledWith(
-      'Dugsi subscription resolved via customer email fallback',
+      'Path 4: billing account and subscription record created via email fallback — linking profiles',
       expect.objectContaining({ level: 'info' })
     )
     expect(mockLoggerWarn).toHaveBeenCalledWith(
@@ -378,8 +378,8 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     )
   })
 
-  it('still succeeds when Stripe metadata update fails', async () => {
-    mockSubscriptionsUpdate.mockRejectedValue(new Error('Stripe API timeout'))
+  it('still succeeds and fires captureException when non-transient error occurs during metadata patch', async () => {
+    mockSubscriptionsUpdate.mockRejectedValue(new Error('unexpected failure'))
 
     const subscription = createMockSubscription({
       customer: CUSTOMER_ID,
@@ -392,6 +392,25 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalled()
     expect(mockLogError).toHaveBeenCalled()
     expect(mockSentrycaptureException).toHaveBeenCalledOnce()
+  })
+
+  it('still succeeds and skips captureException when transient Stripe error occurs during metadata patch', async () => {
+    const connectionError = new Stripe.errors.StripeConnectionError({
+      message: 'Connection timeout',
+      type: 'api_error',
+    })
+    mockSubscriptionsUpdate.mockRejectedValue(connectionError)
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    const result = await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(result.created).toBe(true)
+    expect(mockLogError).toHaveBeenCalled()
+    expect(mockSentrycaptureException).not.toHaveBeenCalled()
   })
 
   it('still succeeds when Stripe auth error occurs during metadata patch', async () => {

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -671,7 +671,7 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     expect(mockSubscriptionsUpdate).not.toHaveBeenCalled()
   })
 
-  it('Stripe metadata is patched before linkProfilesIfPresent when link step throws', async () => {
+  it('falls back to standard rate when Stripe unit_amount is 0', async () => {
     const subscription = createMockSubscription({
       customer: CUSTOMER_ID,
       metadata: {},
@@ -683,11 +683,15 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
       },
     })
 
-    await expect(
-      handleSubscriptionCreated(subscription, 'DUGSI')
-    ).rejects.toThrow('Subscription has invalid amount')
+    const result = await handleSubscriptionCreated(subscription, 'DUGSI')
 
-    expect(mockSubscriptionsUpdate).toHaveBeenCalledOnce()
+    expect(result.created).toBe(true)
+    expect(mockLinkSubscriptionToProfiles).toHaveBeenCalledWith(
+      DB_SUBSCRIPTION_ID,
+      expect.any(Array),
+      STANDARD_RATE,
+      'Linked automatically via webhook'
+    )
   })
 
   it('warns when guardian spans multiple families and uses first family ID', async () => {

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -46,12 +46,14 @@ vi.mock('@/lib/db/queries/billing', () => ({
   getSubscriptionByStripeId: mockGetSubscriptionByStripeId,
   getBillingAssignmentsBySubscription: vi.fn(),
   updateSubscriptionStatus: vi.fn(),
+}))
+
+vi.mock('@/lib/db/queries/person', () => ({
+  findPersonById: mockFindPersonById,
   findPersonByStripeCustomerId: mockFindPersonByStripeCustomerId,
 }))
 
-vi.mock('@/lib/db/queries/program-profile', () => ({
-  findPersonById: mockFindPersonById,
-}))
+vi.mock('@/lib/db/queries/program-profile', () => ({}))
 
 vi.mock('@/lib/db/queries/dugsi-profiles', () => ({
   findGuardianWithBillableDugsiChildren:

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -736,6 +736,39 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
       })
     )
   })
+
+  it('uses standard rate when Stripe unit_amount is null — no infinite retry loop', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+      items: {
+        object: 'list',
+        data: [
+          {
+            price: { unit_amount: null },
+          } as unknown as Stripe.SubscriptionItem,
+        ],
+        has_more: false,
+        url: '',
+      },
+    })
+
+    const result = await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(result.created).toBe(true)
+    expect(mockCreateSubscriptionFromStripe).toHaveBeenCalledWith(
+      expect.anything(),
+      BILLING_ACCOUNT_ID,
+      'DUGSI',
+      STANDARD_RATE
+    )
+    expect(mockLinkSubscriptionToProfiles).toHaveBeenCalledWith(
+      DB_SUBSCRIPTION_ID,
+      expect.any(Array),
+      STANDARD_RATE,
+      'Linked automatically via webhook'
+    )
+  })
 })
 
 describe('handleSubscriptionCreated — Path 3 (existing billing account person)', () => {

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -1,16 +1,64 @@
 import type Stripe from 'stripe'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 
-const { mockGetSubscriptionByStripeId, mockLoggerWarn } = vi.hoisted(() => ({
+const {
+  mockGetSubscriptionByStripeId,
+  mockGetBillingAccountByStripeCustomerId,
+  mockLoggerWarn,
+  mockFindGuardianWithBillableDugsiChildren,
+  mockVerifyDugsiProfileIdsForGuardian,
+  mockFindBillableDugsiProfileIdsForGuardian,
+  mockCustomersRetrieve,
+  mockSubscriptionsUpdate,
+  mockPrismaPersonFindFirst,
+  mockCreateOrUpdateBillingAccount,
+  mockLinkSubscriptionToProfiles,
+  mockCreateSubscriptionFromStripe,
+  mockSentrycaptureMessage,
+  mockCalculateDugsiRate,
+  mockExtractCustomerId,
+  mockLogError,
+  mockFindPersonByStripeCustomerId,
+  mockFindPersonById,
+} = vi.hoisted(() => ({
   mockGetSubscriptionByStripeId: vi.fn(),
+  mockGetBillingAccountByStripeCustomerId: vi.fn(),
   mockLoggerWarn: vi.fn(),
+  mockFindGuardianWithBillableDugsiChildren: vi.fn(),
+  mockVerifyDugsiProfileIdsForGuardian: vi.fn(),
+  mockFindBillableDugsiProfileIdsForGuardian: vi.fn(),
+  mockCustomersRetrieve: vi.fn(),
+  mockSubscriptionsUpdate: vi.fn(),
+  mockPrismaPersonFindFirst: vi.fn(),
+  mockCreateOrUpdateBillingAccount: vi.fn(),
+  mockLinkSubscriptionToProfiles: vi.fn(),
+  mockCreateSubscriptionFromStripe: vi.fn(),
+  mockSentrycaptureMessage: vi.fn(),
+  mockCalculateDugsiRate: vi.fn(),
+  mockExtractCustomerId: vi.fn(),
+  mockLogError: vi.fn(),
+  mockFindPersonByStripeCustomerId: vi.fn(),
+  mockFindPersonById: vi.fn(),
 }))
 
 vi.mock('@/lib/db/queries/billing', () => ({
-  getBillingAccountByStripeCustomerId: vi.fn(),
+  getBillingAccountByStripeCustomerId: mockGetBillingAccountByStripeCustomerId,
   getSubscriptionByStripeId: mockGetSubscriptionByStripeId,
   getBillingAssignmentsBySubscription: vi.fn(),
   updateSubscriptionStatus: vi.fn(),
+  findPersonByStripeCustomerId: mockFindPersonByStripeCustomerId,
+}))
+
+vi.mock('@/lib/db/queries/program-profile', () => ({
+  findPersonById: mockFindPersonById,
+}))
+
+vi.mock('@/lib/db/queries/dugsi-profiles', () => ({
+  findGuardianWithBillableDugsiChildren:
+    mockFindGuardianWithBillableDugsiChildren,
+  verifyDugsiProfileIdsForGuardian: mockVerifyDugsiProfileIdsForGuardian,
+  findBillableDugsiProfileIdsForGuardian:
+    mockFindBillableDugsiProfileIdsForGuardian,
 }))
 
 vi.mock('@/lib/logger', () => ({
@@ -20,30 +68,39 @@ vi.mock('@/lib/logger', () => ({
     error: vi.fn(),
     debug: vi.fn(),
   })),
-  logError: vi.fn(),
+  logError: mockLogError,
 }))
 
 vi.mock('@/lib/db', () => ({
-  prisma: {},
+  prisma: {
+    person: { findFirst: mockPrismaPersonFindFirst },
+  },
 }))
 
 vi.mock('@sentry/nextjs', () => ({
   startSpan: vi.fn((_opts: unknown, cb: () => unknown) => cb()),
-  captureMessage: vi.fn(),
+  captureMessage: mockSentrycaptureMessage,
 }))
 
 vi.mock('@/lib/services/shared/billing-service', () => ({
-  createOrUpdateBillingAccount: vi.fn(),
-  linkSubscriptionToProfiles: vi.fn(),
+  createOrUpdateBillingAccount: mockCreateOrUpdateBillingAccount,
+  linkSubscriptionToProfiles: mockLinkSubscriptionToProfiles,
   unlinkSubscription: vi.fn(),
 }))
 
 vi.mock('@/lib/services/shared/subscription-service', () => ({
-  createSubscriptionFromStripe: vi.fn(),
+  createSubscriptionFromStripe: mockCreateSubscriptionFromStripe,
+}))
+
+vi.mock('@/lib/stripe-dugsi', () => ({
+  getDugsiStripeClient: vi.fn(() => ({
+    customers: { retrieve: mockCustomersRetrieve },
+    subscriptions: { update: mockSubscriptionsUpdate },
+  })),
 }))
 
 vi.mock('@/lib/utils/dugsi-tuition', () => ({
-  calculateDugsiRate: vi.fn(),
+  calculateDugsiRate: mockCalculateDugsiRate,
 }))
 
 vi.mock('@/lib/utils/mahad-tuition', () => ({
@@ -51,7 +108,7 @@ vi.mock('@/lib/utils/mahad-tuition', () => ({
 }))
 
 vi.mock('@/lib/utils/type-guards', () => ({
-  extractCustomerId: vi.fn(),
+  extractCustomerId: mockExtractCustomerId,
   extractPeriodDates: vi.fn(() => ({
     periodStart: new Date(),
     periodEnd: new Date(),
@@ -59,7 +116,14 @@ vi.mock('@/lib/utils/type-guards', () => ({
   isValidSubscriptionStatus: vi.fn(() => true),
 }))
 
-import { handleSubscriptionUpdated } from '../webhook-service'
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+}))
+
+import {
+  handleSubscriptionUpdated,
+  handleSubscriptionCreated,
+} from '../webhook-service'
 
 function createMockSubscription(
   overrides: Partial<Stripe.Subscription> = {}
@@ -69,7 +133,18 @@ function createMockSubscription(
     object: 'subscription',
     status: 'active',
     customer: 'cus_test_123',
-    items: { object: 'list', data: [], has_more: false, url: '' },
+    metadata: {},
+    created: 1700000000,
+    items: {
+      object: 'list',
+      data: [
+        {
+          price: { unit_amount: 5000 },
+        } as Stripe.SubscriptionItem,
+      ],
+      has_more: false,
+      url: '',
+    },
     ...overrides,
   } as Stripe.Subscription
 }
@@ -95,5 +170,781 @@ describe('handleSubscriptionUpdated', () => {
       { stripeSubscriptionId: 'sub_legacy_123' },
       'Subscription not found in database - student may need to re-register'
     )
+  })
+})
+
+describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)', () => {
+  const CUSTOMER_ID = 'cus_UHVIVIKqO7UuK6'
+  const GUARDIAN_ID = 'guardian-person-id'
+  const PROFILE_ID_1 = 'profile-id-1'
+  const PROFILE_ID_2 = 'profile-id-2'
+  const FAMILY_ID = 'family-ref-id'
+  const BILLING_ACCOUNT_ID = 'billing-account-id'
+  const DB_SUBSCRIPTION_ID = 'db-sub-id'
+  const STANDARD_RATE = 6000
+
+  const mockGuardianPerson = {
+    id: GUARDIAN_ID,
+    name: 'Kadar Warfa',
+    email: 'khadra.warfa@gmail.com',
+    phone: '6124420703',
+    programProfiles: [],
+  }
+
+  const mockFamilyProfiles = [
+    { id: PROFILE_ID_1, familyReferenceId: FAMILY_ID },
+    { id: PROFILE_ID_2, familyReferenceId: FAMILY_ID },
+  ]
+
+  const mockGuardianWithChildren = {
+    ...mockGuardianPerson,
+    guardianRelationships: [
+      { dependent: { programProfiles: [mockFamilyProfiles[0]] } },
+      { dependent: { programProfiles: [mockFamilyProfiles[1]] } },
+    ],
+  }
+
+  const mockBillingAccount = {
+    id: BILLING_ACCOUNT_ID,
+    personId: GUARDIAN_ID,
+  }
+
+  const mockDbSubscription = {
+    id: DB_SUBSCRIPTION_ID,
+    status: 'active',
+    stripeSubscriptionId: 'sub_test_123',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExtractCustomerId.mockReturnValue(CUSTOMER_ID)
+    mockGetBillingAccountByStripeCustomerId.mockResolvedValue(null)
+    mockFindPersonById.mockResolvedValue(null)
+    // Path 3: no existing person linked to this customer ID
+    mockFindPersonByStripeCustomerId.mockResolvedValue(null)
+    // Path 4: guardian found by email with billable children
+    mockFindGuardianWithBillableDugsiChildren.mockResolvedValue(
+      mockGuardianWithChildren
+    )
+    mockCustomersRetrieve.mockResolvedValue({
+      id: CUSTOMER_ID,
+      deleted: false,
+      email: 'khadra.warfa@gmail.com',
+    })
+    mockCreateOrUpdateBillingAccount.mockResolvedValue(mockBillingAccount)
+    mockCreateSubscriptionFromStripe.mockResolvedValue(mockDbSubscription)
+    mockCalculateDugsiRate.mockReturnValue(STANDARD_RATE)
+    mockSubscriptionsUpdate.mockResolvedValue({})
+  })
+
+  it('resolves billing account via Stripe customer email and derives profile IDs', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    const result = await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockCustomersRetrieve).toHaveBeenCalledWith(CUSTOMER_ID)
+    expect(mockFindGuardianWithBillableDugsiChildren).toHaveBeenCalledWith(
+      'khadra.warfa@gmail.com'
+    )
+    expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        personId: GUARDIAN_ID,
+        accountType: 'DUGSI',
+        stripeCustomerId: CUSTOMER_ID,
+        paymentMethodCaptured: true,
+      })
+    )
+    expect(result.created).toBe(true)
+    expect(result.subscriptionId).toBe(DB_SUBSCRIPTION_ID)
+  })
+
+  it('uses subscription.created timestamp for paymentMethodCapturedAt in fallback', async () => {
+    const STRIPE_CREATED_TS = 1700000000
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+      created: STRIPE_CREATED_TS,
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentMethodCapturedAt: new Date(STRIPE_CREATED_TS * 1000),
+      })
+    )
+  })
+
+  it('patches Stripe subscription metadata with calculated rate and override flag', async () => {
+    const actualAmount = 4500
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+      items: {
+        object: 'list',
+        data: [
+          { price: { unit_amount: actualAmount } } as Stripe.SubscriptionItem,
+        ],
+        has_more: false,
+        url: '',
+      },
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledWith(
+      'sub_test_123',
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          guardianPersonId: GUARDIAN_ID,
+          familyId: FAMILY_ID,
+          childCount: '2',
+          profileIds: `${PROFILE_ID_1},${PROFILE_ID_2}`,
+          calculatedRate: String(STANDARD_RATE),
+          overrideUsed: 'true',
+          source: 'dugsi-webhook-fallback-recovery',
+        }),
+      })
+    )
+  })
+
+  it('patches metadata after DB subscription is created and profiles are linked', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    const callOrder: string[] = []
+    mockCreateSubscriptionFromStripe.mockImplementation(async () => {
+      callOrder.push('createSubscription')
+      return mockDbSubscription
+    })
+    mockLinkSubscriptionToProfiles.mockImplementation(async () => {
+      callOrder.push('linkProfiles')
+    })
+    mockSubscriptionsUpdate.mockImplementation(async () => {
+      callOrder.push('patchMetadata')
+      return {}
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(callOrder).toEqual([
+      'createSubscription',
+      'linkProfiles',
+      'patchMetadata',
+    ])
+  })
+
+  it('sets overrideUsed to false when actual amount matches standard rate', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+      items: {
+        object: 'list',
+        data: [
+          { price: { unit_amount: STANDARD_RATE } } as Stripe.SubscriptionItem,
+        ],
+        has_more: false,
+        url: '',
+      },
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledWith(
+      'sub_test_123',
+      expect.objectContaining({
+        metadata: expect.objectContaining({ overrideUsed: 'false' }),
+      })
+    )
+  })
+
+  it('emits Sentry warning and logger.warn on successful fallback resolution', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockSentrycaptureMessage).toHaveBeenCalledWith(
+      'Dugsi subscription resolved via customer email fallback',
+      expect.objectContaining({ level: 'warning' })
+    )
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ guardianPersonId: GUARDIAN_ID, childCount: 2 }),
+      'Subscription created without metadata — resolved via Stripe customer email fallback'
+    )
+  })
+
+  it('still succeeds when Stripe metadata update fails and emits Sentry error', async () => {
+    mockSubscriptionsUpdate.mockRejectedValue(new Error('Stripe API timeout'))
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    const result = await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(result.created).toBe(true)
+    expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalled()
+    expect(mockLogError).toHaveBeenCalled()
+    expect(mockSentrycaptureMessage).toHaveBeenCalledWith(
+      'Dugsi subscription metadata patch failed — manual intervention required',
+      expect.objectContaining({ level: 'error' })
+    )
+  })
+
+  it('includes familyName in Stripe metadata patch', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledWith(
+      'sub_test_123',
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          familyName: mockGuardianPerson.name,
+        }),
+      })
+    )
+  })
+
+  it('links derived profile IDs to the created subscription', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockLinkSubscriptionToProfiles).toHaveBeenCalledWith(
+      DB_SUBSCRIPTION_ID,
+      [PROFILE_ID_1, PROFILE_ID_2],
+      5000,
+      'Linked automatically via webhook'
+    )
+  })
+
+  it('throws and logs when customers.retrieve rejects (Stripe API error)', async () => {
+    const apiError = new Error('Stripe network timeout')
+    mockCustomersRetrieve.mockRejectedValue(apiError)
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'DUGSI')
+    ).rejects.toThrow('Stripe network timeout')
+    expect(mockLogError).toHaveBeenCalled()
+    expect(mockFindGuardianWithBillableDugsiChildren).not.toHaveBeenCalled()
+  })
+
+  it('throws when Stripe customer is deleted and does not call guardian lookup', async () => {
+    mockCustomersRetrieve.mockResolvedValue({ id: CUSTOMER_ID, deleted: true })
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'DUGSI')
+    ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
+    expect(mockFindGuardianWithBillableDugsiChildren).not.toHaveBeenCalled()
+  })
+
+  it('throws when Stripe customer has no email (not deleted)', async () => {
+    mockCustomersRetrieve.mockResolvedValue({
+      id: CUSTOMER_ID,
+      deleted: false,
+      email: null,
+    })
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'DUGSI')
+    ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
+    expect(mockFindGuardianWithBillableDugsiChildren).not.toHaveBeenCalled()
+  })
+
+  it('throws when guardian lookup by email returns null', async () => {
+    mockFindGuardianWithBillableDugsiChildren.mockResolvedValue(null)
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'DUGSI')
+    ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
+    expect(mockCreateOrUpdateBillingAccount).not.toHaveBeenCalled()
+  })
+
+  it('throws when guardian has no active Dugsi children', async () => {
+    const guardianNoChildren = {
+      ...mockGuardianPerson,
+      guardianRelationships: [],
+    }
+    mockFindGuardianWithBillableDugsiChildren.mockResolvedValue(
+      guardianNoChildren
+    )
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'DUGSI')
+    ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
+    expect(mockCreateOrUpdateBillingAccount).not.toHaveBeenCalled()
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ guardianPersonId: GUARDIAN_ID }),
+      'Path 4 fallback: Cannot create billing account — guardian has no enrolled Dugsi children'
+    )
+  })
+
+  it('throws without attempting fallback for non-DUGSI account type', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'MAHAD')
+    ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
+    expect(mockCustomersRetrieve).not.toHaveBeenCalled()
+  })
+
+  it('deduplicates profile IDs when guardian has multiple active roles for the same child', async () => {
+    const DUPLICATE_PROFILE_ID = 'profile-id-shared'
+    const guardianWithDuplicateRoles = {
+      ...mockGuardianPerson,
+      guardianRelationships: [
+        {
+          dependent: {
+            programProfiles: [
+              { id: DUPLICATE_PROFILE_ID, familyReferenceId: FAMILY_ID },
+            ],
+          },
+        },
+        {
+          dependent: {
+            programProfiles: [
+              { id: DUPLICATE_PROFILE_ID, familyReferenceId: FAMILY_ID },
+            ],
+          },
+        },
+      ],
+    }
+    mockFindGuardianWithBillableDugsiChildren.mockResolvedValue(
+      guardianWithDuplicateRoles
+    )
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockCalculateDugsiRate).toHaveBeenCalledWith(1)
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledWith(
+      'sub_test_123',
+      expect.objectContaining({
+        metadata: expect.objectContaining({
+          childCount: '1',
+          profileIds: DUPLICATE_PROFILE_ID,
+        }),
+      })
+    )
+  })
+
+  it('omits familyId from Stripe metadata when familyReferenceId is null', async () => {
+    const guardianWithNullFamily = {
+      ...mockGuardianPerson,
+      guardianRelationships: [
+        {
+          dependent: {
+            programProfiles: [{ id: PROFILE_ID_1, familyReferenceId: null }],
+          },
+        },
+      ],
+    }
+    mockFindGuardianWithBillableDugsiChildren.mockResolvedValue(
+      guardianWithNullFamily
+    )
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    const metadataArg = mockSubscriptionsUpdate.mock.calls[0][1].metadata
+    expect(metadataArg).not.toHaveProperty('familyId')
+  })
+
+  it('warns when guardian spans multiple families and uses first family ID', async () => {
+    const FAMILY_ID_2 = 'family-ref-id-2'
+    const guardianMultiFamily = {
+      ...mockGuardianPerson,
+      guardianRelationships: [
+        {
+          dependent: {
+            programProfiles: [
+              { id: PROFILE_ID_1, familyReferenceId: FAMILY_ID },
+            ],
+          },
+        },
+        {
+          dependent: {
+            programProfiles: [
+              { id: PROFILE_ID_2, familyReferenceId: FAMILY_ID_2 },
+            ],
+          },
+        },
+      ],
+    }
+    mockFindGuardianWithBillableDugsiChildren.mockResolvedValue(
+      guardianMultiFamily
+    )
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guardianPersonId: GUARDIAN_ID,
+        familyIds: expect.arrayContaining([FAMILY_ID, FAMILY_ID_2]),
+      }),
+      'Path 4 fallback: guardian spans multiple families — using first family ID'
+    )
+    expect(mockSubscriptionsUpdate).toHaveBeenCalledWith(
+      'sub_test_123',
+      expect.objectContaining({
+        metadata: expect.objectContaining({ familyId: FAMILY_ID }),
+      })
+    )
+  })
+})
+
+describe('handleSubscriptionCreated — Path 3 (existing billing account person)', () => {
+  const CUSTOMER_ID = 'cus_existing_123'
+  const EXISTING_PERSON_ID = 'existing-person-id'
+  const BILLING_ACCOUNT_ID = 'billing-account-id'
+  const DB_SUBSCRIPTION_ID = 'db-sub-id'
+
+  const mockExistingPerson = {
+    id: EXISTING_PERSON_ID,
+    name: 'Existing Person',
+    email: 'existing@example.com',
+    phone: '6125550000',
+  }
+
+  const mockBillingAccount = {
+    id: BILLING_ACCOUNT_ID,
+    personId: EXISTING_PERSON_ID,
+  }
+
+  const mockDbSubscription = {
+    id: DB_SUBSCRIPTION_ID,
+    status: 'active',
+    stripeSubscriptionId: 'sub_existing_123',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExtractCustomerId.mockReturnValue(CUSTOMER_ID)
+    mockGetBillingAccountByStripeCustomerId.mockResolvedValue(null)
+    mockFindPersonById.mockResolvedValue(null)
+    mockFindPersonByStripeCustomerId.mockResolvedValue(mockExistingPerson)
+    mockCreateOrUpdateBillingAccount.mockResolvedValue(mockBillingAccount)
+    mockCreateSubscriptionFromStripe.mockResolvedValue(mockDbSubscription)
+    mockCalculateDugsiRate.mockReturnValue(5000)
+    mockFindBillableDugsiProfileIdsForGuardian.mockResolvedValue([])
+    mockVerifyDugsiProfileIdsForGuardian.mockResolvedValue([])
+  })
+
+  it('creates billing account for person found via existing billing account link', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    const result = await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        personId: EXISTING_PERSON_ID,
+        accountType: 'DUGSI',
+        stripeCustomerId: CUSTOMER_ID,
+      })
+    )
+    expect(mockCreateOrUpdateBillingAccount).not.toHaveBeenCalledWith(
+      expect.objectContaining({ paymentMethodCaptured: true })
+    )
+    expect(result.created).toBe(true)
+    expect(mockCustomersRetrieve).not.toHaveBeenCalled()
+  })
+})
+
+describe('handleSubscriptionCreated — Path 2 (subscription metadata personId)', () => {
+  const CUSTOMER_ID = 'cus_path2_123'
+  const PERSON_ID = 'person-id-from-metadata'
+  const BILLING_ACCOUNT_ID = 'billing-account-id'
+  const DB_SUBSCRIPTION_ID = 'db-sub-id'
+
+  const mockBillingAccount = { id: BILLING_ACCOUNT_ID, personId: PERSON_ID }
+  const mockDbSubscription = {
+    id: DB_SUBSCRIPTION_ID,
+    status: 'active',
+    stripeSubscriptionId: 'sub_path2_123',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExtractCustomerId.mockReturnValue(CUSTOMER_ID)
+    mockGetBillingAccountByStripeCustomerId.mockResolvedValue(null)
+    mockFindPersonById.mockResolvedValue({ id: PERSON_ID })
+    mockCreateOrUpdateBillingAccount.mockResolvedValue(mockBillingAccount)
+    mockCreateSubscriptionFromStripe.mockResolvedValue(mockDbSubscription)
+    mockFindBillableDugsiProfileIdsForGuardian.mockResolvedValue([])
+    mockVerifyDugsiProfileIdsForGuardian.mockResolvedValue([])
+    mockCalculateDugsiRate.mockReturnValue(5000)
+  })
+
+  it('creates billing account from metadata.guardianPersonId', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: { guardianPersonId: PERSON_ID },
+    })
+
+    const result = await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockFindPersonById).toHaveBeenCalledWith(PERSON_ID)
+    expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalledWith(
+      expect.objectContaining({
+        personId: PERSON_ID,
+        accountType: 'DUGSI',
+        stripeCustomerId: CUSTOMER_ID,
+        paymentMethodCaptured: true,
+      })
+    )
+    expect(result.created).toBe(true)
+    expect(mockCustomersRetrieve).not.toHaveBeenCalled()
+  })
+
+  it('creates billing account from metadata.personId (Mahad-style key)', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: { personId: PERSON_ID },
+    })
+
+    const result = await handleSubscriptionCreated(subscription, 'MAHAD')
+
+    expect(mockFindPersonById).toHaveBeenCalledWith(PERSON_ID)
+    expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalledWith(
+      expect.objectContaining({ personId: PERSON_ID, accountType: 'MAHAD' })
+    )
+    expect(result.created).toBe(true)
+  })
+
+  it('falls through to Path 3 and throws when metadata personId not found in DB', async () => {
+    mockFindPersonById.mockResolvedValue(null)
+    mockFindPersonByStripeCustomerId.mockResolvedValue(null)
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: { guardianPersonId: 'nonexistent-person-id' },
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'MAHAD')
+    ).rejects.toThrow(`No person found for customer ${CUSTOMER_ID}`)
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({ metadataPersonId: 'nonexistent-person-id' }),
+      'Path 2: metadataPersonId not found in DB — falling through to Path 3'
+    )
+    expect(mockCreateOrUpdateBillingAccount).not.toHaveBeenCalled()
+  })
+})
+
+describe('handleSubscriptionCreated — Dugsi profile ID verification (Paths 1/2/3)', () => {
+  const CUSTOMER_ID = 'cus_common_123'
+  const GUARDIAN_ID = 'guardian-person-id'
+  const PROFILE_ID_1 = 'profile-id-1'
+  const PROFILE_ID_2 = 'profile-id-2'
+  const BILLING_ACCOUNT_ID = 'billing-account-id'
+  const DB_SUBSCRIPTION_ID = 'db-sub-id'
+
+  const mockBillingAccount = {
+    id: BILLING_ACCOUNT_ID,
+    personId: GUARDIAN_ID,
+  }
+
+  const mockDbSubscription = {
+    id: DB_SUBSCRIPTION_ID,
+    status: 'active',
+    stripeSubscriptionId: 'sub_common_123',
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockExtractCustomerId.mockReturnValue(CUSTOMER_ID)
+    // Path 1: billing account exists
+    mockGetBillingAccountByStripeCustomerId.mockResolvedValue(
+      mockBillingAccount
+    )
+    mockFindPersonById.mockResolvedValue(null)
+    mockFindPersonByStripeCustomerId.mockResolvedValue(null)
+    mockCreateOrUpdateBillingAccount.mockResolvedValue(mockBillingAccount)
+    mockCreateSubscriptionFromStripe.mockResolvedValue(mockDbSubscription)
+    mockCalculateDugsiRate.mockReturnValue(5000)
+    mockVerifyDugsiProfileIdsForGuardian.mockResolvedValue([])
+    mockFindBillableDugsiProfileIdsForGuardian.mockResolvedValue([
+      PROFILE_ID_1,
+      PROFILE_ID_2,
+    ])
+  })
+
+  it('ignores unverified Dugsi profileIds from Stripe metadata and links DB-derived billable children', async () => {
+    const FAKE_PROFILE_ID = 'fake-unverified-profile-id'
+    // Verification rejects the fake ID
+    mockVerifyDugsiProfileIdsForGuardian.mockResolvedValue([])
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: { profileIds: FAKE_PROFILE_ID },
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        metadataProfileIds: [FAKE_PROFILE_ID],
+        verifiedProfileIds: [],
+      }),
+      'Ignoring unverified Dugsi profileIds from Stripe metadata'
+    )
+    expect(mockLinkSubscriptionToProfiles).toHaveBeenCalledWith(
+      DB_SUBSCRIPTION_ID,
+      [PROFILE_ID_1, PROFILE_ID_2],
+      5000,
+      'Linked automatically via webhook'
+    )
+  })
+
+  it('uses verified metadata profile IDs when they pass DB check', async () => {
+    mockVerifyDugsiProfileIdsForGuardian.mockResolvedValue([PROFILE_ID_1])
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: { profileIds: PROFILE_ID_1 },
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockLinkSubscriptionToProfiles).toHaveBeenCalledWith(
+      DB_SUBSCRIPTION_ID,
+      [PROFILE_ID_1],
+      5000,
+      'Linked automatically via webhook'
+    )
+    expect(mockFindBillableDugsiProfileIdsForGuardian).not.toHaveBeenCalled()
+  })
+
+  it('falls back to full DB derivation when no metadata profile hints are present', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockVerifyDugsiProfileIdsForGuardian).not.toHaveBeenCalled()
+    expect(mockFindBillableDugsiProfileIdsForGuardian).toHaveBeenCalledWith(
+      GUARDIAN_ID
+    )
+    expect(mockLinkSubscriptionToProfiles).toHaveBeenCalledWith(
+      DB_SUBSCRIPTION_ID,
+      [PROFILE_ID_1, PROFILE_ID_2],
+      5000,
+      'Linked automatically via webhook'
+    )
+  })
+
+  it('does not fire Dugsi metadata patch for common Dugsi paths', async () => {
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(mockSubscriptionsUpdate).not.toHaveBeenCalled()
+    expect(mockSentrycaptureMessage).not.toHaveBeenCalled()
+  })
+
+  it('uses metadata profile ID hints without Dugsi DB lookup for Mahad subscriptions', async () => {
+    const MAHAD_PROFILE_ID = 'mahad-profile-id'
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: { profileId: MAHAD_PROFILE_ID },
+    })
+
+    await handleSubscriptionCreated(subscription, 'MAHAD')
+
+    expect(mockVerifyDugsiProfileIdsForGuardian).not.toHaveBeenCalled()
+    expect(mockFindBillableDugsiProfileIdsForGuardian).not.toHaveBeenCalled()
+    expect(mockLinkSubscriptionToProfiles).toHaveBeenCalledWith(
+      DB_SUBSCRIPTION_ID,
+      [MAHAD_PROFILE_ID],
+      5000,
+      'Linked automatically via webhook'
+    )
+  })
+
+  it('throws and logs when subscription amount is zero and profiles are present', async () => {
+    mockFindBillableDugsiProfileIdsForGuardian.mockResolvedValue([PROFILE_ID_1])
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+      items: {
+        object: 'list',
+        data: [{ price: { unit_amount: 0 } } as Stripe.SubscriptionItem],
+        has_more: false,
+        url: '',
+      },
+    })
+
+    await expect(
+      handleSubscriptionCreated(subscription, 'DUGSI')
+    ).rejects.toThrow('Subscription has invalid amount')
+    expect(mockLogError).toHaveBeenCalled()
+    expect(mockLinkSubscriptionToProfiles).not.toHaveBeenCalled()
   })
 })

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -420,14 +420,10 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     expect(mockLogError).toHaveBeenCalledWith(
       expect.anything(),
       authError,
-      'Path 4 fallback: transient/auth Stripe error — metadata patch skipped, subscription saved successfully',
+      'Path 4 fallback: Failed to patch Stripe subscription metadata — manual update required',
       expect.any(Object)
     )
-    expect(mockSentrycaptureMessage).not.toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ level: 'error' })
-    )
-    expect(mockSentrycaptureException).not.toHaveBeenCalled()
+    expect(mockSentrycaptureException).toHaveBeenCalledOnce()
   })
 
   it('includes familyName in Stripe metadata patch', async () => {

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -845,9 +845,8 @@ describe('handleSubscriptionCreated — Dugsi profile ID verification (Paths 1/2
     expect(mockLoggerWarn).toHaveBeenCalledWith(
       expect.objectContaining({
         metadataProfileIds: [FAKE_PROFILE_ID],
-        verifiedProfileIds: [],
       }),
-      'Ignoring unverified Dugsi profileIds from Stripe metadata'
+      'All Dugsi profileIds from Stripe metadata failed verification — falling back to DB derivation'
     )
     expect(mockLinkSubscriptionToProfiles).toHaveBeenCalledWith(
       DB_SUBSCRIPTION_ID,

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -420,7 +420,7 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     expect(mockLogError).toHaveBeenCalledWith(
       expect.anything(),
       authError,
-      'Path 4 fallback: Stripe API key invalid — metadata patch skipped, subscription saved successfully',
+      'Path 4 fallback: transient/auth Stripe error — metadata patch skipped, subscription saved successfully',
       expect.any(Object)
     )
     expect(mockSentrycaptureMessage).not.toHaveBeenCalledWith(

--- a/lib/services/webhooks/__tests__/webhook-service.test.ts
+++ b/lib/services/webhooks/__tests__/webhook-service.test.ts
@@ -1,4 +1,4 @@
-import type Stripe from 'stripe'
+import Stripe from 'stripe'
 import { vi, describe, it, expect, beforeEach } from 'vitest'
 
 const {
@@ -381,7 +381,7 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     )
   })
 
-  it('still succeeds when Stripe metadata update fails and emits Sentry error', async () => {
+  it('still succeeds when Stripe metadata update fails', async () => {
     mockSubscriptionsUpdate.mockRejectedValue(new Error('Stripe API timeout'))
 
     const subscription = createMockSubscription({
@@ -394,8 +394,31 @@ describe('handleSubscriptionCreated — Path 4 (Dugsi customer email fallback)',
     expect(result.created).toBe(true)
     expect(mockCreateOrUpdateBillingAccount).toHaveBeenCalled()
     expect(mockLogError).toHaveBeenCalled()
-    expect(mockSentrycaptureMessage).toHaveBeenCalledWith(
-      'Dugsi subscription metadata patch failed — manual intervention required',
+  })
+
+  it('still succeeds when Stripe auth error occurs during metadata patch', async () => {
+    const authError = new Stripe.errors.StripeAuthenticationError({
+      message: 'No such API key',
+      type: 'api_error',
+    })
+    mockSubscriptionsUpdate.mockRejectedValue(authError)
+
+    const subscription = createMockSubscription({
+      customer: CUSTOMER_ID,
+      metadata: {},
+    })
+
+    const result = await handleSubscriptionCreated(subscription, 'DUGSI')
+
+    expect(result.created).toBe(true)
+    expect(mockLogError).toHaveBeenCalledWith(
+      expect.anything(),
+      authError,
+      'Path 4 fallback: Stripe API key invalid — metadata patch skipped, subscription saved successfully',
+      expect.any(Object)
+    )
+    expect(mockSentrycaptureMessage).not.toHaveBeenCalledWith(
+      expect.anything(),
       expect.objectContaining({ level: 'error' })
     )
   })

--- a/lib/services/webhooks/event-handlers.ts
+++ b/lib/services/webhooks/event-handlers.ts
@@ -139,14 +139,7 @@ async function handleSubscriptionCreatedEvent(
     'Processing customer.subscription.created'
   )
 
-  // Extract profile IDs from subscription metadata if available
-  const profileIds = subscription.metadata?.profileIds
-    ? subscription.metadata.profileIds.split(',').filter(Boolean)
-    : subscription.metadata?.profileId
-      ? [subscription.metadata.profileId]
-      : undefined
-
-  await handleSubscriptionCreated(subscription, accountType, profileIds)
+  await handleSubscriptionCreated(subscription, accountType)
 }
 
 /**

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -340,7 +340,8 @@ async function resolveDugsiFallbackFromCustomerEmail(
 
   const effectiveProfileIds = familyProfiles.map((p) => p.id)
   const childCount = familyProfiles.length
-  const familyId = familyProfiles[0]?.familyReferenceId ?? null
+  const familyId =
+    familyProfiles.find((p) => p.familyReferenceId)?.familyReferenceId ?? null
 
   const uniqueFamilyIds = new Set(
     familyProfiles.map((p) => p.familyReferenceId).filter(Boolean)

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -358,6 +358,10 @@ async function resolveDugsiFallbackFromCustomerEmail(
   }
 
   const standardRate = calculateDugsiRate(childCount)
+  // Use || not ?? so that an explicit $0 also falls back to standardRate.
+  // A $0 unit_amount in Path 4 is a data-entry error in the Stripe dashboard;
+  // using standardRate prevents an infinite retry loop where linkProfilesIfPresent
+  // throws on every delivery.
   const actualAmount =
     subscription.items.data[0]?.price?.unit_amount || standardRate
 
@@ -514,7 +518,7 @@ async function patchRecoveredDugsiMetadata(
   Sentry.captureMessage(
     'Path 4: billing account and subscription record created via email fallback — linking profiles',
     {
-      level: 'info',
+      level: 'warning',
       extra: {
         customerId,
         subscriptionId,
@@ -551,7 +555,9 @@ async function patchRecoveredDugsiMetadata(
   } catch (metadataErr) {
     const isTransientError =
       metadataErr instanceof Stripe.errors.StripeConnectionError ||
-      metadataErr instanceof Stripe.errors.StripeRateLimitError
+      metadataErr instanceof Stripe.errors.StripeRateLimitError ||
+      (metadataErr instanceof Stripe.errors.StripeAPIError &&
+        (metadataErr.statusCode ?? 0) >= 500)
 
     if (isTransientError) {
       await logError(

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -22,7 +22,7 @@ import type {
   StudentBillingType,
 } from '@prisma/client'
 import * as Sentry from '@sentry/nextjs'
-import type Stripe from 'stripe'
+import Stripe from 'stripe'
 
 import { prisma } from '@/lib/db'
 import {
@@ -149,7 +149,6 @@ interface DugsiRecoveryMetadata {
   guardianPersonId: string
   familyName: string
   familyId: string | null
-  effectiveProfileIds: string[]
   standardRate: number
   actualAmount: number
 }
@@ -340,7 +339,6 @@ async function resolveDugsiFallbackFromCustomerEmail(
       guardianPersonId: guardian.id,
       familyName: guardian.name,
       familyId,
-      effectiveProfileIds,
       standardRate,
       actualAmount,
     },
@@ -398,7 +396,7 @@ async function resolveSubscriptionContext(
         accountType,
         stripeCustomerId: customerId,
         paymentMethodCaptured: true,
-        paymentMethodCapturedAt: new Date(),
+        paymentMethodCapturedAt: new Date(subscription.created * 1000),
       })
 
       const effectiveProfileIds =
@@ -448,11 +446,12 @@ async function resolveSubscriptionContext(
 async function patchRecoveredDugsiMetadata(
   subscriptionId: string,
   customerId: string,
-  recovery: DugsiRecoveryMetadata
+  recovery: DugsiRecoveryMetadata,
+  effectiveProfileIds: string[]
 ): Promise<void> {
   const dugsiStripe = getDugsiStripeClient()
 
-  const childCount = recovery.effectiveProfileIds.length
+  const childCount = effectiveProfileIds.length
 
   try {
     await dugsiStripe.subscriptions.update(subscriptionId, {
@@ -460,7 +459,7 @@ async function patchRecoveredDugsiMetadata(
         guardianPersonId: recovery.guardianPersonId,
         ...(recovery.familyId ? { familyId: recovery.familyId } : {}),
         childCount: String(childCount),
-        profileIds: recovery.effectiveProfileIds.join(','),
+        profileIds: effectiveProfileIds.join(','),
         calculatedRate: String(recovery.standardRate),
         overrideUsed: String(recovery.actualAmount !== recovery.standardRate),
         familyName: recovery.familyName,
@@ -477,7 +476,7 @@ async function patchRecoveredDugsiMetadata(
           subscriptionId,
           guardianPersonId: recovery.guardianPersonId,
           childCount,
-          derivedProfileIds: recovery.effectiveProfileIds,
+          derivedProfileIds: effectiveProfileIds,
         },
       }
     )
@@ -493,10 +492,7 @@ async function patchRecoveredDugsiMetadata(
     )
   } catch (metadataErr) {
     const isAuthError =
-      metadataErr !== null &&
-      typeof metadataErr === 'object' &&
-      'type' in metadataErr &&
-      (metadataErr as { type: unknown }).type === 'StripeAuthenticationError'
+      metadataErr instanceof Stripe.errors.StripeAuthenticationError
 
     if (isAuthError) {
       await logError(
@@ -758,7 +754,8 @@ export async function handleSubscriptionCreated(
     await patchRecoveredDugsiMetadata(
       subscription.id,
       customerId,
-      resolved.dugsiRecoveryMetadata
+      resolved.dugsiRecoveryMetadata,
+      resolved.effectiveProfileIds
     )
   }
 

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -208,19 +208,29 @@ async function resolveDugsiProfileIds(
   if (hints.length > 0) {
     const verified = await verifyDugsiProfileIdsForGuardian(personId, hints)
 
-    if (verified.length !== hints.length) {
-      logger.warn(
-        {
-          personId,
-          subscriptionId: subscription.id,
-          metadataProfileIds: hints,
-          verifiedProfileIds: verified,
-        },
-        'Ignoring unverified Dugsi profileIds from Stripe metadata'
-      )
+    if (verified.length > 0) {
+      if (verified.length < hints.length) {
+        logger.warn(
+          {
+            personId,
+            subscriptionId: subscription.id,
+            metadataProfileIds: hints,
+            verifiedProfileIds: verified,
+          },
+          'Partial Dugsi profileId verification: some metadata IDs failed — using verified subset'
+        )
+      }
+      return verified
     }
 
-    if (verified.length > 0) return verified
+    logger.warn(
+      {
+        personId,
+        subscriptionId: subscription.id,
+        metadataProfileIds: hints,
+      },
+      'All Dugsi profileIds from Stripe metadata failed verification — falling back to DB derivation'
+    )
   }
 
   const fallbackIds = await findBillableDugsiProfileIdsForGuardian(personId)
@@ -275,7 +285,6 @@ async function resolveDugsiFallbackFromCustomerEmail(
     logger.warn(
       {
         customerId,
-        customerEmail: normalizedEmail,
         subscriptionId: subscription.id,
       },
       'Path 4 fallback: Stripe customer email found but no matching Person record'

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -413,7 +413,7 @@ async function resolveSubscriptionContext(
 
   // Path 2: personId or guardianPersonId present in Stripe subscription metadata
   const metadataPersonId =
-    subscription.metadata?.personId ?? subscription.metadata?.guardianPersonId
+    subscription.metadata?.personId || subscription.metadata?.guardianPersonId
 
   if (metadataPersonId) {
     const verifiedPerson = await findPersonById(metadataPersonId)
@@ -547,16 +547,15 @@ async function patchRecoveredDugsiMetadata(
       },
     })
   } catch (metadataErr) {
-    const isOperationalError =
-      metadataErr instanceof Stripe.errors.StripeAuthenticationError ||
+    const isTransientError =
       metadataErr instanceof Stripe.errors.StripeConnectionError ||
       metadataErr instanceof Stripe.errors.StripeRateLimitError
 
-    if (isOperationalError) {
+    if (isTransientError) {
       await logError(
         logger,
         metadataErr,
-        'Path 4 fallback: transient/auth Stripe error — metadata patch skipped, subscription saved successfully',
+        'Path 4 fallback: transient Stripe error — metadata patch skipped, subscription saved successfully',
         { subscriptionId, customerId }
       )
       return

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -347,6 +347,20 @@ async function resolveDugsiFallbackFromCustomerEmail(
   const actualAmount =
     subscription.items.data[0]?.price?.unit_amount ?? standardRate
 
+  if (actualAmount !== standardRate) {
+    logger.warn(
+      {
+        subscriptionId: subscription.id,
+        customerId,
+        guardianPersonId: guardian.id,
+        stripeAmount: actualAmount,
+        calculatedRate: standardRate,
+        childCount,
+      },
+      'Path 4 fallback: Stripe amount differs from calculated Dugsi rate — custom rate in use'
+    )
+  }
+
   return {
     billingAccount,
     effectiveProfileIds,

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -767,12 +767,6 @@ export async function handleSubscriptionCreated(
     validateDugsiRateIfPresent(subscription)
   }
 
-  await linkProfilesIfPresent(
-    dbSubscription.id,
-    resolved.effectiveProfileIds,
-    subscription
-  )
-
   if (resolved.recoverySource === 'dugsi_email_fallback') {
     await patchRecoveredDugsiMetadata(
       subscription.id,
@@ -781,6 +775,12 @@ export async function handleSubscriptionCreated(
       resolved.effectiveProfileIds
     )
   }
+
+  await linkProfilesIfPresent(
+    dbSubscription.id,
+    resolved.effectiveProfileIds,
+    subscription
+  )
 
   if (accountType === StripeAccountType.MAHAD) {
     revalidateTag('mahad-students')

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -380,7 +380,7 @@ async function resolveSubscriptionContext(
 
   // Path 2: personId or guardianPersonId present in Stripe subscription metadata
   const metadataPersonId =
-    subscription.metadata?.personId || subscription.metadata?.guardianPersonId
+    subscription.metadata?.personId ?? subscription.metadata?.guardianPersonId
 
   if (metadataPersonId) {
     const verifiedPerson = await findPersonById(metadataPersonId)
@@ -507,10 +507,21 @@ async function patchRecoveredDugsiMetadata(
       await logError(
         logger,
         metadataErr,
-        'Path 4 fallback: Stripe API key invalid — metadata patch cannot proceed',
+        'Path 4 fallback: Stripe API key invalid — metadata patch skipped, subscription saved successfully',
         { subscriptionId, customerId }
       )
-      throw metadataErr
+      Sentry.captureMessage(
+        'Dugsi subscription metadata patch failed (auth error) — manual update required',
+        {
+          level: 'error',
+          extra: {
+            subscriptionId,
+            customerId,
+            guardianPersonId: recovery.guardianPersonId,
+          },
+        }
+      )
+      return
     }
 
     await logError(

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -205,7 +205,7 @@ async function resolveDugsiProfileIds(
     Sentry.captureMessage(
       'Dugsi subscription created without profile links — billing account has no personId',
       {
-        level: 'warning',
+        level: 'error',
         extra: { subscriptionId: subscription.id },
       }
     )
@@ -418,23 +418,7 @@ async function resolveSubscriptionContext(
   if (metadataPersonId) {
     const verifiedPerson = await findPersonById(metadataPersonId)
 
-    if (!verifiedPerson) {
-      logger.warn(
-        { customerId, metadataPersonId, subscriptionId: subscription.id },
-        'Path 2: metadataPersonId not found in DB — falling through to Path 3'
-      )
-      Sentry.captureMessage(
-        'Subscription metadata contains personId not found in database',
-        {
-          level: 'warning',
-          extra: {
-            customerId,
-            metadataPersonId,
-            subscriptionId: subscription.id,
-          },
-        }
-      )
-    } else {
+    if (verifiedPerson) {
       logger.info(
         {
           customerId,
@@ -463,6 +447,23 @@ async function resolveSubscriptionContext(
         recoverySource: 'metadata_person_id',
       }
     }
+
+    // Person ID in metadata not found in DB — fall through to Path 3
+    logger.warn(
+      { customerId, metadataPersonId, subscriptionId: subscription.id },
+      'Path 2: metadataPersonId not found in DB — falling through to Path 3'
+    )
+    Sentry.captureMessage(
+      'Subscription metadata contains personId not found in database',
+      {
+        level: 'warning',
+        extra: {
+          customerId,
+          metadataPersonId,
+          subscriptionId: subscription.id,
+        },
+      }
+    )
   }
 
   // Path 3: cross-program person lookup — finds a person via any billing account already
@@ -546,14 +547,16 @@ async function patchRecoveredDugsiMetadata(
       },
     })
   } catch (metadataErr) {
-    const isAuthError =
-      metadataErr instanceof Stripe.errors.StripeAuthenticationError
+    const isOperationalError =
+      metadataErr instanceof Stripe.errors.StripeAuthenticationError ||
+      metadataErr instanceof Stripe.errors.StripeConnectionError ||
+      metadataErr instanceof Stripe.errors.StripeRateLimitError
 
-    if (isAuthError) {
+    if (isOperationalError) {
       await logError(
         logger,
         metadataErr,
-        'Path 4 fallback: Stripe API key invalid — metadata patch skipped, subscription saved successfully',
+        'Path 4 fallback: transient/auth Stripe error — metadata patch skipped, subscription saved successfully',
         { subscriptionId, customerId }
       )
       return

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -718,6 +718,10 @@ async function linkProfilesIfPresent(
   const priceAmount = subscription.items.data[0]?.price?.unit_amount
   if (priceAmount === null || priceAmount === undefined || priceAmount <= 0) {
     const error = new Error('Subscription has invalid amount')
+    Sentry.captureException(error, {
+      level: 'error',
+      extra: { subscriptionId: subscription.id, priceAmount },
+    })
     await logError(
       logger,
       error,

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -359,7 +359,7 @@ async function resolveDugsiFallbackFromCustomerEmail(
 
   const standardRate = calculateDugsiRate(childCount)
   const actualAmount =
-    subscription.items.data[0]?.price?.unit_amount ?? standardRate
+    subscription.items.data[0]?.price?.unit_amount || standardRate
 
   if (actualAmount !== standardRate) {
     logger.warn(

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -350,6 +350,7 @@ async function resolveDugsiFallbackFromCustomerEmail(
       {
         guardianPersonId: guardian.id,
         familyIds: [...uniqueFamilyIds],
+        subscriptionId: subscription.id,
       },
       'Path 4 fallback: guardian spans multiple families — using first family ID'
     )
@@ -561,6 +562,8 @@ async function patchRecoveredDugsiMetadata(
       return
     }
 
+    // Non-transient errors are also swallowed — billing data is already committed
+    // and the metadata patch is best-effort. Sentry alert fires so on-call can investigate.
     Sentry.captureException(metadataErr, {
       extra: {
         subscriptionId,

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -240,6 +240,13 @@ async function resolveDugsiProfileIds(
       { personId, subscriptionId: subscription.id },
       'resolveDugsiProfileIds: no billable Dugsi profiles found via metadata or DB fallback — subscription will be created without profile links'
     )
+    Sentry.captureMessage(
+      'Dugsi subscription created without profile links — manual review required',
+      {
+        level: 'warning',
+        extra: { personId, subscriptionId: subscription.id },
+      }
+    )
   }
 
   return fallbackIds
@@ -510,17 +517,6 @@ async function patchRecoveredDugsiMetadata(
         'Path 4 fallback: Stripe API key invalid — metadata patch skipped, subscription saved successfully',
         { subscriptionId, customerId }
       )
-      Sentry.captureMessage(
-        'Dugsi subscription metadata patch failed (auth error) — manual update required',
-        {
-          level: 'error',
-          extra: {
-            subscriptionId,
-            customerId,
-            guardianPersonId: recovery.guardianPersonId,
-          },
-        }
-      )
       return
     }
 
@@ -532,17 +528,6 @@ async function patchRecoveredDugsiMetadata(
         subscriptionId,
         customerId,
         guardianPersonId: recovery.guardianPersonId,
-      }
-    )
-    Sentry.captureMessage(
-      'Dugsi subscription metadata patch failed — manual intervention required',
-      {
-        level: 'error',
-        extra: {
-          subscriptionId,
-          customerId,
-          guardianPersonId: recovery.guardianPersonId,
-        },
       }
     )
   }

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -327,6 +327,9 @@ async function resolveDugsiFallbackFromCustomerEmail(
     throw buildNoPersonFoundError(customerId)
   }
 
+  // Unlike Paths 1-3 where createOrUpdateBillingAccount is called in the orchestrator,
+  // Path 4 writes it here inside the resolver. On a retry, the billing account exists
+  // so the orchestrator takes Path 1 instead — this is intentional and correct.
   const billingAccount = await createOrUpdateBillingAccount({
     personId: guardian.id,
     accountType: StripeAccountType.DUGSI,
@@ -556,6 +559,13 @@ async function patchRecoveredDugsiMetadata(
       return
     }
 
+    Sentry.captureException(metadataErr, {
+      extra: {
+        subscriptionId,
+        customerId,
+        guardianPersonId: recovery.guardianPersonId,
+      },
+    })
     await logError(
       logger,
       metadataErr,
@@ -782,6 +792,8 @@ export async function handleSubscriptionCreated(
   }
 
   if (accountType === StripeAccountType.DUGSI) {
+    // For Path 4 subscriptions this is a no-op: metadata is empty on first delivery.
+    // Path 4's own rate check runs inside resolveDugsiFallbackFromCustomerEmail.
     validateDugsiRateIfPresent(subscription)
   }
 

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -202,6 +202,13 @@ async function resolveDugsiProfileIds(
       { subscriptionId: subscription.id },
       'resolveDugsiProfileIds: billing account has no personId — cannot resolve profile IDs'
     )
+    Sentry.captureMessage(
+      'Dugsi subscription created without profile links — billing account has no personId',
+      {
+        level: 'warning',
+        extra: { subscriptionId: subscription.id },
+      }
+    )
     return []
   }
 
@@ -412,6 +419,17 @@ async function resolveSubscriptionContext(
       logger.warn(
         { customerId, metadataPersonId, subscriptionId: subscription.id },
         'Path 2: metadataPersonId not found in DB — falling through to Path 3'
+      )
+      Sentry.captureMessage(
+        'Subscription metadata contains personId not found in database',
+        {
+          level: 'warning',
+          extra: {
+            customerId,
+            metadataPersonId,
+            subscriptionId: subscription.id,
+          },
+        }
       )
     } else {
       logger.info(

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -700,7 +700,8 @@ function validateDugsiRateIfPresent(subscription: Stripe.Subscription): void {
 async function linkProfilesIfPresent(
   dbSubscriptionId: string,
   profileIds: string[],
-  subscription: Stripe.Subscription
+  subscription: Stripe.Subscription,
+  overrideAmount?: number
 ): Promise<void> {
   if (profileIds.length === 0) return
 
@@ -715,7 +716,8 @@ async function linkProfilesIfPresent(
     throw error
   }
 
-  const priceAmount = subscription.items.data[0]?.price?.unit_amount
+  const priceAmount =
+    overrideAmount ?? subscription.items.data[0]?.price?.unit_amount
   if (priceAmount === null || priceAmount === undefined || priceAmount <= 0) {
     const error = new Error('Subscription has invalid amount')
     Sentry.captureException(error, {
@@ -779,6 +781,11 @@ export async function handleSubscriptionCreated(
     customerId
   )
 
+  const dugsiActualAmount =
+    resolved.recoverySource === 'dugsi_email_fallback'
+      ? resolved.dugsiRecoveryMetadata.actualAmount
+      : undefined
+
   const dbSubscription = await Sentry.startSpan(
     {
       name: 'subscription.create_from_stripe',
@@ -793,7 +800,8 @@ export async function handleSubscriptionCreated(
       await createSubscriptionFromStripe(
         subscription,
         resolved.billingAccount.id,
-        accountType
+        accountType,
+        dugsiActualAmount
       )
   )
 
@@ -819,7 +827,8 @@ export async function handleSubscriptionCreated(
   await linkProfilesIfPresent(
     dbSubscription.id,
     resolved.effectiveProfileIds,
-    subscription
+    subscription,
+    dugsiActualAmount
   )
 
   if (accountType === StripeAccountType.MAHAD) {

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -30,14 +30,16 @@ import {
   getSubscriptionByStripeId,
   getBillingAssignmentsBySubscription,
   updateSubscriptionStatus as updateSubscriptionStatusQuery,
-  findPersonByStripeCustomerId,
 } from '@/lib/db/queries/billing'
 import {
   findGuardianWithBillableDugsiChildren,
   verifyDugsiProfileIdsForGuardian,
   findBillableDugsiProfileIdsForGuardian,
 } from '@/lib/db/queries/dugsi-profiles'
-import { findPersonById } from '@/lib/db/queries/program-profile'
+import {
+  findPersonById,
+  findPersonByStripeCustomerId,
+} from '@/lib/db/queries/person'
 import type { DatabaseClient } from '@/lib/db/types'
 import { createServiceLogger, logError } from '@/lib/logger'
 import {
@@ -483,6 +485,32 @@ async function patchRecoveredDugsiMetadata(
 
   const childCount = effectiveProfileIds.length
 
+  // Emit observability signals unconditionally — DB writes are already committed at this point.
+  // The Stripe metadata patch below is best-effort; these signals must not depend on its success.
+  Sentry.captureMessage(
+    'Dugsi subscription resolved via customer email fallback',
+    {
+      level: 'info',
+      extra: {
+        customerId,
+        subscriptionId,
+        guardianPersonId: recovery.guardianPersonId,
+        childCount,
+        derivedProfileIds: effectiveProfileIds,
+      },
+    }
+  )
+
+  logger.warn(
+    {
+      customerId,
+      subscriptionId,
+      guardianPersonId: recovery.guardianPersonId,
+      childCount,
+    },
+    'Subscription created without metadata — resolved via Stripe customer email fallback'
+  )
+
   try {
     await dugsiStripe.subscriptions.update(subscriptionId, {
       metadata: {
@@ -496,30 +524,6 @@ async function patchRecoveredDugsiMetadata(
         source: 'dugsi-webhook-fallback-recovery',
       },
     })
-
-    Sentry.captureMessage(
-      'Dugsi subscription resolved via customer email fallback',
-      {
-        level: 'info',
-        extra: {
-          customerId,
-          subscriptionId,
-          guardianPersonId: recovery.guardianPersonId,
-          childCount,
-          derivedProfileIds: effectiveProfileIds,
-        },
-      }
-    )
-
-    logger.warn(
-      {
-        customerId,
-        subscriptionId,
-        guardianPersonId: recovery.guardianPersonId,
-        childCount,
-      },
-      'Subscription created without metadata — resolved via Stripe customer email fallback'
-    )
   } catch (metadataErr) {
     const isAuthError =
       metadataErr instanceof Stripe.errors.StripeAuthenticationError

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -30,7 +30,14 @@ import {
   getSubscriptionByStripeId,
   getBillingAssignmentsBySubscription,
   updateSubscriptionStatus as updateSubscriptionStatusQuery,
+  findPersonByStripeCustomerId,
 } from '@/lib/db/queries/billing'
+import {
+  findGuardianWithBillableDugsiChildren,
+  verifyDugsiProfileIdsForGuardian,
+  findBillableDugsiProfileIdsForGuardian,
+} from '@/lib/db/queries/dugsi-profiles'
+import { findPersonById } from '@/lib/db/queries/program-profile'
 import type { DatabaseClient } from '@/lib/db/types'
 import { createServiceLogger, logError } from '@/lib/logger'
 import {
@@ -39,6 +46,8 @@ import {
   unlinkSubscription,
 } from '@/lib/services/shared/billing-service'
 import { createSubscriptionFromStripe } from '@/lib/services/shared/subscription-service'
+import { getDugsiStripeClient } from '@/lib/stripe-dugsi'
+import { normalizeEmail } from '@/lib/utils/contact-normalization'
 import { calculateDugsiRate } from '@/lib/utils/dugsi-tuition'
 import { calculateMahadRate } from '@/lib/utils/mahad-tuition'
 import {
@@ -128,42 +137,253 @@ export async function handlePaymentMethodCapture(
   }
 }
 
-/**
- * Handle subscription creation event.
- *
- * Called when customer.subscription.created event is received.
- * Creates subscription in database and links to profiles.
- *
- * @param subscription - Stripe subscription object
- * @param accountType - Stripe account type
- * @param profileIds - Program profile IDs to link (optional)
- * @returns Subscription event result
- */
-export async function handleSubscriptionCreated(
-  subscription: Stripe.Subscription,
-  accountType: StripeAccountType,
-  profileIds?: string[]
-): Promise<SubscriptionEventResult> {
-  const customerId = extractCustomerId(subscription.customer)
+// ─── Types ──────────────────────────────────────────────────────────────────
 
-  if (!customerId) {
-    throw new Error('Invalid customer ID in subscription')
+type RecoverySource =
+  | 'existing_billing_account'
+  | 'metadata_person_id'
+  | 'existing_person_by_customer'
+  | 'dugsi_email_fallback'
+
+interface DugsiRecoveryMetadata {
+  guardianPersonId: string
+  familyName: string
+  familyId: string | null
+  effectiveProfileIds: string[]
+  standardRate: number
+  actualAmount: number
+}
+
+type ResolvedSubscriptionContext =
+  | {
+      billingAccount: { id: string; personId: string | null }
+      effectiveProfileIds: string[]
+      recoverySource: Exclude<RecoverySource, 'dugsi_email_fallback'>
+    }
+  | {
+      billingAccount: { id: string; personId: string | null }
+      effectiveProfileIds: string[]
+      recoverySource: 'dugsi_email_fallback'
+      dugsiRecoveryMetadata: DugsiRecoveryMetadata
+    }
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function buildNoPersonFoundError(customerId: string): Error {
+  return new Error(
+    `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`
+  )
+}
+
+function extractMetadataProfileIdHints(
+  subscription: Stripe.Subscription
+): string[] {
+  const metadata = subscription.metadata ?? {}
+  if (metadata.profileIds) {
+    return metadata.profileIds
+      .split(',')
+      .map((id) => id.trim())
+      .filter(Boolean)
+  }
+  if (metadata.profileId) {
+    return [metadata.profileId]
+  }
+  return []
+}
+
+async function resolveDugsiProfileIds(
+  billingAccount: { personId: string | null },
+  subscription: Stripe.Subscription
+): Promise<string[]> {
+  const personId = billingAccount.personId
+  if (!personId) {
+    logger.warn(
+      { subscriptionId: subscription.id },
+      'resolveDugsiProfileIds: billing account has no personId — cannot resolve profile IDs'
+    )
+    return []
   }
 
-  // Get or create billing account
-  let billingAccount = await getBillingAccountByStripeCustomerId(
+  const hints = extractMetadataProfileIdHints(subscription)
+
+  if (hints.length > 0) {
+    const verified = await verifyDugsiProfileIdsForGuardian(personId, hints)
+
+    if (verified.length !== hints.length) {
+      logger.warn(
+        {
+          personId,
+          subscriptionId: subscription.id,
+          metadataProfileIds: hints,
+          verifiedProfileIds: verified,
+        },
+        'Ignoring unverified Dugsi profileIds from Stripe metadata'
+      )
+    }
+
+    if (verified.length > 0) return verified
+  }
+
+  const fallbackIds = await findBillableDugsiProfileIdsForGuardian(personId)
+
+  if (fallbackIds.length === 0) {
+    logger.warn(
+      { personId, subscriptionId: subscription.id },
+      'resolveDugsiProfileIds: no billable Dugsi profiles found via metadata or DB fallback — subscription will be created without profile links'
+    )
+  }
+
+  return fallbackIds
+}
+
+async function resolveDugsiFallbackFromCustomerEmail(
+  subscription: Stripe.Subscription,
+  customerId: string
+): Promise<ResolvedSubscriptionContext> {
+  const dugsiStripe = getDugsiStripeClient()
+
+  let stripeCustomer: Stripe.Customer | Stripe.DeletedCustomer
+  try {
+    stripeCustomer = await dugsiStripe.customers.retrieve(customerId)
+  } catch (stripeErr) {
+    await logError(
+      logger,
+      stripeErr,
+      'Path 4 fallback: Failed to retrieve Stripe customer',
+      { customerId, subscriptionId: subscription.id }
+    )
+    throw stripeErr
+  }
+
+  const customerEmail = stripeCustomer.deleted ? null : stripeCustomer.email
+  const normalizedEmail = normalizeEmail(customerEmail)
+
+  if (!normalizedEmail) {
+    logger.warn(
+      {
+        customerId,
+        subscriptionId: subscription.id,
+        isDeleted: stripeCustomer.deleted ?? false,
+      },
+      'Path 4 fallback: Stripe customer has no email address, cannot resolve guardian'
+    )
+    throw buildNoPersonFoundError(customerId)
+  }
+
+  const guardian = await findGuardianWithBillableDugsiChildren(normalizedEmail)
+
+  if (!guardian) {
+    logger.warn(
+      {
+        customerId,
+        customerEmail: normalizedEmail,
+        subscriptionId: subscription.id,
+      },
+      'Path 4 fallback: Stripe customer email found but no matching Person record'
+    )
+    throw buildNoPersonFoundError(customerId)
+  }
+
+  const rawProfiles = guardian.guardianRelationships.flatMap(
+    (rel) => rel.dependent.programProfiles
+  )
+  const familyProfiles = Array.from(
+    new Map(rawProfiles.map((p) => [p.id, p])).values()
+  )
+
+  if (familyProfiles.length === 0) {
+    logger.warn(
+      {
+        customerId,
+        guardianPersonId: guardian.id,
+        subscriptionId: subscription.id,
+      },
+      'Path 4 fallback: Cannot create billing account — guardian has no enrolled Dugsi children'
+    )
+    throw buildNoPersonFoundError(customerId)
+  }
+
+  const billingAccount = await createOrUpdateBillingAccount({
+    personId: guardian.id,
+    accountType: StripeAccountType.DUGSI,
+    stripeCustomerId: customerId,
+    paymentMethodCaptured: true,
+    paymentMethodCapturedAt: new Date(subscription.created * 1000),
+  })
+
+  const effectiveProfileIds = familyProfiles.map((p) => p.id)
+  const childCount = familyProfiles.length
+  const familyId = familyProfiles[0]?.familyReferenceId ?? null
+
+  const uniqueFamilyIds = new Set(
+    familyProfiles.map((p) => p.familyReferenceId).filter(Boolean)
+  )
+  if (uniqueFamilyIds.size > 1) {
+    logger.warn(
+      {
+        guardianPersonId: guardian.id,
+        familyIds: [...uniqueFamilyIds],
+      },
+      'Path 4 fallback: guardian spans multiple families — using first family ID'
+    )
+  }
+
+  const standardRate = calculateDugsiRate(childCount)
+  const actualAmount =
+    subscription.items.data[0]?.price?.unit_amount ?? standardRate
+
+  return {
+    billingAccount,
+    effectiveProfileIds,
+    recoverySource: 'dugsi_email_fallback',
+    dugsiRecoveryMetadata: {
+      guardianPersonId: guardian.id,
+      familyName: guardian.name,
+      familyId,
+      effectiveProfileIds,
+      standardRate,
+      actualAmount,
+    },
+  }
+}
+
+async function resolveSubscriptionContext(
+  subscription: Stripe.Subscription,
+  accountType: StripeAccountType,
+  customerId: string
+): Promise<ResolvedSubscriptionContext> {
+  // Path 1: billing account already exists for this Stripe customer
+  const existingBillingAccount = await getBillingAccountByStripeCustomerId(
     customerId,
     accountType
   )
 
-  if (!billingAccount) {
-    // Check for personId (Mahad) or guardianPersonId (Dugsi) in subscription metadata
-    const metadataPersonId =
-      subscription.metadata?.personId || subscription.metadata?.guardianPersonId // Mahad // Dugsi
+  if (existingBillingAccount) {
+    const effectiveProfileIds =
+      accountType === StripeAccountType.DUGSI
+        ? await resolveDugsiProfileIds(existingBillingAccount, subscription)
+        : extractMetadataProfileIdHints(subscription)
 
-    if (metadataPersonId) {
-      // Use person ID from metadata to create billing account
-      // Handles race condition where subscription.created arrives before checkout.completed
+    return {
+      billingAccount: existingBillingAccount,
+      effectiveProfileIds,
+      recoverySource: 'existing_billing_account',
+    }
+  }
+
+  // Path 2: personId or guardianPersonId present in Stripe subscription metadata
+  const metadataPersonId =
+    subscription.metadata?.personId || subscription.metadata?.guardianPersonId
+
+  if (metadataPersonId) {
+    const verifiedPerson = await findPersonById(metadataPersonId)
+
+    if (!verifiedPerson) {
+      logger.warn(
+        { customerId, metadataPersonId, subscriptionId: subscription.id },
+        'Path 2: metadataPersonId not found in DB — falling through to Path 3'
+      )
+    } else {
       logger.info(
         {
           customerId,
@@ -173,43 +393,335 @@ export async function handleSubscriptionCreated(
         'Creating billing account from subscription metadata'
       )
 
-      billingAccount = await createOrUpdateBillingAccount({
+      const billingAccount = await createOrUpdateBillingAccount({
         personId: metadataPersonId,
         accountType,
         stripeCustomerId: customerId,
         paymentMethodCaptured: true,
         paymentMethodCapturedAt: new Date(),
       })
-    } else {
-      // Fall back to finding person by existing billing account (for non-Mahad subscriptions)
-      const person = await prisma.person.findFirst({
-        where: {
-          billingAccounts: {
-            some: {
-              OR: [
-                { stripeCustomerIdMahad: customerId },
-                { stripeCustomerIdDugsi: customerId },
-              ],
-            },
-          },
-        },
-      })
 
-      if (!person) {
-        throw new Error(
-          `No person found for customer ${customerId}. Payment method must be captured first or subscription metadata must include personId/guardianPersonId.`
-        )
+      const effectiveProfileIds =
+        accountType === StripeAccountType.DUGSI
+          ? await resolveDugsiProfileIds(billingAccount, subscription)
+          : extractMetadataProfileIdHints(subscription)
+
+      return {
+        billingAccount,
+        effectiveProfileIds,
+        recoverySource: 'metadata_person_id',
       }
-
-      billingAccount = await createOrUpdateBillingAccount({
-        personId: person.id,
-        accountType,
-        stripeCustomerId: customerId,
-      })
     }
   }
 
-  // Create subscription in database
+  // Path 3: cross-program person lookup — finds a person via any billing account already
+  // linked to this Stripe customer ID (searches both Mahad and Dugsi customer ID columns)
+  const existingPerson = await findPersonByStripeCustomerId(customerId)
+
+  if (existingPerson) {
+    const billingAccount = await createOrUpdateBillingAccount({
+      personId: existingPerson.id,
+      accountType,
+      stripeCustomerId: customerId,
+    })
+
+    const effectiveProfileIds =
+      accountType === StripeAccountType.DUGSI
+        ? await resolveDugsiProfileIds(billingAccount, subscription)
+        : extractMetadataProfileIdHints(subscription)
+
+    return {
+      billingAccount,
+      effectiveProfileIds,
+      recoverySource: 'existing_person_by_customer',
+    }
+  }
+
+  // Path 4: Dugsi-only email fallback for subscriptions manually created in the Stripe dashboard
+  if (accountType === StripeAccountType.DUGSI) {
+    return resolveDugsiFallbackFromCustomerEmail(subscription, customerId)
+  }
+
+  throw buildNoPersonFoundError(customerId)
+}
+
+async function patchRecoveredDugsiMetadata(
+  subscriptionId: string,
+  customerId: string,
+  recovery: DugsiRecoveryMetadata
+): Promise<void> {
+  const dugsiStripe = getDugsiStripeClient()
+
+  const childCount = recovery.effectiveProfileIds.length
+
+  try {
+    await dugsiStripe.subscriptions.update(subscriptionId, {
+      metadata: {
+        guardianPersonId: recovery.guardianPersonId,
+        ...(recovery.familyId ? { familyId: recovery.familyId } : {}),
+        childCount: String(childCount),
+        profileIds: recovery.effectiveProfileIds.join(','),
+        calculatedRate: String(recovery.standardRate),
+        overrideUsed: String(recovery.actualAmount !== recovery.standardRate),
+        familyName: recovery.familyName,
+        source: 'dugsi-webhook-fallback-recovery',
+      },
+    })
+
+    Sentry.captureMessage(
+      'Dugsi subscription resolved via customer email fallback',
+      {
+        level: 'warning',
+        extra: {
+          customerId,
+          subscriptionId,
+          guardianPersonId: recovery.guardianPersonId,
+          childCount,
+          derivedProfileIds: recovery.effectiveProfileIds,
+        },
+      }
+    )
+
+    logger.warn(
+      {
+        customerId,
+        subscriptionId,
+        guardianPersonId: recovery.guardianPersonId,
+        childCount,
+      },
+      'Subscription created without metadata — resolved via Stripe customer email fallback'
+    )
+  } catch (metadataErr) {
+    const isAuthError =
+      metadataErr !== null &&
+      typeof metadataErr === 'object' &&
+      'type' in metadataErr &&
+      (metadataErr as { type: unknown }).type === 'StripeAuthenticationError'
+
+    if (isAuthError) {
+      await logError(
+        logger,
+        metadataErr,
+        'Path 4 fallback: Stripe API key invalid — metadata patch cannot proceed',
+        { subscriptionId, customerId }
+      )
+      throw metadataErr
+    }
+
+    await logError(
+      logger,
+      metadataErr,
+      'Path 4 fallback: Failed to patch Stripe subscription metadata — manual update required',
+      {
+        subscriptionId,
+        customerId,
+        guardianPersonId: recovery.guardianPersonId,
+      }
+    )
+    Sentry.captureMessage(
+      'Dugsi subscription metadata patch failed — manual intervention required',
+      {
+        level: 'error',
+        extra: {
+          subscriptionId,
+          customerId,
+          guardianPersonId: recovery.guardianPersonId,
+        },
+      }
+    )
+  }
+}
+
+function validateMahadRateIfPresent(subscription: Stripe.Subscription): void {
+  const metadata = subscription.metadata || {}
+  if (
+    !metadata.calculatedRate ||
+    !metadata.graduationStatus ||
+    !metadata.paymentFrequency ||
+    !metadata.billingType
+  ) {
+    return
+  }
+
+  const priceAmount = subscription.items?.data?.[0]?.price?.unit_amount
+  const expectedRate = parseInt(metadata.calculatedRate, 10)
+
+  const actualCalculatedRate = calculateMahadRate(
+    metadata.graduationStatus as GraduationStatus,
+    metadata.paymentFrequency as PaymentFrequency,
+    metadata.billingType as StudentBillingType
+  )
+
+  if (priceAmount !== expectedRate) {
+    logger.warn(
+      {
+        subscriptionId: subscription.id,
+        stripeAmount: priceAmount,
+        expectedRate,
+        graduationStatus: metadata.graduationStatus,
+        paymentFrequency: metadata.paymentFrequency,
+        billingType: metadata.billingType,
+      },
+      'Rate mismatch: Stripe amount differs from expected calculated rate'
+    )
+  }
+
+  if (actualCalculatedRate !== expectedRate) {
+    logger.warn(
+      {
+        subscriptionId: subscription.id,
+        metadataRate: expectedRate,
+        recalculatedRate: actualCalculatedRate,
+        graduationStatus: metadata.graduationStatus,
+        paymentFrequency: metadata.paymentFrequency,
+        billingType: metadata.billingType,
+      },
+      'Rate calculation mismatch: Stored metadata rate differs from recalculated rate'
+    )
+  }
+
+  if (priceAmount === expectedRate && actualCalculatedRate === expectedRate) {
+    logger.info(
+      {
+        subscriptionId: subscription.id,
+        profileId: metadata.profileId,
+        studentName: metadata.studentName,
+        stripeAmount: priceAmount,
+        expectedRate,
+        graduationStatus: metadata.graduationStatus,
+        paymentFrequency: metadata.paymentFrequency,
+        billingType: metadata.billingType,
+      },
+      'Mahad subscription rate validation completed'
+    )
+  }
+}
+
+function validateDugsiRateIfPresent(subscription: Stripe.Subscription): void {
+  const metadata = subscription.metadata || {}
+  if (!metadata.calculatedRate || !metadata.childCount) return
+
+  const priceAmount = subscription.items?.data?.[0]?.price?.unit_amount
+  const expectedRate = parseInt(metadata.calculatedRate, 10)
+  const childCount = parseInt(metadata.childCount, 10)
+
+  const actualCalculatedRate = calculateDugsiRate(childCount)
+
+  if (priceAmount !== expectedRate) {
+    logger.warn(
+      {
+        subscriptionId: subscription.id,
+        stripeAmount: priceAmount,
+        expectedRate,
+        childCount,
+      },
+      'Rate mismatch: Stripe amount differs from expected calculated rate'
+    )
+  }
+
+  if (actualCalculatedRate !== expectedRate) {
+    logger.warn(
+      {
+        subscriptionId: subscription.id,
+        metadataRate: expectedRate,
+        recalculatedRate: actualCalculatedRate,
+        childCount,
+      },
+      'Rate calculation mismatch: Stored metadata rate differs from recalculated rate'
+    )
+  }
+
+  if (priceAmount === expectedRate && actualCalculatedRate === expectedRate) {
+    logger.info(
+      {
+        subscriptionId: subscription.id,
+        stripeAmount: priceAmount,
+        expectedRate,
+        childCount,
+      },
+      'Dugsi subscription rate validation completed'
+    )
+  }
+}
+
+async function linkProfilesIfPresent(
+  dbSubscriptionId: string,
+  profileIds: string[],
+  subscription: Stripe.Subscription
+): Promise<void> {
+  if (profileIds.length === 0) return
+
+  if (!subscription.items?.data?.length) {
+    const error = new Error('Subscription has no items')
+    await logError(
+      logger,
+      error,
+      'Subscription has no items - cannot link to profiles',
+      { subscriptionId: subscription.id }
+    )
+    throw error
+  }
+
+  const priceAmount = subscription.items.data[0]?.price?.unit_amount
+  if (priceAmount === null || priceAmount === undefined || priceAmount <= 0) {
+    const error = new Error('Subscription has invalid amount')
+    await logError(
+      logger,
+      error,
+      'Subscription has invalid amount - cannot link to profiles',
+      { subscriptionId: subscription.id, priceAmount }
+    )
+    throw error
+  }
+
+  await Sentry.startSpan(
+    {
+      name: 'subscription.link_profiles',
+      op: 'db.transaction',
+      attributes: {
+        subscription_id: dbSubscriptionId,
+        num_profiles: profileIds.length,
+        amount: priceAmount,
+      },
+    },
+    async () =>
+      await linkSubscriptionToProfiles(
+        dbSubscriptionId,
+        profileIds,
+        priceAmount,
+        'Linked automatically via webhook'
+      )
+  )
+}
+
+// ─── Orchestrator ────────────────────────────────────────────────────────────
+
+/**
+ * Handle subscription creation event.
+ *
+ * Called when customer.subscription.created event is received.
+ * Creates subscription in database and links to profiles.
+ *
+ * @param subscription - Stripe subscription object
+ * @param accountType - Stripe account type
+ * @returns Subscription event result
+ */
+export async function handleSubscriptionCreated(
+  subscription: Stripe.Subscription,
+  accountType: StripeAccountType
+): Promise<SubscriptionEventResult> {
+  const customerId = extractCustomerId(subscription.customer)
+
+  if (!customerId) {
+    throw new Error('Invalid customer ID in subscription')
+  }
+
+  const resolved = await resolveSubscriptionContext(
+    subscription,
+    accountType,
+    customerId
+  )
+
   const dbSubscription = await Sentry.startSpan(
     {
       name: 'subscription.create_from_stripe',
@@ -217,183 +729,42 @@ export async function handleSubscriptionCreated(
       attributes: {
         account_type: accountType,
         stripe_subscription_id: subscription.id,
-        billing_account_id: billingAccount.id,
+        billing_account_id: resolved.billingAccount.id,
       },
     },
     async () =>
       await createSubscriptionFromStripe(
         subscription,
-        billingAccount.id,
+        resolved.billingAccount.id,
         accountType
       )
   )
 
-  // Validate rate against calculated rate if metadata is present (Mahad checkout)
-  const subscriptionMetadata = subscription.metadata || {}
-  if (
-    accountType === 'MAHAD' &&
-    subscriptionMetadata.calculatedRate &&
-    subscriptionMetadata.graduationStatus &&
-    subscriptionMetadata.paymentFrequency &&
-    subscriptionMetadata.billingType
-  ) {
-    const priceAmount = subscription.items?.data?.[0]?.price?.unit_amount
-    const expectedRate = parseInt(subscriptionMetadata.calculatedRate, 10)
+  if (accountType === StripeAccountType.MAHAD) {
+    validateMahadRateIfPresent(subscription)
+  }
 
-    // Validate that the checkout session calculated rate matches the actual rate
-    const actualCalculatedRate = calculateMahadRate(
-      subscriptionMetadata.graduationStatus as GraduationStatus,
-      subscriptionMetadata.paymentFrequency as PaymentFrequency,
-      subscriptionMetadata.billingType as StudentBillingType
-    )
+  if (accountType === StripeAccountType.DUGSI) {
+    validateDugsiRateIfPresent(subscription)
+  }
 
-    if (priceAmount !== expectedRate) {
-      logger.warn(
-        {
-          subscriptionId: subscription.id,
-          stripeAmount: priceAmount,
-          expectedRate,
-          graduationStatus: subscriptionMetadata.graduationStatus,
-          paymentFrequency: subscriptionMetadata.paymentFrequency,
-          billingType: subscriptionMetadata.billingType,
-        },
-        'Rate mismatch: Stripe amount differs from expected calculated rate'
-      )
-    }
+  await linkProfilesIfPresent(
+    dbSubscription.id,
+    resolved.effectiveProfileIds,
+    subscription
+  )
 
-    if (actualCalculatedRate !== expectedRate) {
-      logger.warn(
-        {
-          subscriptionId: subscription.id,
-          metadataRate: expectedRate,
-          recalculatedRate: actualCalculatedRate,
-          graduationStatus: subscriptionMetadata.graduationStatus,
-          paymentFrequency: subscriptionMetadata.paymentFrequency,
-          billingType: subscriptionMetadata.billingType,
-        },
-        'Rate calculation mismatch: Stored metadata rate differs from recalculated rate'
-      )
-    }
-
-    logger.info(
-      {
-        subscriptionId: subscription.id,
-        profileId: subscriptionMetadata.profileId,
-        studentName: subscriptionMetadata.studentName,
-        stripeAmount: priceAmount,
-        expectedRate,
-        graduationStatus: subscriptionMetadata.graduationStatus,
-        paymentFrequency: subscriptionMetadata.paymentFrequency,
-        billingType: subscriptionMetadata.billingType,
-        rateValid: priceAmount === expectedRate,
-      },
-      'Mahad subscription rate validation completed'
+  if (resolved.recoverySource === 'dugsi_email_fallback') {
+    await patchRecoveredDugsiMetadata(
+      subscription.id,
+      customerId,
+      resolved.dugsiRecoveryMetadata
     )
   }
 
-  // Validate rate for Dugsi subscriptions
-  if (
-    accountType === 'DUGSI' &&
-    subscriptionMetadata.calculatedRate &&
-    subscriptionMetadata.childCount
-  ) {
-    const priceAmount = subscription.items?.data?.[0]?.price?.unit_amount
-    const expectedRate = parseInt(subscriptionMetadata.calculatedRate, 10)
-    const childCount = parseInt(subscriptionMetadata.childCount, 10)
-
-    const actualCalculatedRate = calculateDugsiRate(childCount)
-
-    if (priceAmount !== expectedRate) {
-      logger.warn(
-        {
-          subscriptionId: subscription.id,
-          stripeAmount: priceAmount,
-          expectedRate,
-          childCount,
-        },
-        'Rate mismatch: Stripe amount differs from expected calculated rate'
-      )
-    }
-
-    if (actualCalculatedRate !== expectedRate) {
-      logger.warn(
-        {
-          subscriptionId: subscription.id,
-          metadataRate: expectedRate,
-          recalculatedRate: actualCalculatedRate,
-          childCount,
-        },
-        'Rate calculation mismatch: Stored metadata rate differs from recalculated rate'
-      )
-    }
-
-    logger.info(
-      {
-        subscriptionId: subscription.id,
-        stripeAmount: priceAmount,
-        expectedRate,
-        childCount,
-        rateValid: priceAmount === expectedRate,
-      },
-      'Dugsi subscription rate validation completed'
-    )
-  }
-
-  // Link to profiles if provided
-  if (profileIds && profileIds.length > 0) {
-    // Validate subscription has items with valid pricing
-    if (!subscription.items?.data?.length) {
-      const error = new Error('Subscription has no items')
-      await logError(
-        logger,
-        error,
-        'Subscription has no items - cannot link to profiles',
-        {
-          subscriptionId: subscription.id,
-        }
-      )
-      throw error
-    }
-
-    const priceAmount = subscription.items.data[0]?.price?.unit_amount
-    if (priceAmount === null || priceAmount === undefined || priceAmount <= 0) {
-      const error = new Error('Subscription has invalid amount')
-      await logError(
-        logger,
-        error,
-        'Subscription has invalid amount - cannot link to profiles',
-        {
-          subscriptionId: subscription.id,
-          priceAmount,
-        }
-      )
-      throw error
-    }
-
-    const amount = priceAmount
-    await Sentry.startSpan(
-      {
-        name: 'subscription.link_profiles',
-        op: 'db.transaction',
-        attributes: {
-          subscription_id: dbSubscription.id,
-          num_profiles: profileIds.length,
-          amount,
-        },
-      },
-      async () =>
-        await linkSubscriptionToProfiles(
-          dbSubscription.id,
-          profileIds,
-          amount,
-          'Linked automatically via webhook'
-        )
-    )
-  }
-
-  if (accountType === 'MAHAD') {
+  if (accountType === StripeAccountType.MAHAD) {
     revalidateTag('mahad-students')
-  } else if (accountType === 'DUGSI') {
+  } else if (accountType === StripeAccountType.DUGSI) {
     revalidateTag('dugsi-registrations')
   }
 
@@ -419,7 +790,6 @@ export async function handleSubscriptionUpdated(
 ): Promise<SubscriptionEventResult> {
   const stripeSubscriptionId = subscription.id
 
-  // Get subscription from database
   const dbSubscription = await getSubscriptionByStripeId(stripeSubscriptionId)
 
   if (!dbSubscription) {
@@ -434,25 +804,22 @@ export async function handleSubscriptionUpdated(
     }
   }
 
-  // Validate status
   const status = subscription.status as SubscriptionStatus
   if (!isValidSubscriptionStatus(status)) {
     throw new Error(`Invalid subscription status: ${status}`)
   }
 
-  // Extract period dates
   const periodDates = extractPeriodDates(subscription)
 
-  // Update subscription
   await updateSubscriptionStatusQuery(dbSubscription.id, status, {
     currentPeriodStart: periodDates.periodStart,
     currentPeriodEnd: periodDates.periodEnd,
     paidUntil: periodDates.periodEnd,
   })
 
-  if (accountType === 'MAHAD') {
+  if (accountType === StripeAccountType.MAHAD) {
     revalidateTag('mahad-students')
-  } else if (accountType === 'DUGSI') {
+  } else if (accountType === StripeAccountType.DUGSI) {
     revalidateTag('dugsi-registrations')
   }
 
@@ -478,7 +845,6 @@ export async function handleSubscriptionDeleted(
 ): Promise<SubscriptionEventResult> {
   const stripeSubscriptionId = subscription.id
 
-  // Get subscription from database
   const dbSubscription = await getSubscriptionByStripeId(stripeSubscriptionId)
 
   if (!dbSubscription) {
@@ -493,7 +859,6 @@ export async function handleSubscriptionDeleted(
     }
   }
 
-  // Update subscription to canceled and unlink from all profiles atomically
   await prisma.$transaction(async (tx) => {
     await updateSubscriptionStatusQuery(
       dbSubscription.id,
@@ -504,9 +869,9 @@ export async function handleSubscriptionDeleted(
     await unlinkSubscription(dbSubscription.id, tx)
   })
 
-  if (accountType === 'MAHAD') {
+  if (accountType === StripeAccountType.MAHAD) {
     revalidateTag('mahad-students')
-  } else if (accountType === 'DUGSI') {
+  } else if (accountType === StripeAccountType.DUGSI) {
     revalidateTag('dugsi-registrations')
   }
 
@@ -545,7 +910,6 @@ export async function handleInvoiceFinalized(
     return null
   }
 
-  // Get subscription from database
   const dbSubscription = await getSubscriptionByStripeId(subscriptionId)
 
   if (!dbSubscription) {
@@ -556,7 +920,6 @@ export async function handleInvoiceFinalized(
     return null
   }
 
-  // Update paid_until to the period_end of the invoice
   const paidUntil = invoice.period_end
     ? new Date(invoice.period_end * 1000)
     : null
@@ -569,9 +932,9 @@ export async function handleInvoiceFinalized(
     }
   )
 
-  if (accountType === 'MAHAD') {
+  if (accountType === StripeAccountType.MAHAD) {
     revalidateTag('mahad-students')
-  } else if (accountType === 'DUGSI') {
+  } else if (accountType === StripeAccountType.DUGSI) {
     revalidateTag('dugsi-registrations')
   }
 

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -512,7 +512,7 @@ async function patchRecoveredDugsiMetadata(
   // Emit observability signals unconditionally — DB writes are already committed at this point.
   // The Stripe metadata patch below is best-effort; these signals must not depend on its success.
   Sentry.captureMessage(
-    'Dugsi subscription resolved via customer email fallback',
+    'Path 4: billing account and subscription record created via email fallback — linking profiles',
     {
       level: 'info',
       extra: {

--- a/lib/services/webhooks/webhook-service.ts
+++ b/lib/services/webhooks/webhook-service.ts
@@ -47,7 +47,7 @@ import {
 } from '@/lib/services/shared/billing-service'
 import { createSubscriptionFromStripe } from '@/lib/services/shared/subscription-service'
 import { getDugsiStripeClient } from '@/lib/stripe-dugsi'
-import { normalizeEmail } from '@/lib/utils/contact-normalization'
+import { validateAndNormalizeEmail } from '@/lib/utils/contact-normalization'
 import { calculateDugsiRate } from '@/lib/utils/dugsi-tuition'
 import { calculateMahadRate } from '@/lib/utils/mahad-tuition'
 import {
@@ -265,7 +265,7 @@ async function resolveDugsiFallbackFromCustomerEmail(
   }
 
   const customerEmail = stripeCustomer.deleted ? null : stripeCustomer.email
-  const normalizedEmail = normalizeEmail(customerEmail)
+  const normalizedEmail = validateAndNormalizeEmail(customerEmail)
 
   if (!normalizedEmail) {
     logger.warn(
@@ -479,7 +479,7 @@ async function patchRecoveredDugsiMetadata(
     Sentry.captureMessage(
       'Dugsi subscription resolved via customer email fallback',
       {
-        level: 'warning',
+        level: 'info',
         extra: {
           customerId,
           subscriptionId,


### PR DESCRIPTION
### Why?

Dugsi subscriptions created manually in the Stripe dashboard arrive with no metadata. The webhook handler had a single fallback (look up billing account by customer ID) that failed for new customers, throwing `No person found for customer` on every retry for 72 hours until event exhaustion.

### How?

Replaced the single fallback with a 4-path resolution system behind an orchestrator (`resolveSubscriptionContext`). Path 4 is Dugsi-only: fetch the Stripe customer email, resolve the guardian from DB, derive their active children's profile IDs, then patch the Stripe subscription metadata so all future webhook events work normally. DB is always authoritative; Stripe metadata is treated as a hint that gets DB-verified before use. A `ResolvedSubscriptionContext` discriminated union structurally enforces that Path 4 recovery data is always present when the recovery source is `dugsi_email_fallback`.

Supersedes #222 (same changes, squashed into a single commit for clarity).

<sub>Generated with Claude Code</sub>